### PR TITLE
[tiny performance fix] Array that are not coerced, creating a copy is unnecessary.

### DIFF
--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -488,17 +488,10 @@ namespace nifpga_grpc {
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    auto array_storage = std::vector<double>(size);
-    auto array = array_storage.data();
+    function_data->data.mutable_value()->Resize(size, 0);
+    auto array = function_data->data.mutable_value()->mutable_data();
     auto status = library->ReadArrayDbl(session, indicator, array, size);
     if (status >= 0) {
-      std::transform(
-        array,
-        array + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
       packedData.PackFrom(function_data->data);
     }
 
@@ -543,17 +536,10 @@ namespace nifpga_grpc {
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    auto array_storage = std::vector<int32_t>(size);
-    auto array = array_storage.data();
+    function_data->data.mutable_value()->Resize(size, 0);
+    auto array = function_data->data.mutable_value()->mutable_data();
     auto status = library->ReadArrayI32(session, indicator, array, size);
     if (status >= 0) {
-      std::transform(
-        array,
-        array + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
       packedData.PackFrom(function_data->data);
     }
 
@@ -571,17 +557,10 @@ namespace nifpga_grpc {
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    auto array_storage = std::vector<int64_t>(size);
-    auto array = array_storage.data();
+    function_data->data.mutable_value()->Resize(size, 0);
+    auto array = function_data->data.mutable_value()->mutable_data();
     auto status = library->ReadArrayI64(session, indicator, array, size);
     if (status >= 0) {
-      std::transform(
-        array,
-        array + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
       packedData.PackFrom(function_data->data);
     }
 
@@ -626,17 +605,10 @@ namespace nifpga_grpc {
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    auto array_storage = std::vector<float>(size);
-    auto array = array_storage.data();
+    function_data->data.mutable_value()->Resize(size, 0);
+    auto array = function_data->data.mutable_value()->mutable_data();
     auto status = library->ReadArraySgl(session, indicator, array, size);
     if (status >= 0) {
-      std::transform(
-        array,
-        array + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
       packedData.PackFrom(function_data->data);
     }
 
@@ -681,17 +653,10 @@ namespace nifpga_grpc {
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    auto array_storage = std::vector<uint32_t>(size);
-    auto array = array_storage.data();
+    function_data->data.mutable_value()->Resize(size, 0);
+    auto array = function_data->data.mutable_value()->mutable_data();
     auto status = library->ReadArrayU32(session, indicator, array, size);
     if (status >= 0) {
-      std::transform(
-        array,
-        array + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
       packedData.PackFrom(function_data->data);
     }
 
@@ -709,17 +674,10 @@ namespace nifpga_grpc {
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    auto array_storage = std::vector<uint64_t>(size);
-    auto array = array_storage.data();
+    function_data->data.mutable_value()->Resize(size, 0);
+    auto array = function_data->data.mutable_value()->mutable_data();
     auto status = library->ReadArrayU64(session, indicator, array, size);
     if (status >= 0) {
-      std::transform(
-        array,
-        array + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
       packedData.PackFrom(function_data->data);
     }
 

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -376,12 +376,12 @@ std::vector<${data_type}> array(${size}, ${data_type}());
 % elif is_coerced:
 std::vector<${data_type}> array(${size});
 % else:
-auto array_storage = std::vector<${data_type}>(${size});
-    auto array = array_storage.data();
+function_data->data.mutable_value()->Resize(${size}, 0);
+    auto array = function_data->data.mutable_value()->mutable_data();
 % endif
     auto status = library->${c_api_name}(${arg_string});
-% if is_coerced or common_helpers.supports_standard_copy_conversion_routines(streaming_param):
     if (status >= 0) {
+% if is_coerced or common_helpers.supports_standard_copy_conversion_routines(streaming_param):
       std::transform(
         array.begin(),
         array.begin() + ${size},
@@ -389,20 +389,9 @@ auto array_storage = std::vector<${data_type}>(${size});
         [&](auto x) {
            return x;
       });
-      packedData.PackFrom(function_data->data);
-    }
-% else:
-    if (status >= 0) {
-      std::transform(
-        array,
-        array + ${size},
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
-      packedData.PackFrom(function_data->data);
-    }
 % endif
+      packedData.PackFrom(function_data->data);
+    }
 </%def>
 
 <%def name="streaming_handle_out_direction_scaler(c_api_name, arg_string, streaming_type)">\


### PR DESCRIPTION
### What does this Pull Request accomplish?
For data types in an array that are not coerced, creating a copy is unnecessary. We can efficiently utilize the existing data within our structure.

### Why should this Pull Request be merged?

- Instead of allocating a new array and transferring the data, we can pass a pointer directly to the existing data.
- Updated mako accordingly as we don't need an else condition now, hence moved the status check before the **if**.

### What testing has been done?

The APIs have been tested, and they function as expected, maintaining the same behavior as before.