### PR TITLE
Build using Ninja on Windows and Linux Desktop

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -53,7 +53,7 @@ jobs:
       run: git submodule update --init --recursive --depth=1
 
     - name: Setup Ninja
-      uses: ashutoshvarma/setup-ninja@v1
+      uses: ashutoshvarma/setup-ninja@v1.1
       with:
           version: 1.12.1
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -63,7 +63,7 @@ jobs:
       env:
           CC: ${{ matrix.config.cc }}
           CXX: ${{ matrix.config.cxx }}
-      run: |
+      run: >
         cmake
         -S .
         -B build
@@ -71,7 +71,7 @@ jobs:
         ${{ matrix.config.cmake_generator }}
 
     - name: Build
-      run: |
+      run: >
         cmake
         --build build
         --config ${{ matrix.config.build_type }}
@@ -85,7 +85,7 @@ jobs:
       run: git diff --exit-code
 
     - name: Run Tests
-      run: |
+      run: >
         ctest
         --test-dir build
         -j ${{ steps.cpu-cores.outputs.count }}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -19,19 +19,21 @@ jobs:
         - {
             name: "Windows Build", artifact: "Windows.tar.xz",
             os: windows-latest,
-            build_type: "Release", cc: "gcc-9", cxx: "g++-9",
-            cmake_platform: "-A x64",
+            cc: "cl", cxx: "cl",
+            cmake_platform: "",
             # On msvc, the -j flag does not help build times and causes intermittent
             # file permission errors.
-            cmake_number_of_jobs: ""
+            cmake_number_of_jobs: "",
+            cmake_generator: '-G "Ninja Multi-Config"'
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
-            build_type: "Release", cc: "gcc-9", cxx: "g++-9",
+            cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             glibc_version: "2_31",
             cmake_number_of_jobs: "-j 2"
+            cmake_generator: ''
           }
 
     steps:
@@ -50,6 +52,17 @@ jobs:
     - name: Update Submodules
       run: git submodule update --init --recursive --depth=1
 
+    - name: Setup Ninja
+      uses: ashutoshvarma/setup-ninja@v1
+      with:
+          version: 1.12.1
+
+    - name: Setup MSVC for compilation
+      if: ${{ runner.os == 'Windows' }}
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+          arch: x64
+
     - name: Configure
       shell: cmake -P {0}
       run: |
@@ -65,7 +78,7 @@ jobs:
             -S .
             -B build
             -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
-            ${{ matrix.config.cmake_platform }}
+            ${{ matrix.config.cmake_generator }}
           RESULT_VARIABLE result
         )
         if (NOT result EQUAL 0)

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -65,11 +65,11 @@ jobs:
       env:
           CC: ${{ matrix.config.cc }}
           CXX: ${{ matrix.config.cxx }}
-      run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ cmatrix.config.build_type }} ${{ cmatrix.config.cmake_generator }}
+      run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }} ${{ matrix.config.cmake_generator }}
 
     - name: Build
       run: |
-          cmake --build build --config ${{ cmatrix.config.build_type }} -j ${{ steps.cpu-cores.outputs.count }}
+          cmake --build build --config ${{ matrix.config.build_type }} -j ${{ steps.cpu-cores.outputs.count }}
 
 #    - name: Build & Test
 #      uses: ashutoshvarma/action-cmake-build@v1
@@ -135,7 +135,7 @@ jobs:
       run: git diff --exit-code
 
     - name: Run Tests
-      run: ctest --test-dir build -j ${{ steps.cpu-cores.outputs.count }} -C ${{ cmatrix.config.build_type }} -E System --output-on-failure
+      run: ctest --test-dir build -j ${{ steps.cpu-cores.outputs.count }} -C ${{ matrix.config.build_type }} -E System --output-on-failure
 
 #    - name: Run Tests
 #      shell: cmake -P {0}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -21,9 +21,6 @@ jobs:
             os: windows-latest,
             cc: "cl", cxx: "cl",
             cmake_platform: "",
-            # On msvc, the -j flag does not help build times and causes intermittent
-            # file permission errors.
-            cmake_number_of_jobs: "",
             cmake_generator: '-G "Ninja Multi-Config"'
           }
         - {
@@ -32,8 +29,7 @@ jobs:
             cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             glibc_version: "2_31",
-            cmake_number_of_jobs: "-j 2",
-            cmake_generator: ''
+            cmake_generator: '-G "Ninja"'
           }
 
     steps:
