### PR TITLE
Adding BuildListString and BuildListStepString APIs for LTE

### DIFF
--- a/generated/nirfmxlte/nirfmxlte.proto
+++ b/generated/nirfmxlte/nirfmxlte.proto
@@ -45,6 +45,8 @@ service NiRFmxLTE {
   rpc AutoLevel(AutoLevelRequest) returns (AutoLevelResponse);
   rpc BuildCarrierString(BuildCarrierStringRequest) returns (BuildCarrierStringResponse);
   rpc BuildClusterString(BuildClusterStringRequest) returns (BuildClusterStringResponse);
+  rpc BuildListStepString(BuildListStepStringRequest) returns (BuildListStepStringResponse);
+  rpc BuildListString(BuildListStringRequest) returns (BuildListStringResponse);
   rpc BuildOffsetString(BuildOffsetStringRequest) returns (BuildOffsetStringResponse);
   rpc BuildPDSCHString(BuildPDSCHStringRequest) returns (BuildPDSCHStringResponse);
   rpc BuildSignalString(BuildSignalStringRequest) returns (BuildSignalStringResponse);
@@ -1921,6 +1923,27 @@ message BuildClusterStringRequest {
 message BuildClusterStringResponse {
   int32 status = 1;
   string selector_string_out = 2;
+}
+
+message BuildListStepStringRequest {
+  string list_name = 1;
+  string result_name = 2;
+  int32 step_number = 3;
+}
+
+message BuildListStepStringResponse {
+  int32 status = 1;
+  string selector_string = 2;
+}
+
+message BuildListStringRequest {
+  string list_name = 1;
+  string result_name = 2;
+}
+
+message BuildListStringResponse {
+  int32 status = 1;
+  string selector_string = 2;
 }
 
 message BuildOffsetStringRequest {

--- a/generated/nirfmxlte/nirfmxlte_client.cpp
+++ b/generated/nirfmxlte/nirfmxlte_client.cpp
@@ -629,6 +629,43 @@ build_cluster_string(const StubPtr& stub, const std::string& selector_string, co
   return response;
 }
 
+BuildListStepStringResponse
+build_list_step_string(const StubPtr& stub, const std::string& list_name, const std::string& result_name, const pb::int32& step_number)
+{
+  ::grpc::ClientContext context;
+
+  auto request = BuildListStepStringRequest{};
+  request.set_list_name(list_name);
+  request.set_result_name(result_name);
+  request.set_step_number(step_number);
+
+  auto response = BuildListStepStringResponse{};
+
+  raise_if_error(
+      stub->BuildListStepString(&context, request, &response),
+      context);
+
+  return response;
+}
+
+BuildListStringResponse
+build_list_string(const StubPtr& stub, const std::string& list_name, const std::string& result_name)
+{
+  ::grpc::ClientContext context;
+
+  auto request = BuildListStringRequest{};
+  request.set_list_name(list_name);
+  request.set_result_name(result_name);
+
+  auto response = BuildListStringResponse{};
+
+  raise_if_error(
+      stub->BuildListString(&context, request, &response),
+      context);
+
+  return response;
+}
+
 BuildOffsetStringResponse
 build_offset_string(const StubPtr& stub, const std::string& selector_string, const pb::int32& offset_number)
 {

--- a/generated/nirfmxlte/nirfmxlte_client.h
+++ b/generated/nirfmxlte/nirfmxlte_client.h
@@ -50,6 +50,8 @@ AnalyzeSpectrum1WaveformResponse analyze_spectrum1_waveform(const StubPtr& stub,
 AutoLevelResponse auto_level(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& measurement_interval);
 BuildCarrierStringResponse build_carrier_string(const StubPtr& stub, const std::string& selector_string, const pb::int32& carrier_number);
 BuildClusterStringResponse build_cluster_string(const StubPtr& stub, const std::string& selector_string, const pb::int32& cluster_number);
+BuildListStepStringResponse build_list_step_string(const StubPtr& stub, const std::string& list_name, const std::string& result_name, const pb::int32& step_number);
+BuildListStringResponse build_list_string(const StubPtr& stub, const std::string& list_name, const std::string& result_name);
 BuildOffsetStringResponse build_offset_string(const StubPtr& stub, const std::string& selector_string, const pb::int32& offset_number);
 BuildPDSCHStringResponse build_pdsch_string(const StubPtr& stub, const std::string& selector_string, const pb::int32& pdsch_number);
 BuildSignalStringResponse build_signal_string(const StubPtr& stub, const std::string& signal_name, const std::string& result_name);

--- a/generated/nirfmxlte/nirfmxlte_compilation_test.cpp
+++ b/generated/nirfmxlte/nirfmxlte_compilation_test.cpp
@@ -147,6 +147,16 @@ int32 BuildClusterString(char selectorString[], int32 clusterNumber, int32 selec
   return RFmxLTE_BuildClusterString(selectorString, clusterNumber, selectorStringOutLength, selectorStringOut);
 }
 
+int32 BuildListStepString(char listName[], char resultName[], int32 stepNumber, int32 selectorStringLength, char selectorString[])
+{
+  return RFmxLTE_BuildListStepString(listName, resultName, stepNumber, selectorStringLength, selectorString);
+}
+
+int32 BuildListString(char listName[], char resultName[], int32 selectorStringLength, char selectorString[])
+{
+  return RFmxLTE_BuildListString(listName, resultName, selectorStringLength, selectorString);
+}
+
 int32 BuildOffsetString(char selectorString[], int32 offsetNumber, int32 selectorStringOutLength, char selectorStringOut[])
 {
   return RFmxLTE_BuildOffsetString(selectorString, offsetNumber, selectorStringOutLength, selectorStringOut);

--- a/generated/nirfmxlte/nirfmxlte_library.cpp
+++ b/generated/nirfmxlte/nirfmxlte_library.cpp
@@ -55,6 +55,8 @@ NiRFmxLTELibrary::NiRFmxLTELibrary(std::shared_ptr<nidevice_grpc::SharedLibraryI
   function_pointers_.AutoLevel = reinterpret_cast<AutoLevelPtr>(shared_library_->get_function_pointer("RFmxLTE_AutoLevel"));
   function_pointers_.BuildCarrierString = reinterpret_cast<BuildCarrierStringPtr>(shared_library_->get_function_pointer("RFmxLTE_BuildCarrierString"));
   function_pointers_.BuildClusterString = reinterpret_cast<BuildClusterStringPtr>(shared_library_->get_function_pointer("RFmxLTE_BuildClusterString"));
+  function_pointers_.BuildListStepString = reinterpret_cast<BuildListStepStringPtr>(shared_library_->get_function_pointer("RFmxLTE_BuildListStepString"));
+  function_pointers_.BuildListString = reinterpret_cast<BuildListStringPtr>(shared_library_->get_function_pointer("RFmxLTE_BuildListString"));
   function_pointers_.BuildOffsetString = reinterpret_cast<BuildOffsetStringPtr>(shared_library_->get_function_pointer("RFmxLTE_BuildOffsetString"));
   function_pointers_.BuildPDSCHString = reinterpret_cast<BuildPDSCHStringPtr>(shared_library_->get_function_pointer("RFmxLTE_BuildPDSCHString"));
   function_pointers_.BuildSignalString = reinterpret_cast<BuildSignalStringPtr>(shared_library_->get_function_pointer("RFmxLTE_BuildSignalString"));
@@ -573,6 +575,22 @@ int32 NiRFmxLTELibrary::BuildClusterString(char selectorString[], int32 clusterN
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxLTE_BuildClusterString.");
   }
   return function_pointers_.BuildClusterString(selectorString, clusterNumber, selectorStringOutLength, selectorStringOut);
+}
+
+int32 NiRFmxLTELibrary::BuildListStepString(char listName[], char resultName[], int32 stepNumber, int32 selectorStringLength, char selectorString[])
+{
+  if (!function_pointers_.BuildListStepString) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxLTE_BuildListStepString.");
+  }
+  return function_pointers_.BuildListStepString(listName, resultName, stepNumber, selectorStringLength, selectorString);
+}
+
+int32 NiRFmxLTELibrary::BuildListString(char listName[], char resultName[], int32 selectorStringLength, char selectorString[])
+{
+  if (!function_pointers_.BuildListString) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxLTE_BuildListString.");
+  }
+  return function_pointers_.BuildListString(listName, resultName, selectorStringLength, selectorString);
 }
 
 int32 NiRFmxLTELibrary::BuildOffsetString(char selectorString[], int32 offsetNumber, int32 selectorStringOutLength, char selectorStringOut[])

--- a/generated/nirfmxlte/nirfmxlte_library.h
+++ b/generated/nirfmxlte/nirfmxlte_library.h
@@ -49,6 +49,8 @@ class NiRFmxLTELibrary : public nirfmxlte_grpc::NiRFmxLTELibraryInterface {
   int32 AutoLevel(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 measurementInterval, float64* referenceLevel) override;
   int32 BuildCarrierString(char selectorString[], int32 carrierNumber, int32 selectorStringOutLength, char selectorStringOut[]) override;
   int32 BuildClusterString(char selectorString[], int32 clusterNumber, int32 selectorStringOutLength, char selectorStringOut[]) override;
+  int32 BuildListStepString(char listName[], char resultName[], int32 stepNumber, int32 selectorStringLength, char selectorString[]) override;
+  int32 BuildListString(char listName[], char resultName[], int32 selectorStringLength, char selectorString[]) override;
   int32 BuildOffsetString(char selectorString[], int32 offsetNumber, int32 selectorStringOutLength, char selectorStringOut[]) override;
   int32 BuildPDSCHString(char selectorString[], int32 pdschNumber, int32 selectorStringOutLength, char selectorStringOut[]) override;
   int32 BuildSignalString(char signalName[], char resultName[], int32 selectorStringLength, char selectorString[]) override;
@@ -362,6 +364,8 @@ class NiRFmxLTELibrary : public nirfmxlte_grpc::NiRFmxLTELibraryInterface {
   using AutoLevelPtr = decltype(&RFmxLTE_AutoLevel);
   using BuildCarrierStringPtr = decltype(&RFmxLTE_BuildCarrierString);
   using BuildClusterStringPtr = decltype(&RFmxLTE_BuildClusterString);
+  using BuildListStepStringPtr = decltype(&RFmxLTE_BuildListStepString);
+  using BuildListStringPtr = decltype(&RFmxLTE_BuildListString);
   using BuildOffsetStringPtr = decltype(&RFmxLTE_BuildOffsetString);
   using BuildPDSCHStringPtr = decltype(&RFmxLTE_BuildPDSCHString);
   using BuildSignalStringPtr = decltype(&RFmxLTE_BuildSignalString);
@@ -675,6 +679,8 @@ class NiRFmxLTELibrary : public nirfmxlte_grpc::NiRFmxLTELibraryInterface {
     AutoLevelPtr AutoLevel;
     BuildCarrierStringPtr BuildCarrierString;
     BuildClusterStringPtr BuildClusterString;
+    BuildListStepStringPtr BuildListStepString;
+    BuildListStringPtr BuildListString;
     BuildOffsetStringPtr BuildOffsetString;
     BuildPDSCHStringPtr BuildPDSCHString;
     BuildSignalStringPtr BuildSignalString;

--- a/generated/nirfmxlte/nirfmxlte_library_interface.h
+++ b/generated/nirfmxlte/nirfmxlte_library_interface.h
@@ -43,6 +43,8 @@ class NiRFmxLTELibraryInterface {
   virtual int32 AutoLevel(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 measurementInterval, float64* referenceLevel) = 0;
   virtual int32 BuildCarrierString(char selectorString[], int32 carrierNumber, int32 selectorStringOutLength, char selectorStringOut[]) = 0;
   virtual int32 BuildClusterString(char selectorString[], int32 clusterNumber, int32 selectorStringOutLength, char selectorStringOut[]) = 0;
+  virtual int32 BuildListStepString(char listName[], char resultName[], int32 stepNumber, int32 selectorStringLength, char selectorString[]) = 0;
+  virtual int32 BuildListString(char listName[], char resultName[], int32 selectorStringLength, char selectorString[]) = 0;
   virtual int32 BuildOffsetString(char selectorString[], int32 offsetNumber, int32 selectorStringOutLength, char selectorStringOut[]) = 0;
   virtual int32 BuildPDSCHString(char selectorString[], int32 pdschNumber, int32 selectorStringOutLength, char selectorStringOut[]) = 0;
   virtual int32 BuildSignalString(char signalName[], char resultName[], int32 selectorStringLength, char selectorString[]) = 0;

--- a/generated/nirfmxlte/nirfmxlte_mock_library.h
+++ b/generated/nirfmxlte/nirfmxlte_mock_library.h
@@ -45,6 +45,8 @@ class NiRFmxLTEMockLibrary : public nirfmxlte_grpc::NiRFmxLTELibraryInterface {
   MOCK_METHOD(int32, AutoLevel, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 measurementInterval, float64* referenceLevel), (override));
   MOCK_METHOD(int32, BuildCarrierString, (char selectorString[], int32 carrierNumber, int32 selectorStringOutLength, char selectorStringOut[]), (override));
   MOCK_METHOD(int32, BuildClusterString, (char selectorString[], int32 clusterNumber, int32 selectorStringOutLength, char selectorStringOut[]), (override));
+  MOCK_METHOD(int32, BuildListStepString, (char listName[], char resultName[], int32 stepNumber, int32 selectorStringLength, char selectorString[]), (override));
+  MOCK_METHOD(int32, BuildListString, (char listName[], char resultName[], int32 selectorStringLength, char selectorString[]), (override));
   MOCK_METHOD(int32, BuildOffsetString, (char selectorString[], int32 offsetNumber, int32 selectorStringOutLength, char selectorStringOut[]), (override));
   MOCK_METHOD(int32, BuildPDSCHString, (char selectorString[], int32 pdschNumber, int32 selectorStringOutLength, char selectorStringOut[]), (override));
   MOCK_METHOD(int32, BuildSignalString, (char signalName[], char resultName[], int32 selectorStringLength, char selectorString[]), (override));

--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -1095,6 +1095,97 @@ namespace nirfmxlte_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxLTEService::BuildListStepString(::grpc::ServerContext* context, const BuildListStepStringRequest* request, BuildListStepStringResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto list_name_mbcs = convert_from_grpc<std::string>(request->list_name());
+      char* list_name = (char*)list_name_mbcs.c_str();
+      auto result_name_mbcs = convert_from_grpc<std::string>(request->result_name());
+      char* result_name = (char*)result_name_mbcs.c_str();
+      int32 step_number = request->step_number();
+
+      while (true) {
+        auto status = library_->BuildListStepString(list_name, result_name, step_number, 0, nullptr);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
+        }
+        int32 selector_string_length = status;
+
+        std::string selector_string;
+        if (selector_string_length > 0) {
+            selector_string.resize(selector_string_length - 1);
+        }
+        status = library_->BuildListStepString(list_name, result_name, step_number, selector_string_length, (char*)selector_string.data());
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(selector_string_length)) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
+        }
+        response->set_status(status);
+        std::string selector_string_utf8;
+        convert_to_grpc(selector_string, &selector_string_utf8);
+        response->set_selector_string(selector_string_utf8);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string()));
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxLTEService::BuildListString(::grpc::ServerContext* context, const BuildListStringRequest* request, BuildListStringResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto list_name_mbcs = convert_from_grpc<std::string>(request->list_name());
+      char* list_name = (char*)list_name_mbcs.c_str();
+      auto result_name_mbcs = convert_from_grpc<std::string>(request->result_name());
+      char* result_name = (char*)result_name_mbcs.c_str();
+
+      while (true) {
+        auto status = library_->BuildListString(list_name, result_name, 0, nullptr);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
+        }
+        int32 selector_string_length = status;
+
+        std::string selector_string;
+        if (selector_string_length > 0) {
+            selector_string.resize(selector_string_length - 1);
+        }
+        status = library_->BuildListString(list_name, result_name, selector_string_length, (char*)selector_string.data());
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(selector_string_length)) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
+        }
+        response->set_status(status);
+        std::string selector_string_utf8;
+        convert_to_grpc(selector_string, &selector_string_utf8);
+        response->set_selector_string(selector_string_utf8);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string()));
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxLTEService::BuildOffsetString(::grpc::ServerContext* context, const BuildOffsetStringRequest* request, BuildOffsetStringResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfmxlte/nirfmxlte_service.h
+++ b/generated/nirfmxlte/nirfmxlte_service.h
@@ -72,6 +72,8 @@ public:
   ::grpc::Status AutoLevel(::grpc::ServerContext* context, const AutoLevelRequest* request, AutoLevelResponse* response) override;
   ::grpc::Status BuildCarrierString(::grpc::ServerContext* context, const BuildCarrierStringRequest* request, BuildCarrierStringResponse* response) override;
   ::grpc::Status BuildClusterString(::grpc::ServerContext* context, const BuildClusterStringRequest* request, BuildClusterStringResponse* response) override;
+  ::grpc::Status BuildListStepString(::grpc::ServerContext* context, const BuildListStepStringRequest* request, BuildListStepStringResponse* response) override;
+  ::grpc::Status BuildListString(::grpc::ServerContext* context, const BuildListStringRequest* request, BuildListStringResponse* response) override;
   ::grpc::Status BuildOffsetString(::grpc::ServerContext* context, const BuildOffsetStringRequest* request, BuildOffsetStringResponse* response) override;
   ::grpc::Status BuildPDSCHString(::grpc::ServerContext* context, const BuildPDSCHStringRequest* request, BuildPDSCHStringResponse* response) override;
   ::grpc::Status BuildSignalString(::grpc::ServerContext* context, const BuildSignalStringRequest* request, BuildSignalStringResponse* response) override;

--- a/source/codegen/metadata/nirfmxlte/functions.py
+++ b/source/codegen/metadata/nirfmxlte/functions.py
@@ -996,6 +996,69 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'BuildListStepString': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'listName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'resultName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'stepNumber',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorStringLength',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'selectorString',
+                'size': {
+                    'mechanism': 'ivi-dance',
+                    'value': 'selectorStringLength'
+                },
+                'type': 'char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'BuildListString': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'listName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'resultName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorStringLength',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'selectorString',
+                'size': {
+                    'mechanism': 'ivi-dance',
+                    'value': 'selectorStringLength'
+                },
+                'type': 'char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
     'BuildOffsetString': {
         'parameters': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?
Updates the gRPC Scrapigen Device Code by adding BuildListString and BuildListStepString APIs for LTE.

### Why should this Pull Request be merged?
Adding BuildListString and BuildListStepString APIs for LTE as part of Customer Escalation : https://dev.azure.com/ni/DevCentral/_workitems/edit/2881583?src=WorkItemMention&src-action=artifact_link

### What testing has been done?
Copied files from grpc-device-scrapigen/out/rfmxlte/export/ to grpc-device/source/codegen/metadata/nirfmxlte/ and built grpc-device successfully.
Manually inspected nirfmxlte.proto file.
