### PR TITLE
Use new action to download ninja

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -45,7 +45,7 @@ jobs:
       run: git submodule update --init --recursive --depth=1
 
     - name: Setup Ninja
-      uses: ashutoshvarma/setup-ninja@v1.1
+      uses: seanmiddleditch/gha-setup-ninja@v5
       with:
           version: 1.12.1
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Use a github action that is more recently updated to download ninja and add to path so cmake can find it.
[seanmiddleditch/gha-setup-ninja](https://github.com/seanmiddleditch/gha-setup-ninja). Project and dependencies appear to be updated as of 3 weeks ago and it specifies using Node.js 20. 

The code is very straight forward and is all in one [file](https://github.com/seanmiddleditch/gha-setup-ninja/blob/96bed6edff20d1dd61ecff9b75cc519d516e6401/index.js#L26) currently. It performs the same operations of the previous action, using the github url to download the released version of ninja to the system and then adds it to the path to be referenced in later steps.

### Why should this Pull Request be merged?
The current action being used uses Node.js 16 which github is planning to deprecate in the future.

### What testing has been done?
- PR build
  - No warnings about Node.js version in the build anymore