@@ -63,44 +59,65 @@ jobs:
       with:
           arch: x64
 
-    - name: Configure
-      shell: cmake -P {0}
-      run: |
-        set(ENV{CC} ${{ matrix.config.cc }})
-        set(ENV{CXX} ${{ matrix.config.cxx }})
-        set(path_separator ":")
-        if ("${{ runner.os }}" STREQUAL "Windows")
-          set(path_separator ";")
-        endif()
-        set(ENV{PATH} "$ENV{GITHUB_WORKSPACE}${path_separator}$ENV{PATH}")
-        execute_process(
-          COMMAND cmake
-            -S .
-            -B build
-            -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
-            ${{ matrix.config.cmake_generator }}
-          RESULT_VARIABLE result
-        )
-        if (NOT result EQUAL 0)
-          message(FATAL_ERROR "Bad exit status")
-        endif()
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
 
-    - name: Build
-      shell: cmake -P {0}
-      run: |
-        execute_process(
-          COMMAND cmake --build build --config $ENV{BUILD_TYPE} ${{ matrix.config.cmake_number_of_jobs }}
-          RESULT_VARIABLE result
-          OUTPUT_VARIABLE output
-          ERROR_VARIABLE output
-          ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
-        )
-        if (NOT result EQUAL 0)
-          string(REGEX MATCH "FAILED:.*$" error_message "${output}")
-          string(REPLACE "\n" "%0A" error_message "${error_message}")
-          message("::error::${error_message}")
-          message(FATAL_ERROR "Build failed")
-        endif()
+    - name: Build & Test
+      uses: ashutoshvarma/action-cmake-build@v1
+      with:
+          build-dir: ${{ github.workspace }}/build
+          cc: ${{ matrix.config.cc }}
+          cxx: ${{ matrix.config.cxx }}
+          build-type: $ENV{BUILD_TYPE}
+          configure-options: ${{ matrix.config.cmake_generator }}
+          build-options: --config $ENV{BUILD_TYPE}
+          run-test: true
+          ctest-options: -C $ENV{BUILD_TYPE} -E System --output-on-failure
+          parallel: ${{ steps.cpu-cores.outputs.count }}
+
+#    - name: Configure
+#      run: |
+#          cmake -S . -B build -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
+#      shell: cmake -P {0}
+#      run: |
+#        set(ENV{CC} ${{ matrix.config.cc }})
+#        set(ENV{CXX} ${{ matrix.config.cxx }})
+#        set(path_separator ":")
+#        if ("${{ runner.os }}" STREQUAL "Windows")
+#          set(path_separator ";")
+#        endif()
+#        set(ENV{PATH} "$ENV{GITHUB_WORKSPACE}${path_separator}$ENV{PATH}")
+#        execute_process(
+#          COMMAND cmake
+#            -S .
+#            -B build
+#            -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
+#            ${{ matrix.config.cmake_generator }}
+#          RESULT_VARIABLE result
+#        )
+#        if (NOT result EQUAL 0)
+#          message(FATAL_ERROR "Bad exit status")
+#        endif()
+#
+#    - name: Build
+#      run: |
+#          cmake --build build --config $ENV{BUILD_TYPE} -j ${{ steps.cpu-cores.outputs.count }}
+#      # shell: cmake -P {0}
+#      # run: |
+#      #   execute_process(
+#      #     COMMAND cmake --build build --config $ENV{BUILD_TYPE} -j ${{ steps.cpu-cores.outputs.count }}
+#      #     RESULT_VARIABLE result
+#      #     OUTPUT_VARIABLE output
+#      #     ERROR_VARIABLE output
+#      #     ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
+#      #   )
+#      #   if (NOT result EQUAL 0)
+#      #     string(REGEX MATCH "FAILED:.*$" error_message "${output}")
+#      #     string(REPLACE "\n" "%0A" error_message "${error_message}")
+#      #     message("::error::${error_message}")
+#      #     message(FATAL_ERROR "Build failed")
+#      #   endif()
 
     # The generated source in git must match the output of workflow builds.
     # If this step fails, something is changing during build. Either:
