### PR TITLE
Fix xnetsocket recvfrom never populating the from_addr due to fromlen being zero

### DIFF
--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -772,7 +772,7 @@ namespace nixnetsocket_grpc {
 
       std::string data(size, '\0');
       auto from_addr = allocate_output_storage<nxsockaddr, SockAddr>();
-      nxsocklen_t fromlen {};
+      auto fromlen = static_cast<nxsocklen_t>(sizeof(from_addr.storage));
       auto status = library_->RecvFrom(socket, (char*)data.data(), size, flags, &from_addr, &fromlen);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSOCKET(context, status, socket);

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -811,7 +811,8 @@ functions = {
                 'direction': 'out',
                 'name': 'fromlen',
                 'include_in_proto': False,
-                'type': 'nxsocklen_t'
+                'type': 'nxsocklen_t',
+                'hardcoded_value': 'static_cast<nxsocklen_t>(sizeof(from_addr))'
             },
         ],
         'returns': 'int32_t'

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -812,7 +812,7 @@ functions = {
                 'name': 'fromlen',
                 'include_in_proto': False,
                 'type': 'nxsocklen_t',
-                'hardcoded_value': 'static_cast<nxsocklen_t>(sizeof(from_addr))'
+                'hardcoded_value': 'static_cast<nxsocklen_t>(sizeof(from_addr.storage))'
             },
         ],
         'returns': 'int32_t'


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fix xnet socket grpc service `RecvFrom` implementation incorrectly passing 0 as `fromlen` to the xnet socket `recvfrom` C API.

### Why should this Pull Request be merged?

When calling `recvfrom` grpc API, I noticed that the `from_addr` is never filled in.

```proto
service NiXnetSocket {
    // ...
    rpc RecvFrom(RecvFromRequest) returns (RecvFromResponse);
}

message RecvFromResponse {
  int32 status = 1;
  bytes data = 2;
  SockAddr from_addr = 3;  // <--- this structure is never populated
  string error_message = 4 [deprecated = true];
  int32 error_num = 5 [deprecated = true];
}
```

`recvfrom` is used by UDP sockets to receive a datagram packet, the [`RecvFrom` grpc service code is implemented](https://github.com/ni/grpc-device/blob/783f0381ed9f04d764fc991b887a1d2b0beaeb01/generated/nixnetsocket/nixnetsocket_service.cpp#L760C39-L760C47) like this:

```cpp
::grpc::Status NiXnetSocketService::RecvFrom(::grpc::ServerContext* context, const RecvFromRequest* request, RecvFromResponse* response)
{
    // ...
    auto from_addr = allocate_output_storage<nxsockaddr, SockAddr>();
    nxsocklen_t fromlen {};
    auto status = library_->RecvFrom(socket, (char*)data.data(), size, flags, &from_addr, &fromlen);
}
```
`from_addr` is a structure that `library_->RecvFrom` will fill in with the remote address that sent the datagram packet;  the `fromlen` parameter tells the API the size of the `from_addr` structure.

The currently generated grpc service code initializes `fromlen` as 0:

```cpp
nxsocklen_t fromlen {};
```
However, the `recvfrom` C implementation will [only populate `from_addr` if `fromlen` is NOT 0](https://dev.azure.com/ni/DevCentral/_git/ni-central?path=/src/xnet/xnetCored/nixnttcpip/source/fusion/net/stack/recvfrom.c&version=GCd188d0026ee1c28e3de374220f1e2bf9f6280f2e&line=194&lineEnd=194&lineStartColumn=4&lineEndColumn=85&lineStyle=plain&_a=contents):

```cpp
if (from != (struct sockaddr *)0 &&  fromlen != (FNS_SOCKLEN_T *)0  &&  *fromlen)
```

By passing 0, `from_addr` structure is never populated, leaving the grpc caller unable to retrieve information about the client address that sent the packet.

### What testing has been done?

Manually tested that by setting `fromlen` to `sizeof(from_addr.storage)` the grpc call is now getting the client address.
