### PR TITLE
Pick up scrapigen daqmx enum metadata update

### DIFF
--- a/source/codegen/metadata/nidaqmx/enums.py
+++ b/source/codegen/metadata/nidaqmx/enums.py
@@ -1488,20 +1488,6 @@ enums = {
                 'documentation': {
                     'description': ' '
                 },
-                'name': 'PROPERTY_NOT_SPECD_FOR_ENTIRE_PORT',
-                'value': -209898
-            },
-            {
-                'documentation': {
-                    'description': ' '
-                },
-                'name': 'CANNOT_SET_PROPERTY_WHEN_DA_QMX_TASK_RUNNING',
-                'value': -209897
-            },
-            {
-                'documentation': {
-                    'description': ' '
-                },
                 'name': 'ATTR_NOT_SUPPORTED_USE_PHYSICAL_CHANNEL_PROPERTY',
                 'value': -209896
             },

--- a/source/codegen/metadata/nidaqmx/enums.py
+++ b/source/codegen/metadata/nidaqmx/enums.py
@@ -1488,6 +1488,20 @@ enums = {
                 'documentation': {
                     'description': ' '
                 },
+                'name': 'PROPERTY_NOT_SPECD_FOR_ENTIRE_PORT',
+                'value': -209898
+            },
+            {
+                'documentation': {
+                    'description': ' '
+                },
+                'name': 'CANNOT_SET_PROPERTY_WHEN_DA_QMX_TASK_RUNNING',
+                'value': -209897
+            },
+            {
+                'documentation': {
+                    'description': ' '
+                },
                 'name': 'ATTR_NOT_SUPPORTED_USE_PHYSICAL_CHANNEL_PROPERTY',
                 'value': -209896
             },


### PR DESCRIPTION
### What does this Pull Request accomplish?

Pull latest scrapigen daqmx error code metadata update from this PR: https://github.com/ni/grpc-device-scrapigen/pull/255

### Why should this Pull Request be merged?

To make sure the metadata stays coherent although it does not re-codegen any file.

### What testing has been done?

Local build successfully.