@@ -109,20 +126,20 @@ jobs:
     - name: Check for files dirtied by codegen
       run: git diff --exit-code
 
-    - name: Run Tests
-      shell: cmake -P {0}
-      run: |
-        include(ProcessorCount)
-        ProcessorCount(N)
-
-        execute_process(
-          COMMAND ctest -j ${N} -C $ENV{BUILD_TYPE} -E System --output-on-failure
-          WORKING_DIRECTORY build
-          RESULT_VARIABLE result
-        )
-        if (NOT result EQUAL 0)
-            message(FATAL_ERROR "Running tests failed!")
-        endif()
+#    - name: Run Tests
+#      shell: cmake -P {0}
+#      run: |
+#        include(ProcessorCount)
+#        ProcessorCount(N)
+#
+#        execute_process(
+#          COMMAND ctest -j ${N} -C $ENV{BUILD_TYPE} -E System --output-on-failure
+#          WORKING_DIRECTORY build
+#          RESULT_VARIABLE result
+#        )
+#        if (NOT result EQUAL 0)
+#            message(FATAL_ERROR "Running tests failed!")
+#        endif()
 
     - name: Tar Linux Server Binaries
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -16,7 +16,6 @@ jobs:
             name: "Windows Build", artifact: "Windows.tar.xz",
             os: windows-latest,
             cc: "cl", cxx: "cl",
-            cmake_platform: "",
             cmake_generator: '-G "Ninja Multi-Config"',
             build_type: RelWithDebInfo
           }
@@ -24,7 +23,6 @@ jobs:
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
             os: ubuntu-20.04,
             cc: "gcc-9", cxx: "g++-9",
-            cmake_platform: "",
             glibc_version: "2_31",
             cmake_generator: '-G "Ninja"',
             build_type: RelWithDebInfo
@@ -65,67 +63,19 @@ jobs:
       env:
           CC: ${{ matrix.config.cc }}
           CXX: ${{ matrix.config.cxx }}
-      run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }} ${{ matrix.config.cmake_generator }}
+      run: |
+        cmake
+        -S .
+        -B build
+        -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+        ${{ matrix.config.cmake_generator }}
 
     - name: Build
       run: |
-          cmake --build build --config ${{ matrix.config.build_type }} -j ${{ steps.cpu-cores.outputs.count }}
-
-#    - name: Build & Test
-#      uses: ashutoshvarma/action-cmake-build@v1
-#      with:
-#          build-dir: ${{ github.workspace }}/build
-#          cc: ${{ matrix.config.cc }}
-#          cxx: ${{ matrix.config.cxx }}
-#          build-type: $ENV{BUILD_TYPE}
-#          configure-options: ${{ matrix.config.cmake_generator }}
-#          build-options: --config $ENV{BUILD_TYPE}
-#          run-test: true
-#          ctest-options: -C $ENV{BUILD_TYPE} -E System --output-on-failure
-#          parallel: ${{ steps.cpu-cores.outputs.count }}
-
-#    - name: Configure
-#      run: |
-#          cmake -S . -B build -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
-#      shell: cmake -P {0}
-#      run: |
-#        set(ENV{CC} ${{ matrix.config.cc }})
-#        set(ENV{CXX} ${{ matrix.config.cxx }})
-#        set(path_separator ":")
-#        if ("${{ runner.os }}" STREQUAL "Windows")
-#          set(path_separator ";")
-#        endif()
-#        set(ENV{PATH} "$ENV{GITHUB_WORKSPACE}${path_separator}$ENV{PATH}")
-#        execute_process(
-#          COMMAND cmake
-#            -S .
-#            -B build
-#            -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
-#            ${{ matrix.config.cmake_generator }}
-#          RESULT_VARIABLE result
-#        )
-#        if (NOT result EQUAL 0)
-#          message(FATAL_ERROR "Bad exit status")
-#        endif()
-#
-#    - name: Build
-#      run: |
-#          cmake --build build --config $ENV{BUILD_TYPE} -j ${{ steps.cpu-cores.outputs.count }}
-#      # shell: cmake -P {0}
-#      # run: |
-#      #   execute_process(
-#      #     COMMAND cmake --build build --config $ENV{BUILD_TYPE} -j ${{ steps.cpu-cores.outputs.count }}
-#      #     RESULT_VARIABLE result
-#      #     OUTPUT_VARIABLE output
-#      #     ERROR_VARIABLE output
-#      #     ECHO_OUTPUT_VARIABLE ECHO_ERROR_VARIABLE
-#      #   )
-#      #   if (NOT result EQUAL 0)
-#      #     string(REGEX MATCH "FAILED:.*$" error_message "${output}")
-#      #     string(REPLACE "\n" "%0A" error_message "${error_message}")
-#      #     message("::error::${error_message}")
-#      #     message(FATAL_ERROR "Build failed")
-#      #   endif()
+        cmake
+        --build build
+        --config ${{ matrix.config.build_type }}
+        -j ${{ steps.cpu-cores.outputs.count }}
 
     # The generated source in git must match the output of workflow builds.
     # If this step fails, something is changing during build. Either:
