### PR TITLE
Fix Accept addrlen initialization

### DIFF
--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -58,7 +58,7 @@ namespace nixnetsocket_grpc {
       auto initialization_behavior = request->initialization_behavior();
 
       auto addr = allocate_output_storage<nxsockaddr, SockAddr>();
-      nxsocklen_t addrlen {};
+      auto addrlen = static_cast<nxsocklen_t>(sizeof(addr.storage));
       bool new_session_initialized {};
       auto init_lambda = [&] () {
         auto socket_out = library_->Accept(socket, &addr, &addrlen);

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -21,7 +21,8 @@ functions = {
                 'direction': 'out',
                 'name': 'addrlen',
                 'include_in_proto': False,
-                'type': 'nxsocklen_t'
+                'type': 'nxsocklen_t',
+                'hardcoded_value': 'static_cast<nxsocklen_t>(sizeof(addr.storage))'
             },
             {
                 'direction': 'out',


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Properly initialize the address length variable being passed to the `nxaccept` call.
- Fix mirrored to https://github.com/ni/grpc-device-scrapigen/pull/252

### Why should this Pull Request be merged?

Similar to #1107 , the address is also not being populated in the `Accept` call.

### What testing has been done?

Manually tested that by setting `addrlen` to `sizeof(addr.storage)` the grpc call is now getting the client address.
