### PR TITLE
Update version number in CMakeLists.txt from 2.7.0 to 2.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12.0)
 
 project(ni_grpc_device_server
   LANGUAGES C CXX
-  VERSION 2.7.0)
+  VERSION 2.8.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Bumps the version in CMake file

### Why should this Pull Request be merged?

To reflect that the next grpc-device release will be 2.8.0

### What testing has been done?

No testing done.

### Additional Information

This was also bumped in Azdo in !802552.  This is for Azdo Feature 2860199.