@@ -135,22 +85,13 @@ jobs:
       run: git diff --exit-code
 
     - name: Run Tests
-      run: ctest --test-dir build -j ${{ steps.cpu-cores.outputs.count }} -C ${{ matrix.config.build_type }} -E System --output-on-failure
-
-#    - name: Run Tests
-#      shell: cmake -P {0}
-#      run: |
-#        include(ProcessorCount)
-#        ProcessorCount(N)
-#
-#        execute_process(
-#          COMMAND ctest -j ${N} -C $ENV{BUILD_TYPE} -E System --output-on-failure
-#          WORKING_DIRECTORY build
-#          RESULT_VARIABLE result
-#        )
-#        if (NOT result EQUAL 0)
-#            message(FATAL_ERROR "Running tests failed!")
-#        endif()
+      run: |
+        ctest
+        --test-dir build
+        -j ${{ steps.cpu-cores.outputs.count }}
+        -C ${{ matrix.config.build_type }}
+        -E System
+        --output-on-failure
 
     - name: Tar Linux Server Binaries
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -17,7 +17,7 @@ jobs:
             os: windows-latest,
             cc: "cl", cxx: "cl",
             cmake_platform: "",
-            cmake_generator: '-G "Ninja Multi-Config"'
+            cmake_generator: '-G "Ninja Multi-Config"',
             build_type: RelWithDebInfo
           }
         - {
@@ -26,7 +26,7 @@ jobs:
             cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             glibc_version: "2_31",
-            cmake_generator: '-G "Ninja"'
+            cmake_generator: '-G "Ninja"',
             build_type: RelWithDebInfo
           }
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -21,7 +21,7 @@ jobs:
             os: windows-latest,
             cc: "cl", cxx: "cl",
             cmake_platform: "",
-            cmake_generator: '-G "Ninja Multi-Config"'
+            cmake_generator: "Ninja Multi-Config"
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
@@ -29,7 +29,7 @@ jobs:
             cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             glibc_version: "2_31",
-            cmake_generator: '-G "Ninja"'
+            cmake_generator: "Ninja"
           }
 
     steps:
@@ -63,18 +63,28 @@ jobs:
       uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
-    - name: Build & Test
-      uses: ashutoshvarma/action-cmake-build@v1
-      with:
-          build-dir: ${{ github.workspace }}/build
-          cc: ${{ matrix.config.cc }}
-          cxx: ${{ matrix.config.cxx }}
-          build-type: $ENV{BUILD_TYPE}
-          configure-options: ${{ matrix.config.cmake_generator }}
-          build-options: --config $ENV{BUILD_TYPE}
-          run-test: true
-          ctest-options: -C $ENV{BUILD_TYPE} -E System --output-on-failure
-          parallel: ${{ steps.cpu-cores.outputs.count }}
+    - name: Configure
+      env:
+          CC: ${{ matrix.config.cc }}
+          CXX: ${{ matrix.config.cxx }}
+      run: cmake -S . -B build -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
+
+    - name: Build
+      run: |
+          cmake --build build --config $ENV{BUILD_TYPE} -j ${{ steps.cpu-cores.outputs.count }}
+
+#    - name: Build & Test
+#      uses: ashutoshvarma/action-cmake-build@v1
+#      with:
+#          build-dir: ${{ github.workspace }}/build
+#          cc: ${{ matrix.config.cc }}
+#          cxx: ${{ matrix.config.cxx }}
+#          build-type: $ENV{BUILD_TYPE}
+#          configure-options: ${{ matrix.config.cmake_generator }}
+#          build-options: --config $ENV{BUILD_TYPE}
+#          run-test: true
+#          ctest-options: -C $ENV{BUILD_TYPE} -E System --output-on-failure
+#          parallel: ${{ steps.cpu-cores.outputs.count }}
 
 #    - name: Configure
 #      run: |
