### PR TITLE
[tiny] Use parameter name from get_cpp_local_name

### DIFF
--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1235,7 +1235,7 @@ def _is_streaming_param_input_array(streaming_param):
     )
 
 
-def get_input_streaming_param(parameters):
+def get_input_streaming_params(parameters):
     """Determine if a parameter should be included based on streaming conditions."""
     streaming_param = None
     for param in parameters:


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR mostly contains cosmetic changes. The only notable change here is to use the name we get from `get_cpp_local_name`, which takes care of camel case as well, which would help in another initialization name to be same.

### Why should this Pull Request be merged?

- Updated to use `get_cpp_local_name` for the parameter name.
- Other cosmetic changes related to helper name.

### What testing has been done?

No functional changes for FPGA as most of them already follow the pattern.