### PR TITLE
Move to using GITHUB_OUTPUT from set-output

### DIFF
--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -35,7 +35,7 @@ jobs:
       id: submodules
       run: |
         git submodule update --init --recursive
-        echo "::set-output name=grpc-commit::$(git rev-parse --short @:./third_party/grpc)"
+        echo "grpc-commit=$(git rev-parse --short @:./third_party/grpc)" >> $GITHUB_OUTPUT
 
     - name: Cache Host OS gRPC Support
       uses: actions/cache@v4

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -59,13 +59,13 @@ jobs:
     - name: "Get previous tag"
       id: previoustag
       run: >-
-        echo "::set-output name=tag::$(
+        echo "tag=$(
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1
-        )"
+        )" >> $GITHUB_OUTPUT
 
-    - name: "Get next version"
-      id: semvers
-      uses: "WyriHaximus/github-action-next-semvers@v1"
+    - NAME: "GET NEXT VERSION"
+      ID: SEMVERS
+      USES: "WYRIHAXIMUS/GITHUB-ACTION-NEXT-SEMVERS@V1"
       with:
         version: ${{ steps.previoustag.outputs.tag}}
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -59,13 +59,13 @@ jobs:
     - name: "Get previous tag"
       id: previoustag
       run: >-
-        echo "tag=$(
+        echo "::set-output name=tag::$(
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1
-        )" >> $GITHUB_OUTPUT
+        )"
 
-    - NAME: "GET NEXT VERSION"
-      ID: SEMVERS
-      USES: "WYRIHAXIMUS/GITHUB-ACTION-NEXT-SEMVERS@V1"
+    - name: "Get next version"
+      id: semvers
+      uses: "WyriHaximus/github-action-next-semvers@v1"
       with:
         version: ${{ steps.previoustag.outputs.tag}}
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -59,9 +59,9 @@ jobs:
     - name: "Get previous tag"
       id: previoustag
       run: >-
-        echo "::set-output name=tag::$(
+        echo "tag=$(
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1
-        )"
+        )" >> $GITHUB_OUTPUT
 
     - name: "Get next version"
       id: semvers

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -22,23 +22,23 @@ jobs:
     - name: Get the latest tag
       id: latesttag
       run: >-
-        echo "::set-output name=tag::$(
+        echo "tag=$(
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1
-        )"
+        )" >> $GITHUB_OUTPUT
 
     - name: Get latest tag without leading v
       id: latesttagwithoutv
       run: >-
-        echo "::set-output name=tag::$(
+        echo ":tag=$(
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1 | cut -c2-
-        )"
+        )" >> $GITHUB_OUTPUT
 
     - name: Get the second latest tag
       id: secondlatesttag
       run: >-
-        echo "::set-output name=tag::$(
+        echo "tag=$(
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | sed '1d' | head -1
-        )"
+        )" >> $GITHUB_OUTPUT
 
     - name: Fail if new tag is not latest tag
       if: ${{ github.ref_name != steps.latesttag.outputs.tag}}
@@ -59,7 +59,7 @@ jobs:
       run: |
         raw=$(git branch -r --contains ${{ github.ref }})
         branch_sans_origin=${raw/origin\/}
-        echo ::set-output name=branch::$branch_sans_origin
+        echo branch=$branch_sans_origin >> $GITHUB_OUTPUT
 
     - name: Create GitHub Issue
       if: ${{ env.SHOULD_UPDATE_LINUX_RT == 'True'}}

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Get latest tag without leading v
       id: latesttagwithoutv
       run: >-
-        echo ":tag=$(
+        echo "tag=$(
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1 | cut -c2-
         )" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### What does this Pull Request accomplish?
Fixes #908

set-output is deprecated and there are warnings being logged in our CI build specifying so. Here is a github blog article about it, [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). I followed that article along with  this github doc [Workflow commands for GitHub Actions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#environment-files) on how to use the new environment file correctly. 

### Why should this Pull Request be merged?
Move away from deprecated set-output to github's new suggested workflow using `$GITHUB_OUTPUT` environment file.

### What testing has been done?

PR build