@@ -125,6 +135,9 @@ jobs:
     # 2. Build locally to ensure generated files are up-to-date.
     - name: Check for files dirtied by codegen
       run: git diff --exit-code
+
+    - name: Run Tests
+      run: ctest --test-dir build -j ${{ steps.cpu-cores.outputs.count }} -C $ENV{BUILD_TYPE} -E System --output-on-failure
 
 #    - name: Run Tests
 #      shell: cmake -P {0}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -4,10 +4,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-env:
-  CMAKE_VERSION: 3.18.3
-  BUILD_TYPE: RelWithDebInfo
-
 jobs:
   build:
     name: ${{ matrix.config.name }}
@@ -21,7 +17,8 @@ jobs:
             os: windows-latest,
             cc: "cl", cxx: "cl",
             cmake_platform: "",
-            cmake_generator: "Ninja Multi-Config"
+            cmake_generator: '-G "Ninja Multi-Config"'
+            build_type: RelWithDebInfo
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
@@ -29,7 +26,8 @@ jobs:
             cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             glibc_version: "2_31",
-            cmake_generator: "Ninja"
+            cmake_generator: '-G "Ninja"'
+            build_type: RelWithDebInfo
           }
 
     steps:
@@ -67,11 +65,11 @@ jobs:
       env:
           CC: ${{ matrix.config.cc }}
           CXX: ${{ matrix.config.cxx }}
-      run: cmake -S . -B build -D CMAKE_BUILD_TYPE=$ENV{BUILD_TYPE}
+      run: cmake -S . -B build -D CMAKE_BUILD_TYPE=${{ cmatrix.config.build_type }} ${{ cmatrix.config.cmake_generator }}
 
     - name: Build
       run: |
-          cmake --build build --config $ENV{BUILD_TYPE} -j ${{ steps.cpu-cores.outputs.count }}
+          cmake --build build --config ${{ cmatrix.config.build_type }} -j ${{ steps.cpu-cores.outputs.count }}
 
 #    - name: Build & Test
 #      uses: ashutoshvarma/action-cmake-build@v1
@@ -137,7 +135,7 @@ jobs:
       run: git diff --exit-code
 
     - name: Run Tests
-      run: ctest --test-dir build -j ${{ steps.cpu-cores.outputs.count }} -C $ENV{BUILD_TYPE} -E System --output-on-failure
+      run: ctest --test-dir build -j ${{ steps.cpu-cores.outputs.count }} -C ${{ cmatrix.config.build_type }} -E System --output-on-failure
 
 #    - name: Run Tests
 #      shell: cmake -P {0}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -32,7 +32,7 @@ jobs:
             cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             glibc_version: "2_31",
-            cmake_number_of_jobs: "-j 2"
+            cmake_number_of_jobs: "-j 2",
             cmake_generator: ''
           }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update the build step to use the ninja build system for both Windows and Linux. Also simplifies the build steps and removes things that were not being used.

Also a side note is that on Windows using ninja provides better developer efficiency as it appears to track dependencies better and reduces the amount of things being rebuilt after a first full build unlike Visual Studio which I have experience rebuilding much of the project over repeatedly even though there were no changes to those files. This doesn't help with the build but might help with developers wanting to build grpc-device this way.

### Why should this Pull Request be merged?

- Build times are reduced using ninja
  - Windows Average build times
    - Before Change: 1 hr 30 min
    - After Change: 50 min (about a 45% build time reduction)
  - Linux Average build times
    - Before Change:  1 hr
    - After Change: 50 min (about a 17% build time reduction)
- The steps have been simplified to just cmake command calls making it easier to understand. 
- Removed things like CMAKE_VERSION which didn't appear to be doing anything as the build before were using the version that was provided by the github provided runner images.

### What testing has been done?
- PR Build
  - Windows still specifies using MSVC 19.40.33811.0 for the CC and CXX compilers
  - Linux still specifies using GNU 9.4.0 for the CC and CXX compilers
