### PR TITLE
Moniker streaming functions return standard reponse message instead of custom data type

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -8518,6 +8518,16 @@ message BeginReadAnalogF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadAnalogF64StreamingData {
+  ReadAnalogF64StreamingDataResponse response = 2;
+}
+
+message ReadAnalogF64StreamingDataResponse {
+  int32 status = 1;
+  repeated double read_array = 2;
+  int32 samps_per_chan_read = 3;
+}
+
 message ReadAnalogScalarF64Request {
   nidevice_grpc.Session task = 1;
   double timeout = 2;
@@ -8536,6 +8546,15 @@ message BeginReadAnalogScalarF64Request {
 message BeginReadAnalogScalarF64Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadAnalogScalarF64StreamingData {
+  ReadAnalogScalarF64StreamingDataResponse response = 2;
+}
+
+message ReadAnalogScalarF64StreamingDataResponse {
+  int32 status = 1;
+  double value = 2;
 }
 
 message ReadBinaryI16Request {
@@ -8571,6 +8590,16 @@ message BeginReadBinaryI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadBinaryI16StreamingData {
+  ReadBinaryI16StreamingDataResponse response = 2;
+}
+
+message ReadBinaryI16StreamingDataResponse {
+  int32 status = 1;
+  repeated int32 read_array = 2;
+  int32 samps_per_chan_read = 3;
+}
+
 message ReadBinaryI32Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -8602,6 +8631,16 @@ message BeginReadBinaryI32Request {
 message BeginReadBinaryI32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadBinaryI32StreamingData {
+  ReadBinaryI32StreamingDataResponse response = 2;
+}
+
+message ReadBinaryI32StreamingDataResponse {
+  int32 status = 1;
+  repeated int32 read_array = 2;
+  int32 samps_per_chan_read = 3;
 }
 
 message ReadBinaryU16Request {
@@ -8637,6 +8676,16 @@ message BeginReadBinaryU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadBinaryU16StreamingData {
+  ReadBinaryU16StreamingDataResponse response = 2;
+}
+
+message ReadBinaryU16StreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 read_array = 2;
+  int32 samps_per_chan_read = 3;
+}
+
 message ReadBinaryU32Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -8670,6 +8719,16 @@ message BeginReadBinaryU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadBinaryU32StreamingData {
+  ReadBinaryU32StreamingDataResponse response = 2;
+}
+
+message ReadBinaryU32StreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 read_array = 2;
+  int32 samps_per_chan_read = 3;
+}
+
 message ReadCounterF64Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -8693,6 +8752,16 @@ message BeginReadCounterF64Request {
 message BeginReadCounterF64Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadCounterF64StreamingData {
+  ReadCounterF64StreamingDataResponse response = 2;
+}
+
+message ReadCounterF64StreamingDataResponse {
+  int32 status = 1;
+  repeated double read_array = 2;
+  int32 samps_per_chan_read = 3;
 }
 
 message ReadCounterF64ExRequest {
@@ -8728,6 +8797,16 @@ message BeginReadCounterF64ExResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadCounterF64ExStreamingData {
+  ReadCounterF64ExStreamingDataResponse response = 2;
+}
+
+message ReadCounterF64ExStreamingDataResponse {
+  int32 status = 1;
+  repeated double read_array = 2;
+  int32 samps_per_chan_read = 3;
+}
+
 message ReadCounterScalarF64Request {
   nidevice_grpc.Session task = 1;
   double timeout = 2;
@@ -8748,6 +8827,15 @@ message BeginReadCounterScalarF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadCounterScalarF64StreamingData {
+  ReadCounterScalarF64StreamingDataResponse response = 2;
+}
+
+message ReadCounterScalarF64StreamingDataResponse {
+  int32 status = 1;
+  double value = 2;
+}
+
 message ReadCounterScalarU32Request {
   nidevice_grpc.Session task = 1;
   double timeout = 2;
@@ -8766,6 +8854,15 @@ message BeginReadCounterScalarU32Request {
 message BeginReadCounterScalarU32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadCounterScalarU32StreamingData {
+  ReadCounterScalarU32StreamingDataResponse response = 2;
+}
+
+message ReadCounterScalarU32StreamingDataResponse {
+  int32 status = 1;
+  uint32 value = 2;
 }
 
 message ReadCounterU32Request {
@@ -8791,6 +8888,16 @@ message BeginReadCounterU32Request {
 message BeginReadCounterU32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadCounterU32StreamingData {
+  ReadCounterU32StreamingDataResponse response = 2;
+}
+
+message ReadCounterU32StreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 read_array = 2;
+  int32 samps_per_chan_read = 3;
 }
 
 message ReadCounterU32ExRequest {
@@ -8824,6 +8931,16 @@ message BeginReadCounterU32ExRequest {
 message BeginReadCounterU32ExResponse {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadCounterU32ExStreamingData {
+  ReadCounterU32ExStreamingDataResponse response = 2;
+}
+
+message ReadCounterU32ExStreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 read_array = 2;
+  int32 samps_per_chan_read = 3;
 }
 
 message ReadCtrFreqRequest {
@@ -8951,6 +9068,15 @@ message BeginReadDigitalScalarU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadDigitalScalarU32StreamingData {
+  ReadDigitalScalarU32StreamingDataResponse response = 2;
+}
+
+message ReadDigitalScalarU32StreamingDataResponse {
+  int32 status = 1;
+  uint32 value = 2;
+}
+
 message ReadDigitalU16Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -8984,6 +9110,16 @@ message BeginReadDigitalU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadDigitalU16StreamingData {
+  ReadDigitalU16StreamingDataResponse response = 2;
+}
+
+message ReadDigitalU16StreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 read_array = 2;
+  int32 samps_per_chan_read = 3;
+}
+
 message ReadDigitalU32Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -9015,6 +9151,16 @@ message BeginReadDigitalU32Request {
 message BeginReadDigitalU32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadDigitalU32StreamingData {
+  ReadDigitalU32StreamingDataResponse response = 2;
+}
+
+message ReadDigitalU32StreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 read_array = 2;
+  int32 samps_per_chan_read = 3;
 }
 
 message ReadDigitalU8Request {
@@ -10405,6 +10551,15 @@ message BeginWaitForNextSampleClockResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WaitForNextSampleClockStreamingData {
+  WaitForNextSampleClockStreamingDataResponse response = 2;
+}
+
+message WaitForNextSampleClockStreamingDataResponse {
+  int32 status = 1;
+  bool is_late = 2;
+}
+
 message WaitForValidTimestampRequest {
   nidevice_grpc.Session task = 1;
   oneof timestamp_event_enum {
@@ -10461,6 +10616,20 @@ message BeginWriteAnalogF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteAnalogF64StreamingData {
+  WriteAnalogF64StreamingDataRequest request = 1;
+  WriteAnalogF64StreamingDataResponse response = 2;
+}
+
+message WriteAnalogF64StreamingDataRequest {
+  repeated double write_array = 1;
+}
+
+message WriteAnalogF64StreamingDataResponse {
+  int32 status = 1;
+  int32 samps_per_chan_written = 2;
+}
+
 message WriteAnalogScalarF64Request {
   nidevice_grpc.Session task = 1;
   bool auto_start = 2;
@@ -10481,6 +10650,19 @@ message BeginWriteAnalogScalarF64Request {
 message BeginWriteAnalogScalarF64Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteAnalogScalarF64StreamingData {
+  WriteAnalogScalarF64StreamingDataRequest request = 1;
+  WriteAnalogScalarF64StreamingDataResponse response = 2;
+}
+
+message WriteAnalogScalarF64StreamingDataRequest {
+  double value = 1;
+}
+
+message WriteAnalogScalarF64StreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteBinaryI16Request {
@@ -10516,6 +10698,20 @@ message BeginWriteBinaryI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteBinaryI16StreamingData {
+  WriteBinaryI16StreamingDataRequest request = 1;
+  WriteBinaryI16StreamingDataResponse response = 2;
+}
+
+message WriteBinaryI16StreamingDataRequest {
+  repeated int32 write_array = 1;
+}
+
+message WriteBinaryI16StreamingDataResponse {
+  int32 status = 1;
+  int32 samps_per_chan_written = 2;
+}
+
 message WriteBinaryI32Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -10547,6 +10743,20 @@ message BeginWriteBinaryI32Request {
 message BeginWriteBinaryI32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteBinaryI32StreamingData {
+  WriteBinaryI32StreamingDataRequest request = 1;
+  WriteBinaryI32StreamingDataResponse response = 2;
+}
+
+message WriteBinaryI32StreamingDataRequest {
+  repeated int32 write_array = 1;
+}
+
+message WriteBinaryI32StreamingDataResponse {
+  int32 status = 1;
+  int32 samps_per_chan_written = 2;
 }
 
 message WriteBinaryU16Request {
@@ -10582,6 +10792,20 @@ message BeginWriteBinaryU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteBinaryU16StreamingData {
+  WriteBinaryU16StreamingDataRequest request = 1;
+  WriteBinaryU16StreamingDataResponse response = 2;
+}
+
+message WriteBinaryU16StreamingDataRequest {
+  repeated uint32 write_array = 1;
+}
+
+message WriteBinaryU16StreamingDataResponse {
+  int32 status = 1;
+  int32 samps_per_chan_written = 2;
+}
+
 message WriteBinaryU32Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -10613,6 +10837,20 @@ message BeginWriteBinaryU32Request {
 message BeginWriteBinaryU32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteBinaryU32StreamingData {
+  WriteBinaryU32StreamingDataRequest request = 1;
+  WriteBinaryU32StreamingDataResponse response = 2;
+}
+
+message WriteBinaryU32StreamingDataRequest {
+  repeated uint32 write_array = 1;
+}
+
+message WriteBinaryU32StreamingDataResponse {
+  int32 status = 1;
+  int32 samps_per_chan_written = 2;
 }
 
 message WriteCtrFreqRequest {
@@ -10744,6 +10982,19 @@ message BeginWriteDigitalScalarU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteDigitalScalarU32StreamingData {
+  WriteDigitalScalarU32StreamingDataRequest request = 1;
+  WriteDigitalScalarU32StreamingDataResponse response = 2;
+}
+
+message WriteDigitalScalarU32StreamingDataRequest {
+  uint32 value = 1;
+}
+
+message WriteDigitalScalarU32StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteDigitalU16Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -10777,6 +11028,20 @@ message BeginWriteDigitalU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteDigitalU16StreamingData {
+  WriteDigitalU16StreamingDataRequest request = 1;
+  WriteDigitalU16StreamingDataResponse response = 2;
+}
+
+message WriteDigitalU16StreamingDataRequest {
+  repeated uint32 write_array = 1;
+}
+
+message WriteDigitalU16StreamingDataResponse {
+  int32 status = 1;
+  int32 samps_per_chan_written = 2;
+}
+
 message WriteDigitalU32Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -10808,6 +11073,20 @@ message BeginWriteDigitalU32Request {
 message BeginWriteDigitalU32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteDigitalU32StreamingData {
+  WriteDigitalU32StreamingDataRequest request = 1;
+  WriteDigitalU32StreamingDataResponse response = 2;
+}
+
+message WriteDigitalU32StreamingDataRequest {
+  repeated uint32 write_array = 1;
+}
+
+message WriteDigitalU32StreamingDataResponse {
+  int32 status = 1;
+  int32 samps_per_chan_written = 2;
 }
 
 message WriteDigitalU8Request {

--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -8518,11 +8518,7 @@ message BeginReadAnalogF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadAnalogF64StreamingData {
-  ReadAnalogF64StreamingDataResponse response = 2;
-}
-
-message ReadAnalogF64StreamingDataResponse {
+message ReadAnalogF64StreamingResponse {
   int32 status = 1;
   repeated double read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -8548,11 +8544,7 @@ message BeginReadAnalogScalarF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadAnalogScalarF64StreamingData {
-  ReadAnalogScalarF64StreamingDataResponse response = 2;
-}
-
-message ReadAnalogScalarF64StreamingDataResponse {
+message ReadAnalogScalarF64StreamingResponse {
   int32 status = 1;
   double value = 2;
 }
@@ -8590,11 +8582,7 @@ message BeginReadBinaryI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadBinaryI16StreamingData {
-  ReadBinaryI16StreamingDataResponse response = 2;
-}
-
-message ReadBinaryI16StreamingDataResponse {
+message ReadBinaryI16StreamingResponse {
   int32 status = 1;
   repeated int32 read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -8633,11 +8621,7 @@ message BeginReadBinaryI32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadBinaryI32StreamingData {
-  ReadBinaryI32StreamingDataResponse response = 2;
-}
-
-message ReadBinaryI32StreamingDataResponse {
+message ReadBinaryI32StreamingResponse {
   int32 status = 1;
   repeated int32 read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -8676,11 +8660,7 @@ message BeginReadBinaryU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadBinaryU16StreamingData {
-  ReadBinaryU16StreamingDataResponse response = 2;
-}
-
-message ReadBinaryU16StreamingDataResponse {
+message ReadBinaryU16StreamingResponse {
   int32 status = 1;
   repeated uint32 read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -8719,11 +8699,7 @@ message BeginReadBinaryU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadBinaryU32StreamingData {
-  ReadBinaryU32StreamingDataResponse response = 2;
-}
-
-message ReadBinaryU32StreamingDataResponse {
+message ReadBinaryU32StreamingResponse {
   int32 status = 1;
   repeated uint32 read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -8754,11 +8730,7 @@ message BeginReadCounterF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadCounterF64StreamingData {
-  ReadCounterF64StreamingDataResponse response = 2;
-}
-
-message ReadCounterF64StreamingDataResponse {
+message ReadCounterF64StreamingResponse {
   int32 status = 1;
   repeated double read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -8797,11 +8769,7 @@ message BeginReadCounterF64ExResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadCounterF64ExStreamingData {
-  ReadCounterF64ExStreamingDataResponse response = 2;
-}
-
-message ReadCounterF64ExStreamingDataResponse {
+message ReadCounterF64ExStreamingResponse {
   int32 status = 1;
   repeated double read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -8827,11 +8795,7 @@ message BeginReadCounterScalarF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadCounterScalarF64StreamingData {
-  ReadCounterScalarF64StreamingDataResponse response = 2;
-}
-
-message ReadCounterScalarF64StreamingDataResponse {
+message ReadCounterScalarF64StreamingResponse {
   int32 status = 1;
   double value = 2;
 }
@@ -8856,11 +8820,7 @@ message BeginReadCounterScalarU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadCounterScalarU32StreamingData {
-  ReadCounterScalarU32StreamingDataResponse response = 2;
-}
-
-message ReadCounterScalarU32StreamingDataResponse {
+message ReadCounterScalarU32StreamingResponse {
   int32 status = 1;
   uint32 value = 2;
 }
@@ -8890,11 +8850,7 @@ message BeginReadCounterU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadCounterU32StreamingData {
-  ReadCounterU32StreamingDataResponse response = 2;
-}
-
-message ReadCounterU32StreamingDataResponse {
+message ReadCounterU32StreamingResponse {
   int32 status = 1;
   repeated uint32 read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -8933,11 +8889,7 @@ message BeginReadCounterU32ExResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadCounterU32ExStreamingData {
-  ReadCounterU32ExStreamingDataResponse response = 2;
-}
-
-message ReadCounterU32ExStreamingDataResponse {
+message ReadCounterU32ExStreamingResponse {
   int32 status = 1;
   repeated uint32 read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -9068,11 +9020,7 @@ message BeginReadDigitalScalarU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadDigitalScalarU32StreamingData {
-  ReadDigitalScalarU32StreamingDataResponse response = 2;
-}
-
-message ReadDigitalScalarU32StreamingDataResponse {
+message ReadDigitalScalarU32StreamingResponse {
   int32 status = 1;
   uint32 value = 2;
 }
@@ -9110,11 +9058,7 @@ message BeginReadDigitalU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadDigitalU16StreamingData {
-  ReadDigitalU16StreamingDataResponse response = 2;
-}
-
-message ReadDigitalU16StreamingDataResponse {
+message ReadDigitalU16StreamingResponse {
   int32 status = 1;
   repeated uint32 read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -9153,11 +9097,7 @@ message BeginReadDigitalU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadDigitalU32StreamingData {
-  ReadDigitalU32StreamingDataResponse response = 2;
-}
-
-message ReadDigitalU32StreamingDataResponse {
+message ReadDigitalU32StreamingResponse {
   int32 status = 1;
   repeated uint32 read_array = 2;
   int32 samps_per_chan_read = 3;
@@ -10551,11 +10491,7 @@ message BeginWaitForNextSampleClockResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WaitForNextSampleClockStreamingData {
-  WaitForNextSampleClockStreamingDataResponse response = 2;
-}
-
-message WaitForNextSampleClockStreamingDataResponse {
+message WaitForNextSampleClockStreamingResponse {
   int32 status = 1;
   bool is_late = 2;
 }
@@ -10616,16 +10552,11 @@ message BeginWriteAnalogF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteAnalogF64StreamingData {
-  WriteAnalogF64StreamingDataRequest request = 1;
-  WriteAnalogF64StreamingDataResponse response = 2;
-}
-
-message WriteAnalogF64StreamingDataRequest {
+message WriteAnalogF64StreamingRequest {
   repeated double write_array = 1;
 }
 
-message WriteAnalogF64StreamingDataResponse {
+message WriteAnalogF64StreamingResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
 }
@@ -10652,16 +10583,11 @@ message BeginWriteAnalogScalarF64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteAnalogScalarF64StreamingData {
-  WriteAnalogScalarF64StreamingDataRequest request = 1;
-  WriteAnalogScalarF64StreamingDataResponse response = 2;
-}
-
-message WriteAnalogScalarF64StreamingDataRequest {
+message WriteAnalogScalarF64StreamingRequest {
   double value = 1;
 }
 
-message WriteAnalogScalarF64StreamingDataResponse {
+message WriteAnalogScalarF64StreamingResponse {
   int32 status = 1;
 }
 
@@ -10698,16 +10624,11 @@ message BeginWriteBinaryI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteBinaryI16StreamingData {
-  WriteBinaryI16StreamingDataRequest request = 1;
-  WriteBinaryI16StreamingDataResponse response = 2;
-}
-
-message WriteBinaryI16StreamingDataRequest {
+message WriteBinaryI16StreamingRequest {
   repeated int32 write_array = 1;
 }
 
-message WriteBinaryI16StreamingDataResponse {
+message WriteBinaryI16StreamingResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
 }
@@ -10745,16 +10666,11 @@ message BeginWriteBinaryI32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteBinaryI32StreamingData {
-  WriteBinaryI32StreamingDataRequest request = 1;
-  WriteBinaryI32StreamingDataResponse response = 2;
-}
-
-message WriteBinaryI32StreamingDataRequest {
+message WriteBinaryI32StreamingRequest {
   repeated int32 write_array = 1;
 }
 
-message WriteBinaryI32StreamingDataResponse {
+message WriteBinaryI32StreamingResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
 }
@@ -10792,16 +10708,11 @@ message BeginWriteBinaryU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteBinaryU16StreamingData {
-  WriteBinaryU16StreamingDataRequest request = 1;
-  WriteBinaryU16StreamingDataResponse response = 2;
-}
-
-message WriteBinaryU16StreamingDataRequest {
+message WriteBinaryU16StreamingRequest {
   repeated uint32 write_array = 1;
 }
 
-message WriteBinaryU16StreamingDataResponse {
+message WriteBinaryU16StreamingResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
 }
@@ -10839,16 +10750,11 @@ message BeginWriteBinaryU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteBinaryU32StreamingData {
-  WriteBinaryU32StreamingDataRequest request = 1;
-  WriteBinaryU32StreamingDataResponse response = 2;
-}
-
-message WriteBinaryU32StreamingDataRequest {
+message WriteBinaryU32StreamingRequest {
   repeated uint32 write_array = 1;
 }
 
-message WriteBinaryU32StreamingDataResponse {
+message WriteBinaryU32StreamingResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
 }
@@ -10982,16 +10888,11 @@ message BeginWriteDigitalScalarU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteDigitalScalarU32StreamingData {
-  WriteDigitalScalarU32StreamingDataRequest request = 1;
-  WriteDigitalScalarU32StreamingDataResponse response = 2;
-}
-
-message WriteDigitalScalarU32StreamingDataRequest {
+message WriteDigitalScalarU32StreamingRequest {
   uint32 value = 1;
 }
 
-message WriteDigitalScalarU32StreamingDataResponse {
+message WriteDigitalScalarU32StreamingResponse {
   int32 status = 1;
 }
 
@@ -11028,16 +10929,11 @@ message BeginWriteDigitalU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteDigitalU16StreamingData {
-  WriteDigitalU16StreamingDataRequest request = 1;
-  WriteDigitalU16StreamingDataResponse response = 2;
-}
-
-message WriteDigitalU16StreamingDataRequest {
+message WriteDigitalU16StreamingRequest {
   repeated uint32 write_array = 1;
 }
 
-message WriteDigitalU16StreamingDataResponse {
+message WriteDigitalU16StreamingResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
 }
@@ -11075,16 +10971,11 @@ message BeginWriteDigitalU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteDigitalU32StreamingData {
-  WriteDigitalU32StreamingDataRequest request = 1;
-  WriteDigitalU32StreamingDataResponse response = 2;
-}
-
-message WriteDigitalU32StreamingDataRequest {
+message WriteDigitalU32StreamingRequest {
   repeated uint32 write_array = 1;
 }
 
-message WriteDigitalU32StreamingDataResponse {
+message WriteDigitalU32StreamingResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
 }

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -14471,8 +14471,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadAnalogF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14635,8 +14635,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14735,8 +14735,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14843,8 +14843,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14943,8 +14943,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15010,8 +15010,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15110,8 +15110,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterF64Ex", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15289,8 +15289,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15389,8 +15389,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterU32Ex", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15833,8 +15833,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDigitalU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15933,8 +15933,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+      data->response.mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->response.mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDigitalU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -33,7 +33,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayDoubleData data;
+     nidaqmx_grpc::ReadAnalogF64StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -42,7 +42,7 @@ namespace nidaqmx_grpc {
      TaskHandle task;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::DoubleData data;
+     nidaqmx_grpc::ReadAnalogScalarF64StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -54,7 +54,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayI16Data data;
+     nidaqmx_grpc::ReadBinaryI16StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -66,7 +66,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayI32Data data;
+     nidaqmx_grpc::ReadBinaryI32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -78,7 +78,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU16Data data;
+     nidaqmx_grpc::ReadBinaryU16StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -90,7 +90,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU32Data data;
+     nidaqmx_grpc::ReadBinaryU32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -101,7 +101,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayDoubleData data;
+     nidaqmx_grpc::ReadCounterF64StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -113,7 +113,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayDoubleData data;
+     nidaqmx_grpc::ReadCounterF64ExStreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -122,7 +122,7 @@ namespace nidaqmx_grpc {
      TaskHandle task;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::DoubleData data;
+     nidaqmx_grpc::ReadCounterScalarF64StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -131,7 +131,7 @@ namespace nidaqmx_grpc {
      TaskHandle task;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::U32Data data;
+     nidaqmx_grpc::ReadCounterScalarU32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -142,7 +142,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU32Data data;
+     nidaqmx_grpc::ReadCounterU32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -154,7 +154,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU32Data data;
+     nidaqmx_grpc::ReadCounterU32ExStreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -163,7 +163,7 @@ namespace nidaqmx_grpc {
      TaskHandle task;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::U32Data data;
+     nidaqmx_grpc::ReadDigitalScalarU32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -175,7 +175,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU16Data data;
+     nidaqmx_grpc::ReadDigitalU16StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -187,7 +187,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU32Data data;
+     nidaqmx_grpc::ReadDigitalU32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -195,7 +195,7 @@ namespace nidaqmx_grpc {
   {
      TaskHandle task;
      float64 timeout;
-     nidaqmx_grpc::BoolData data;
+     nidaqmx_grpc::WaitForNextSampleClockStreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -207,7 +207,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::ArrayDoubleData data;
+     nidaqmx_grpc::WriteAnalogF64StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -217,7 +217,7 @@ namespace nidaqmx_grpc {
      bool32 auto_start;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::DoubleData data;
+     nidaqmx_grpc::WriteAnalogScalarF64StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -229,7 +229,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::ArrayI16Data data;
+     nidaqmx_grpc::WriteBinaryI16StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -241,7 +241,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::ArrayI32Data data;
+     nidaqmx_grpc::WriteBinaryI32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -253,7 +253,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU16Data data;
+     nidaqmx_grpc::WriteBinaryU16StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -265,7 +265,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU32Data data;
+     nidaqmx_grpc::WriteBinaryU32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -275,7 +275,7 @@ namespace nidaqmx_grpc {
      bool32 auto_start;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::U32Data data;
+     nidaqmx_grpc::WriteDigitalScalarU32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -287,7 +287,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU16Data data;
+     nidaqmx_grpc::WriteDigitalU16StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -299,7 +299,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::ArrayU32Data data;
+     nidaqmx_grpc::WriteDigitalU32StreamingData data;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -359,6 +359,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadAnalogF64Data* function_data = static_cast<MonikerReadAnalogF64Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -366,16 +367,30 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
-    function_data->data.mutable_value()->Resize(array_size_in_samps, 0);
-    auto read_array = function_data->data.mutable_value()->mutable_data();
+    int32 samps_per_chan_read = {};        
+    response->mutable_read_array()->Resize(array_size_in_samps, 0);
+    auto read_array = response->mutable_read_array()->mutable_data();
     auto status = library->ReadAnalogF64(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadAnalogF64 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -384,19 +399,32 @@ namespace nidaqmx_grpc {
 {
     MonikerReadAnalogScalarF64Data* function_data = static_cast<MonikerReadAnalogScalarF64Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-
-    float64 value {};
+        
+float64 value {};
     auto status = library->ReadAnalogScalarF64(task, timeout, &value, reserved);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
 
-    if (status < 0) {
-      std::cout << "MonikerReadAnalogScalarF64 error: " << status << std::endl;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -405,6 +433,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadBinaryI16Data* function_data = static_cast<MonikerReadBinaryI16Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -412,22 +441,47 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
+    int32 samps_per_chan_read = {};        
     std::vector<int16> read_array(array_size_in_samps);
     auto status = library->ReadBinaryI16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
-      std::transform(
-        read_array.begin(),
-        read_array.begin() + array_size_in_samps,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+        response->mutable_read_array()->Clear();
+        response->mutable_read_array()->Reserve(array_size_in_samps);
+        std::transform(
+          read_array.begin(),
+          read_array.begin() + array_size_in_samps,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+        response->mutable_read_array()->Clear();
+        response->mutable_read_array()->Reserve(array_size_in_samps);
+        std::transform(
+          read_array.begin(),
+          read_array.begin() + array_size_in_samps,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadBinaryI16 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -436,6 +490,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadBinaryI32Data* function_data = static_cast<MonikerReadBinaryI32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -443,16 +498,30 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
-    function_data->data.mutable_value()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<int32*>(function_data->data.mutable_value()->mutable_data());
+    int32 samps_per_chan_read = {};        
+    response->mutable_read_array()->Resize(array_size_in_samps, 0);
+    auto read_array = reinterpret_cast<int32*>(response->mutable_read_array()->mutable_data());
     auto status = library->ReadBinaryI32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadBinaryI32 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -461,6 +530,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadBinaryU16Data* function_data = static_cast<MonikerReadBinaryU16Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -468,22 +538,47 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
+    int32 samps_per_chan_read = {};        
     std::vector<uInt16> read_array(array_size_in_samps);
     auto status = library->ReadBinaryU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
-      std::transform(
-        read_array.begin(),
-        read_array.begin() + array_size_in_samps,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+        response->mutable_read_array()->Clear();
+        response->mutable_read_array()->Reserve(array_size_in_samps);
+        std::transform(
+          read_array.begin(),
+          read_array.begin() + array_size_in_samps,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+        response->mutable_read_array()->Clear();
+        response->mutable_read_array()->Reserve(array_size_in_samps);
+        std::transform(
+          read_array.begin(),
+          read_array.begin() + array_size_in_samps,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadBinaryU16 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -492,6 +587,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadBinaryU32Data* function_data = static_cast<MonikerReadBinaryU32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -499,16 +595,30 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
-    function_data->data.mutable_value()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<uInt32*>(function_data->data.mutable_value()->mutable_data());
+    int32 samps_per_chan_read = {};        
+    response->mutable_read_array()->Resize(array_size_in_samps, 0);
+    auto read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
     auto status = library->ReadBinaryU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadBinaryU32 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -517,22 +627,37 @@ namespace nidaqmx_grpc {
 {
     MonikerReadCounterF64Data* function_data = static_cast<MonikerReadCounterF64Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
-    function_data->data.mutable_value()->Resize(array_size_in_samps, 0);
-    auto read_array = function_data->data.mutable_value()->mutable_data();
+    int32 samps_per_chan_read = {};        
+    response->mutable_read_array()->Resize(array_size_in_samps, 0);
+    auto read_array = response->mutable_read_array()->mutable_data();
     auto status = library->ReadCounterF64(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadCounterF64 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -541,6 +666,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadCounterF64ExData* function_data = static_cast<MonikerReadCounterF64ExData*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -548,16 +674,30 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
-    function_data->data.mutable_value()->Resize(array_size_in_samps, 0);
-    auto read_array = function_data->data.mutable_value()->mutable_data();
+    int32 samps_per_chan_read = {};        
+    response->mutable_read_array()->Resize(array_size_in_samps, 0);
+    auto read_array = response->mutable_read_array()->mutable_data();
     auto status = library->ReadCounterF64Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadCounterF64Ex error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -566,19 +706,32 @@ namespace nidaqmx_grpc {
 {
     MonikerReadCounterScalarF64Data* function_data = static_cast<MonikerReadCounterScalarF64Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-
-    float64 value {};
+        
+float64 value {};
     auto status = library->ReadCounterScalarF64(task, timeout, &value, reserved);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
 
-    if (status < 0) {
-      std::cout << "MonikerReadCounterScalarF64 error: " << status << std::endl;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -587,19 +740,32 @@ namespace nidaqmx_grpc {
 {
     MonikerReadCounterScalarU32Data* function_data = static_cast<MonikerReadCounterScalarU32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-
-    uInt32 value {};
+        
+uInt32 value {};
     auto status = library->ReadCounterScalarU32(task, timeout, &value, reserved);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
 
-    if (status < 0) {
-      std::cout << "MonikerReadCounterScalarU32 error: " << status << std::endl;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -608,22 +774,37 @@ namespace nidaqmx_grpc {
 {
     MonikerReadCounterU32Data* function_data = static_cast<MonikerReadCounterU32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
-    function_data->data.mutable_value()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<uInt32*>(function_data->data.mutable_value()->mutable_data());
+    int32 samps_per_chan_read = {};        
+    response->mutable_read_array()->Resize(array_size_in_samps, 0);
+    auto read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
     auto status = library->ReadCounterU32(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadCounterU32 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -632,6 +813,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadCounterU32ExData* function_data = static_cast<MonikerReadCounterU32ExData*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -639,16 +821,30 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
-    function_data->data.mutable_value()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<uInt32*>(function_data->data.mutable_value()->mutable_data());
+    int32 samps_per_chan_read = {};        
+    response->mutable_read_array()->Resize(array_size_in_samps, 0);
+    auto read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
     auto status = library->ReadCounterU32Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadCounterU32Ex error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -657,19 +853,32 @@ namespace nidaqmx_grpc {
 {
     MonikerReadDigitalScalarU32Data* function_data = static_cast<MonikerReadDigitalScalarU32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-
-    uInt32 value {};
+        
+uInt32 value {};
     auto status = library->ReadDigitalScalarU32(task, timeout, &value, reserved);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
 
-    if (status < 0) {
-      std::cout << "MonikerReadDigitalScalarU32 error: " << status << std::endl;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -678,6 +887,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadDigitalU16Data* function_data = static_cast<MonikerReadDigitalU16Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -685,22 +895,47 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
+    int32 samps_per_chan_read = {};        
     std::vector<uInt16> read_array(array_size_in_samps);
     auto status = library->ReadDigitalU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
-      std::transform(
-        read_array.begin(),
-        read_array.begin() + array_size_in_samps,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-           return x;
-      });
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+        response->mutable_read_array()->Clear();
+        response->mutable_read_array()->Reserve(array_size_in_samps);
+        std::transform(
+          read_array.begin(),
+          read_array.begin() + array_size_in_samps,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+        response->mutable_read_array()->Clear();
+        response->mutable_read_array()->Reserve(array_size_in_samps);
+        std::transform(
+          read_array.begin(),
+          read_array.begin() + array_size_in_samps,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadDigitalU16 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -709,6 +944,7 @@ namespace nidaqmx_grpc {
 {
     MonikerReadDigitalU32Data* function_data = static_cast<MonikerReadDigitalU32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
@@ -716,16 +952,30 @@ namespace nidaqmx_grpc {
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_read = {};
-    function_data->data.mutable_value()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<uInt32*>(function_data->data.mutable_value()->mutable_data());
+    int32 samps_per_chan_read = {};        
+    response->mutable_read_array()->Resize(array_size_in_samps, 0);
+    auto read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
     auto status = library->ReadDigitalU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
-    if (status >= 0) {
+
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_samps_per_chan_read(samps_per_chan_read);
       packedData.PackFrom(function_data->data);
     }
-
-    if (status < 0) {
-      std::cout << "MonikerReadDigitalU32 error: " << status << std::endl;
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -734,18 +984,31 @@ namespace nidaqmx_grpc {
 {
     MonikerWaitForNextSampleClockData* function_data = static_cast<MonikerWaitForNextSampleClockData*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto timeout = function_data->timeout;
-
-    bool32 is_late {};
+        
+bool32 is_late {};
     auto status = library->WaitForNextSampleClock(task, timeout, &is_late);
-    function_data->data.set_value(is_late);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
 
-    if (status < 0) {
-      std::cout << "MonikerWaitForNextSampleClock error: " << status << std::endl;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_is_late(is_late);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_is_late(is_late);
+      packedData.PackFrom(function_data->data);
+    }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -754,6 +1017,7 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteAnalogF64Data* function_data = static_cast<MonikerWriteAnalogF64Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
@@ -761,7 +1025,7 @@ namespace nidaqmx_grpc {
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_written = {};
+    int32 samps_per_chan_written = {};        
     ArrayDoubleData arraydoubledata_message;
     packedData.UnpackTo(&arraydoubledata_message);
     
@@ -770,9 +1034,15 @@ namespace nidaqmx_grpc {
     auto size = data_array.size();
 
     auto status = library->WriteAnalogF64(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteAnalogF64 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_written(samps_per_chan_written);
+    */
     return ::grpc::Status::OK;
 }
 
@@ -780,19 +1050,24 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteAnalogScalarF64Data* function_data = static_cast<MonikerWriteAnalogScalarF64Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-
+        
     DoubleData doubledata_message;
     packedData.UnpackTo(&doubledata_message);
     auto value = doubledata_message.value();
 
     auto status = library->WriteAnalogScalarF64(task, auto_start, timeout, value, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteAnalogScalarF64 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+    */
     return ::grpc::Status::OK;
 }
 
@@ -800,6 +1075,7 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteBinaryI16Data* function_data = static_cast<MonikerWriteBinaryI16Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
@@ -807,7 +1083,7 @@ namespace nidaqmx_grpc {
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_written = {};
+    int32 samps_per_chan_written = {};        
     ArrayI16Data arrayi16data_message;
     packedData.UnpackTo(&arrayi16data_message);
     
@@ -828,9 +1104,15 @@ namespace nidaqmx_grpc {
       });
 
     auto status = library->WriteBinaryI16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteBinaryI16 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_written(samps_per_chan_written);
+    */
     return ::grpc::Status::OK;
 }
 
@@ -838,6 +1120,7 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteBinaryI32Data* function_data = static_cast<MonikerWriteBinaryI32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
@@ -845,7 +1128,7 @@ namespace nidaqmx_grpc {
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_written = {};
+    int32 samps_per_chan_written = {};        
     ArrayI32Data arrayi32data_message;
     packedData.UnpackTo(&arrayi32data_message);
     
@@ -854,9 +1137,15 @@ namespace nidaqmx_grpc {
     auto size = data_array.size();
 
     auto status = library->WriteBinaryI32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteBinaryI32 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_written(samps_per_chan_written);
+    */
     return ::grpc::Status::OK;
 }
 
@@ -864,6 +1153,7 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteBinaryU16Data* function_data = static_cast<MonikerWriteBinaryU16Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
@@ -871,7 +1161,7 @@ namespace nidaqmx_grpc {
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_written = {};
+    int32 samps_per_chan_written = {};        
     ArrayU16Data arrayu16data_message;
     packedData.UnpackTo(&arrayu16data_message);
     
@@ -892,9 +1182,15 @@ namespace nidaqmx_grpc {
       });
 
     auto status = library->WriteBinaryU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteBinaryU16 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_written(samps_per_chan_written);
+    */
     return ::grpc::Status::OK;
 }
 
@@ -902,6 +1198,7 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteBinaryU32Data* function_data = static_cast<MonikerWriteBinaryU32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
@@ -909,7 +1206,7 @@ namespace nidaqmx_grpc {
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_written = {};
+    int32 samps_per_chan_written = {};        
     ArrayU32Data arrayu32data_message;
     packedData.UnpackTo(&arrayu32data_message);
     
@@ -918,9 +1215,15 @@ namespace nidaqmx_grpc {
     auto size = data_array.size();
 
     auto status = library->WriteBinaryU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteBinaryU32 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_written(samps_per_chan_written);
+    */
     return ::grpc::Status::OK;
 }
 
@@ -928,19 +1231,24 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteDigitalScalarU32Data* function_data = static_cast<MonikerWriteDigitalScalarU32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-
+        
     U32Data u32data_message;
     packedData.UnpackTo(&u32data_message);
     auto value = u32data_message.value();
 
     auto status = library->WriteDigitalScalarU32(task, auto_start, timeout, value, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteDigitalScalarU32 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+    */
     return ::grpc::Status::OK;
 }
 
@@ -948,6 +1256,7 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteDigitalU16Data* function_data = static_cast<MonikerWriteDigitalU16Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
@@ -955,7 +1264,7 @@ namespace nidaqmx_grpc {
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_written = {};
+    int32 samps_per_chan_written = {};        
     ArrayU16Data arrayu16data_message;
     packedData.UnpackTo(&arrayu16data_message);
     
@@ -976,9 +1285,15 @@ namespace nidaqmx_grpc {
       });
 
     auto status = library->WriteDigitalU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteDigitalU16 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_written(samps_per_chan_written);
+    */
     return ::grpc::Status::OK;
 }
 
@@ -986,6 +1301,7 @@ namespace nidaqmx_grpc {
 {
     MonikerWriteDigitalU32Data* function_data = static_cast<MonikerWriteDigitalU32Data*>(data);
     auto library = function_data->library;
+    auto response = function_data->data.mutable_response();
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
@@ -993,7 +1309,7 @@ namespace nidaqmx_grpc {
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
 
-    int32 samps_per_chan_written = {};
+    int32 samps_per_chan_written = {};        
     ArrayU32Data arrayu32data_message;
     packedData.UnpackTo(&arrayu32data_message);
     
@@ -1002,11 +1318,18 @@ namespace nidaqmx_grpc {
     auto size = data_array.size();
 
     auto status = library->WriteDigitalU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
-    if (status < 0) {
-      std::cout << "MonikerWriteDigitalU32 error: " << status << std::endl;
-    }
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      response->set_samps_per_chan_written(samps_per_chan_written);
+    */
     return ::grpc::Status::OK;
 }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::AddCDAQSyncConnection(::grpc::ServerContext* context, const AddCDAQSyncConnectionRequest* request, AddCDAQSyncConnectionResponse* response)
@@ -14198,8 +14521,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadAnalogF64Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadAnalogF64Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -14207,8 +14530,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadAnalogF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14259,8 +14582,8 @@ namespace nidaqmx_grpc {
       float64 timeout = request->timeout();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadAnalogScalarF64Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadAnalogScalarF64Data>();
+            data->task = task;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
@@ -14362,8 +14685,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadBinaryI16Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadBinaryI16Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -14371,8 +14694,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14462,8 +14785,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadBinaryI32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadBinaryI32Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -14471,8 +14794,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14570,8 +14893,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadBinaryU16Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadBinaryU16Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -14579,8 +14902,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14670,8 +14993,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadBinaryU32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadBinaryU32Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -14679,8 +15002,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14738,16 +15061,16 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadCounterF64Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadCounterF64Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14837,8 +15160,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadCounterF64ExData>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadCounterF64ExData>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -14846,8 +15169,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterF64Ex", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14898,8 +15221,8 @@ namespace nidaqmx_grpc {
       float64 timeout = request->timeout();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadCounterScalarF64Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadCounterScalarF64Data>();
+            data->task = task;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
@@ -14954,8 +15277,8 @@ namespace nidaqmx_grpc {
       float64 timeout = request->timeout();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadCounterScalarU32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadCounterScalarU32Data>();
+            data->task = task;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
@@ -15017,16 +15340,16 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadCounterU32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadCounterU32Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15116,8 +15439,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadCounterU32ExData>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadCounterU32ExData>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -15125,8 +15448,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterU32Ex", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15457,8 +15780,8 @@ namespace nidaqmx_grpc {
       float64 timeout = request->timeout();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadDigitalScalarU32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadDigitalScalarU32Data>();
+            data->task = task;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
@@ -15560,8 +15883,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadDigitalU16Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadDigitalU16Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -15569,8 +15892,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDigitalU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15660,8 +15983,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerReadDigitalU32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerReadDigitalU32Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
@@ -15669,8 +15992,8 @@ namespace nidaqmx_grpc {
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
-      data->data.mutable_value()->Reserve(request->array_size_in_samps());
-      data->data.mutable_value()->Resize(request->array_size_in_samps(), 0);
+      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDigitalU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -20197,8 +20520,8 @@ namespace nidaqmx_grpc {
       TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
 
-      auto data = std::make_unique<MonikerWaitForNextSampleClockData>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWaitForNextSampleClockData>();
+            data->task = task;
       data->timeout = timeout;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
       
@@ -20354,8 +20677,8 @@ namespace nidaqmx_grpc {
 
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteAnalogF64Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteAnalogF64Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
@@ -20414,8 +20737,8 @@ namespace nidaqmx_grpc {
       float64 timeout = request->timeout();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteAnalogScalarF64Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteAnalogScalarF64Data>();
+            data->task = task;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->reserved = reserved;
@@ -20526,8 +20849,8 @@ namespace nidaqmx_grpc {
 
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteBinaryI16Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteBinaryI16Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
@@ -20623,8 +20946,8 @@ namespace nidaqmx_grpc {
 
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteBinaryI32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteBinaryI32Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
@@ -20737,8 +21060,8 @@ namespace nidaqmx_grpc {
 
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteBinaryU16Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteBinaryU16Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
@@ -20834,8 +21157,8 @@ namespace nidaqmx_grpc {
 
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteBinaryU32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteBinaryU32Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
@@ -21162,8 +21485,8 @@ namespace nidaqmx_grpc {
       float64 timeout = request->timeout();
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteDigitalScalarU32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteDigitalScalarU32Data>();
+            data->task = task;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->reserved = reserved;
@@ -21274,8 +21597,8 @@ namespace nidaqmx_grpc {
 
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteDigitalU16Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteDigitalU16Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
@@ -21371,8 +21694,8 @@ namespace nidaqmx_grpc {
 
       auto reserved = nullptr;
 
-      auto data = std::make_unique<MonikerWriteDigitalU32Data>();      
-      data->task = task;
+      auto data = std::make_unique<MonikerWriteDigitalU32Data>();
+            data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -862,6 +862,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteAnalogF64(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -881,6 +885,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteAnalogScalarF64(task, auto_start, timeout, value, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -918,6 +926,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteBinaryI16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -943,6 +955,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteBinaryI32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -980,6 +996,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteBinaryU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1005,6 +1025,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteBinaryU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1024,6 +1048,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteDigitalScalarU32(task, auto_start, timeout, value, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1061,6 +1089,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteDigitalU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1086,6 +1118,10 @@ namespace nidaqmx_grpc {
 
     auto status = library->WriteDigitalU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -389,8 +389,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -415,8 +414,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -454,8 +452,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -485,8 +482,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -524,8 +520,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -555,8 +550,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -585,8 +579,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -616,8 +609,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -642,8 +634,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -668,8 +659,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -698,8 +688,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -729,8 +718,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -755,8 +743,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -794,8 +781,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -825,8 +811,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -850,8 +835,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -870,7 +854,7 @@ namespace nidaqmx_grpc {
     int32 samps_per_chan_written {};
 
     ArrayDoubleData arraydoubledata_message;
-    packedData.UnpackTo(&arraydoubledata_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arraydoubledata_message);
     
     auto data_array = arraydoubledata_message.value();
     auto write_array = const_cast<const float64*>(arraydoubledata_message.value().data());
@@ -892,7 +876,7 @@ namespace nidaqmx_grpc {
     auto reserved = function_data->reserved;
 
     DoubleData doubledata_message;
-    packedData.UnpackTo(&doubledata_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&doubledata_message);
     auto value = doubledata_message.value();
 
     auto status = library->WriteAnalogScalarF64(task, auto_start, timeout, value, reserved);
@@ -914,7 +898,7 @@ namespace nidaqmx_grpc {
     int32 samps_per_chan_written {};
 
     ArrayI16Data arrayi16data_message;
-    packedData.UnpackTo(&arrayi16data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayi16data_message);
     
     auto data_array = arrayi16data_message.value();
     auto write_array = std::vector<int16>();
@@ -951,7 +935,7 @@ namespace nidaqmx_grpc {
     int32 samps_per_chan_written {};
 
     ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayi32data_message);
     
     auto data_array = arrayi32data_message.value();
     auto write_array = reinterpret_cast<const int32*>(arrayi32data_message.value().data());
@@ -976,7 +960,7 @@ namespace nidaqmx_grpc {
     int32 samps_per_chan_written {};
 
     ArrayU16Data arrayu16data_message;
-    packedData.UnpackTo(&arrayu16data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayu16data_message);
     
     auto data_array = arrayu16data_message.value();
     auto write_array = std::vector<uInt16>();
@@ -1013,7 +997,7 @@ namespace nidaqmx_grpc {
     int32 samps_per_chan_written {};
 
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayu32data_message);
     
     auto data_array = arrayu32data_message.value();
     auto write_array = reinterpret_cast<const uInt32*>(arrayu32data_message.value().data());
@@ -1035,7 +1019,7 @@ namespace nidaqmx_grpc {
     auto reserved = function_data->reserved;
 
     U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&u32data_message);
     auto value = u32data_message.value();
 
     auto status = library->WriteDigitalScalarU32(task, auto_start, timeout, value, reserved);
@@ -1057,7 +1041,7 @@ namespace nidaqmx_grpc {
     int32 samps_per_chan_written {};
 
     ArrayU16Data arrayu16data_message;
-    packedData.UnpackTo(&arrayu16data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayu16data_message);
     
     auto data_array = arrayu16data_message.value();
     auto write_array = std::vector<uInt16>();
@@ -1094,7 +1078,7 @@ namespace nidaqmx_grpc {
     int32 samps_per_chan_written {};
 
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayu32data_message);
     
     auto data_array = arrayu32data_message.value();
     auto write_array = reinterpret_cast<const uInt32*>(arrayu32data_message.value().data());

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -381,15 +381,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadAnalogF64(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -398,7 +389,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -416,14 +407,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadAnalogScalarF64(task, timeout, &value, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -432,7 +415,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -454,24 +437,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadBinaryI16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-        response->mutable_read_array()->Clear();
-        response->mutable_read_array()->Reserve(array_size_in_samps);
-        std::transform(
-          read_array.begin(),
-          read_array.begin() + array_size_in_samps,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
-          [&](auto x) {
-              return x;
-          });
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -489,7 +454,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -512,15 +477,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadBinaryI32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -529,7 +485,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -551,24 +507,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadBinaryU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-        response->mutable_read_array()->Clear();
-        response->mutable_read_array()->Reserve(array_size_in_samps);
-        std::transform(
-          read_array.begin(),
-          read_array.begin() + array_size_in_samps,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
-          [&](auto x) {
-              return x;
-          });
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -586,7 +524,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -609,15 +547,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadBinaryU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -626,7 +555,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -648,15 +577,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadCounterF64(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -665,7 +585,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -688,15 +608,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadCounterF64Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -705,7 +616,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -723,14 +634,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadCounterScalarF64(task, timeout, &value, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -739,7 +642,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -757,14 +660,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadCounterScalarU32(task, timeout, &value, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -773,7 +668,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -795,15 +690,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadCounterU32(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -812,7 +698,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -835,15 +721,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadCounterU32Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -852,7 +729,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -870,14 +747,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadDigitalScalarU32(task, timeout, &value, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -886,7 +755,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -908,24 +777,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadDigitalU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-        response->mutable_read_array()->Clear();
-        response->mutable_read_array()->Reserve(array_size_in_samps);
-        std::transform(
-          read_array.begin(),
-          read_array.begin() + array_size_in_samps,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
-          [&](auto x) {
-              return x;
-          });
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -943,7 +794,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -966,15 +817,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->ReadDigitalU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-read", std::to_string(samps_per_chan_read));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_read(samps_per_chan_read);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -983,7 +825,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1000,14 +842,6 @@ namespace nidaqmx_grpc {
 
     auto status = library->WaitForNextSampleClock(task, timeout, &is_late);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_is_late(is_late);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1016,7 +850,7 @@ namespace nidaqmx_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -368,17 +368,17 @@ namespace nidaqmx_grpc {
 {
     MonikerReadAnalogF64Data* function_data = static_cast<MonikerReadAnalogF64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     response->mutable_read_array()->Resize(array_size_in_samps, 0);
-    auto read_array = response->mutable_read_array()->mutable_data();
+    float64* read_array = response->mutable_read_array()->mutable_data();
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadAnalogF64(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -394,7 +394,7 @@ namespace nidaqmx_grpc {
     {
       response->set_status(status);
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -408,12 +408,12 @@ namespace nidaqmx_grpc {
 {
     MonikerReadAnalogScalarF64Data* function_data = static_cast<MonikerReadAnalogScalarF64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-        
-float64 value {};
+    float64 value {};
+
     auto status = library->ReadAnalogScalarF64(task, timeout, &value, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -428,7 +428,7 @@ float64 value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -442,16 +442,16 @@ float64 value {};
 {
     MonikerReadBinaryI16Data* function_data = static_cast<MonikerReadBinaryI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     std::vector<int16> read_array(array_size_in_samps);
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadBinaryI16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -485,7 +485,7 @@ float64 value {};
               return x;
           });
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -499,17 +499,17 @@ float64 value {};
 {
     MonikerReadBinaryI32Data* function_data = static_cast<MonikerReadBinaryI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     response->mutable_read_array()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<int32*>(response->mutable_read_array()->mutable_data());
+    int32* read_array = reinterpret_cast<int32*>(response->mutable_read_array()->mutable_data());
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadBinaryI32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -525,7 +525,7 @@ float64 value {};
     {
       response->set_status(status);
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -539,16 +539,16 @@ float64 value {};
 {
     MonikerReadBinaryU16Data* function_data = static_cast<MonikerReadBinaryU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     std::vector<uInt16> read_array(array_size_in_samps);
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadBinaryU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -582,7 +582,7 @@ float64 value {};
               return x;
           });
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -596,17 +596,17 @@ float64 value {};
 {
     MonikerReadBinaryU32Data* function_data = static_cast<MonikerReadBinaryU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     response->mutable_read_array()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
+    uInt32* read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadBinaryU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -622,7 +622,7 @@ float64 value {};
     {
       response->set_status(status);
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -636,16 +636,16 @@ float64 value {};
 {
     MonikerReadCounterF64Data* function_data = static_cast<MonikerReadCounterF64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     response->mutable_read_array()->Resize(array_size_in_samps, 0);
-    auto read_array = response->mutable_read_array()->mutable_data();
+    float64* read_array = response->mutable_read_array()->mutable_data();
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadCounterF64(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -661,7 +661,7 @@ float64 value {};
     {
       response->set_status(status);
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -675,17 +675,17 @@ float64 value {};
 {
     MonikerReadCounterF64ExData* function_data = static_cast<MonikerReadCounterF64ExData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     response->mutable_read_array()->Resize(array_size_in_samps, 0);
-    auto read_array = response->mutable_read_array()->mutable_data();
+    float64* read_array = response->mutable_read_array()->mutable_data();
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadCounterF64Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -701,7 +701,7 @@ float64 value {};
     {
       response->set_status(status);
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -715,12 +715,12 @@ float64 value {};
 {
     MonikerReadCounterScalarF64Data* function_data = static_cast<MonikerReadCounterScalarF64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-        
-float64 value {};
+    float64 value {};
+
     auto status = library->ReadCounterScalarF64(task, timeout, &value, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -735,7 +735,7 @@ float64 value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -749,12 +749,12 @@ float64 value {};
 {
     MonikerReadCounterScalarU32Data* function_data = static_cast<MonikerReadCounterScalarU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-        
-uInt32 value {};
+    uInt32 value {};
+
     auto status = library->ReadCounterScalarU32(task, timeout, &value, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -769,7 +769,7 @@ uInt32 value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -783,16 +783,16 @@ uInt32 value {};
 {
     MonikerReadCounterU32Data* function_data = static_cast<MonikerReadCounterU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     response->mutable_read_array()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
+    uInt32* read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadCounterU32(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -808,7 +808,7 @@ uInt32 value {};
     {
       response->set_status(status);
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -822,17 +822,17 @@ uInt32 value {};
 {
     MonikerReadCounterU32ExData* function_data = static_cast<MonikerReadCounterU32ExData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     response->mutable_read_array()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
+    uInt32* read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadCounterU32Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -848,7 +848,7 @@ uInt32 value {};
     {
       response->set_status(status);
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -862,12 +862,12 @@ uInt32 value {};
 {
     MonikerReadDigitalScalarU32Data* function_data = static_cast<MonikerReadDigitalScalarU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-        
-uInt32 value {};
+    uInt32 value {};
+
     auto status = library->ReadDigitalScalarU32(task, timeout, &value, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -882,7 +882,7 @@ uInt32 value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -896,16 +896,16 @@ uInt32 value {};
 {
     MonikerReadDigitalU16Data* function_data = static_cast<MonikerReadDigitalU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     std::vector<uInt16> read_array(array_size_in_samps);
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadDigitalU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -939,7 +939,7 @@ uInt32 value {};
               return x;
           });
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -953,17 +953,17 @@ uInt32 value {};
 {
     MonikerReadDigitalU32Data* function_data = static_cast<MonikerReadDigitalU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto timeout = function_data->timeout;
     auto fill_mode = function_data->fill_mode;
     auto array_size_in_samps = function_data->array_size_in_samps;
     auto reserved = function_data->reserved;
-
-    int32 samps_per_chan_read = {};        
     response->mutable_read_array()->Resize(array_size_in_samps, 0);
-    auto read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
+    uInt32* read_array = reinterpret_cast<uInt32*>(response->mutable_read_array()->mutable_data());
+    int32 samps_per_chan_read {};
+
     auto status = library->ReadDigitalU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -979,7 +979,7 @@ uInt32 value {};
     {
       response->set_status(status);
       response->set_samps_per_chan_read(samps_per_chan_read);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -993,11 +993,11 @@ uInt32 value {};
 {
     MonikerWaitForNextSampleClockData* function_data = static_cast<MonikerWaitForNextSampleClockData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto timeout = function_data->timeout;
-        
-bool32 is_late {};
+    bool32 is_late {};
+
     auto status = library->WaitForNextSampleClock(task, timeout, &is_late);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1012,7 +1012,7 @@ bool32 is_late {};
     {
       response->set_status(status);
       response->set_is_late(is_late);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1026,32 +1026,24 @@ bool32 is_late {};
 {
     MonikerWriteAnalogF64Data* function_data = static_cast<MonikerWriteAnalogF64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
+    int32 samps_per_chan_written {};
 
-    int32 samps_per_chan_written = {};        
     ArrayDoubleData arraydoubledata_message;
-    packedData.UnpackTo(&arraydoubledata_message);
+    packedData.UnpackTo(&arraydoubledata_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arraydoubledata_message.value();
     auto write_array = const_cast<const float64*>(arraydoubledata_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteAnalogF64(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_written(samps_per_chan_written);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1059,24 +1051,18 @@ bool32 is_late {};
 {
     MonikerWriteAnalogScalarF64Data* function_data = static_cast<MonikerWriteAnalogScalarF64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-        
+
     DoubleData doubledata_message;
-    packedData.UnpackTo(&doubledata_message);
+    packedData.UnpackTo(&doubledata_message); // TODO: should unpack to function_data->mutable_request()
     auto value = doubledata_message.value();
 
     auto status = library->WriteAnalogScalarF64(task, auto_start, timeout, value, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1084,17 +1070,17 @@ bool32 is_late {};
 {
     MonikerWriteBinaryI16Data* function_data = static_cast<MonikerWriteBinaryI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
+    int32 samps_per_chan_written {};
 
-    int32 samps_per_chan_written = {};        
     ArrayI16Data arrayi16data_message;
-    packedData.UnpackTo(&arrayi16data_message);
+    packedData.UnpackTo(&arrayi16data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayi16data_message.value();
     auto write_array = std::vector<int16>();
@@ -1113,15 +1099,7 @@ bool32 is_late {};
       });
 
     auto status = library->WriteBinaryI16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_written(samps_per_chan_written);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1129,32 +1107,24 @@ bool32 is_late {};
 {
     MonikerWriteBinaryI32Data* function_data = static_cast<MonikerWriteBinaryI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
+    int32 samps_per_chan_written {};
 
-    int32 samps_per_chan_written = {};        
     ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message);
+    packedData.UnpackTo(&arrayi32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayi32data_message.value();
     auto write_array = reinterpret_cast<const int32*>(arrayi32data_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteBinaryI32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_written(samps_per_chan_written);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1162,17 +1132,17 @@ bool32 is_late {};
 {
     MonikerWriteBinaryU16Data* function_data = static_cast<MonikerWriteBinaryU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
+    int32 samps_per_chan_written {};
 
-    int32 samps_per_chan_written = {};        
     ArrayU16Data arrayu16data_message;
-    packedData.UnpackTo(&arrayu16data_message);
+    packedData.UnpackTo(&arrayu16data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayu16data_message.value();
     auto write_array = std::vector<uInt16>();
@@ -1191,15 +1161,7 @@ bool32 is_late {};
       });
 
     auto status = library->WriteBinaryU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_written(samps_per_chan_written);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1207,32 +1169,24 @@ bool32 is_late {};
 {
     MonikerWriteBinaryU32Data* function_data = static_cast<MonikerWriteBinaryU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
+    int32 samps_per_chan_written {};
 
-    int32 samps_per_chan_written = {};        
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message);
+    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayu32data_message.value();
     auto write_array = reinterpret_cast<const uInt32*>(arrayu32data_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteBinaryU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_written(samps_per_chan_written);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1240,24 +1194,18 @@ bool32 is_late {};
 {
     MonikerWriteDigitalScalarU32Data* function_data = static_cast<MonikerWriteDigitalScalarU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto reserved = function_data->reserved;
-        
+
     U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message);
+    packedData.UnpackTo(&u32data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = u32data_message.value();
 
     auto status = library->WriteDigitalScalarU32(task, auto_start, timeout, value, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1265,17 +1213,17 @@ bool32 is_late {};
 {
     MonikerWriteDigitalU16Data* function_data = static_cast<MonikerWriteDigitalU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
+    int32 samps_per_chan_written {};
 
-    int32 samps_per_chan_written = {};        
     ArrayU16Data arrayu16data_message;
-    packedData.UnpackTo(&arrayu16data_message);
+    packedData.UnpackTo(&arrayu16data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayu16data_message.value();
     auto write_array = std::vector<uInt16>();
@@ -1294,15 +1242,7 @@ bool32 is_late {};
       });
 
     auto status = library->WriteDigitalU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_written(samps_per_chan_written);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1310,32 +1250,24 @@ bool32 is_late {};
 {
     MonikerWriteDigitalU32Data* function_data = static_cast<MonikerWriteDigitalU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto task = function_data->task;
     auto num_samps_per_chan = function_data->num_samps_per_chan;
     auto auto_start = function_data->auto_start;
     auto timeout = function_data->timeout;
     auto data_layout = function_data->data_layout;
     auto reserved = function_data->reserved;
+    int32 samps_per_chan_written {};
 
-    int32 samps_per_chan_written = {};        
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message);
+    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayu32data_message.value();
     auto write_array = reinterpret_cast<const uInt32*>(arrayu32data_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteDigitalU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      context->AddTrailingMetadata("ni-samps-per-chan-written", std::to_string(samps_per_chan_written));
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForTaskHandle(context, status, task);
-      }
-      response->set_status(status);
-      response->set_samps_per_chan_written(samps_per_chan_written);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -14531,16 +14463,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadAnalogF64Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadAnalogF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14592,11 +14524,11 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadAnalogScalarF64Data>();
-            data->task = task;
+      data->task = task;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadAnalogScalarF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14695,16 +14627,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadBinaryI16Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14795,16 +14727,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadBinaryI32Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -14903,16 +14835,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadBinaryU16Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15003,16 +14935,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadBinaryU32Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBinaryU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15071,15 +15003,15 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadCounterF64Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15170,16 +15102,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadCounterF64ExData>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterF64Ex", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15231,11 +15163,11 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadCounterScalarF64Data>();
-            data->task = task;
+      data->task = task;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterScalarF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15287,11 +15219,11 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadCounterScalarU32Data>();
-            data->task = task;
+      data->task = task;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterScalarU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15350,15 +15282,15 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadCounterU32Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15449,16 +15381,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadCounterU32ExData>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadCounterU32Ex", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15790,11 +15722,11 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadDigitalScalarU32Data>();
-            data->task = task;
+      data->task = task;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDigitalScalarU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15893,16 +15825,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadDigitalU16Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDigitalU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -15993,16 +15925,16 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerReadDigitalU32Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->timeout = timeout;
       data->fill_mode = fill_mode;
       data->array_size_in_samps = array_size_in_samps;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
-      data->data.mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
+
+      data->mutable_response()->mutable_read_array()->Reserve(request->array_size_in_samps());
+      data->mutable_response()->mutable_read_array()->Resize(request->array_size_in_samps(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDigitalU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -20530,10 +20462,10 @@ bool32 is_late {};
       float64 timeout = request->timeout();
 
       auto data = std::make_unique<MonikerWaitForNextSampleClockData>();
-            data->task = task;
+      data->task = task;
       data->timeout = timeout;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWaitForNextSampleClock", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -20687,14 +20619,14 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteAnalogF64Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->data_layout = data_layout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteAnalogF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -20747,12 +20679,12 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteAnalogScalarF64Data>();
-            data->task = task;
+      data->task = task;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteAnalogScalarF64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -20859,14 +20791,14 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteBinaryI16Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->data_layout = data_layout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBinaryI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -20956,14 +20888,14 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteBinaryI32Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->data_layout = data_layout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBinaryI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -21070,14 +21002,14 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteBinaryU16Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->data_layout = data_layout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBinaryU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -21167,14 +21099,14 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteBinaryU32Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->data_layout = data_layout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBinaryU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -21495,12 +21427,12 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteDigitalScalarU32Data>();
-            data->task = task;
+      data->task = task;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDigitalScalarU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -21607,14 +21539,14 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteDigitalU16Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->data_layout = data_layout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDigitalU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -21704,14 +21636,14 @@ bool32 is_late {};
       auto reserved = nullptr;
 
       auto data = std::make_unique<MonikerWriteDigitalU32Data>();
-            data->task = task;
+      data->task = task;
       data->num_samps_per_chan = num_samps_per_chan;
       data->auto_start = auto_start;
       data->timeout = timeout;
       data->data_layout = data_layout;
       data->reserved = reserved;
       data->library = std::shared_ptr<NiDAQmxLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDigitalU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -33,7 +33,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadAnalogF64StreamingData data;
+     nidaqmx_grpc::ReadAnalogF64StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -42,7 +42,7 @@ namespace nidaqmx_grpc {
      TaskHandle task;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::ReadAnalogScalarF64StreamingData data;
+     nidaqmx_grpc::ReadAnalogScalarF64StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -54,7 +54,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadBinaryI16StreamingData data;
+     nidaqmx_grpc::ReadBinaryI16StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -66,7 +66,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadBinaryI32StreamingData data;
+     nidaqmx_grpc::ReadBinaryI32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -78,7 +78,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadBinaryU16StreamingData data;
+     nidaqmx_grpc::ReadBinaryU16StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -90,7 +90,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadBinaryU32StreamingData data;
+     nidaqmx_grpc::ReadBinaryU32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -101,7 +101,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadCounterF64StreamingData data;
+     nidaqmx_grpc::ReadCounterF64StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -113,7 +113,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadCounterF64ExStreamingData data;
+     nidaqmx_grpc::ReadCounterF64ExStreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -122,7 +122,7 @@ namespace nidaqmx_grpc {
      TaskHandle task;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::ReadCounterScalarF64StreamingData data;
+     nidaqmx_grpc::ReadCounterScalarF64StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -131,7 +131,7 @@ namespace nidaqmx_grpc {
      TaskHandle task;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::ReadCounterScalarU32StreamingData data;
+     nidaqmx_grpc::ReadCounterScalarU32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -142,7 +142,7 @@ namespace nidaqmx_grpc {
      float64 timeout;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadCounterU32StreamingData data;
+     nidaqmx_grpc::ReadCounterU32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -154,7 +154,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadCounterU32ExStreamingData data;
+     nidaqmx_grpc::ReadCounterU32ExStreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -163,7 +163,7 @@ namespace nidaqmx_grpc {
      TaskHandle task;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::ReadDigitalScalarU32StreamingData data;
+     nidaqmx_grpc::ReadDigitalScalarU32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -175,7 +175,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadDigitalU16StreamingData data;
+     nidaqmx_grpc::ReadDigitalU16StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -187,7 +187,7 @@ namespace nidaqmx_grpc {
      int32 fill_mode;
      uInt32 array_size_in_samps;
      bool32* reserved;
-     nidaqmx_grpc::ReadDigitalU32StreamingData data;
+     nidaqmx_grpc::ReadDigitalU32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -195,7 +195,7 @@ namespace nidaqmx_grpc {
   {
      TaskHandle task;
      float64 timeout;
-     nidaqmx_grpc::WaitForNextSampleClockStreamingData data;
+     nidaqmx_grpc::WaitForNextSampleClockStreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -207,7 +207,8 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::WriteAnalogF64StreamingData data;
+     nidaqmx_grpc::WriteAnalogF64StreamingRequest request;
+     nidaqmx_grpc::WriteAnalogF64StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -217,7 +218,8 @@ namespace nidaqmx_grpc {
      bool32 auto_start;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::WriteAnalogScalarF64StreamingData data;
+     nidaqmx_grpc::WriteAnalogScalarF64StreamingRequest request;
+     nidaqmx_grpc::WriteAnalogScalarF64StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -229,7 +231,8 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::WriteBinaryI16StreamingData data;
+     nidaqmx_grpc::WriteBinaryI16StreamingRequest request;
+     nidaqmx_grpc::WriteBinaryI16StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -241,7 +244,8 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::WriteBinaryI32StreamingData data;
+     nidaqmx_grpc::WriteBinaryI32StreamingRequest request;
+     nidaqmx_grpc::WriteBinaryI32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -253,7 +257,8 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::WriteBinaryU16StreamingData data;
+     nidaqmx_grpc::WriteBinaryU16StreamingRequest request;
+     nidaqmx_grpc::WriteBinaryU16StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -265,7 +270,8 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::WriteBinaryU32StreamingData data;
+     nidaqmx_grpc::WriteBinaryU32StreamingRequest request;
+     nidaqmx_grpc::WriteBinaryU32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -275,7 +281,8 @@ namespace nidaqmx_grpc {
      bool32 auto_start;
      float64 timeout;
      bool32* reserved;
-     nidaqmx_grpc::WriteDigitalScalarU32StreamingData data;
+     nidaqmx_grpc::WriteDigitalScalarU32StreamingRequest request;
+     nidaqmx_grpc::WriteDigitalScalarU32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -287,7 +294,8 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::WriteDigitalU16StreamingData data;
+     nidaqmx_grpc::WriteDigitalU16StreamingRequest request;
+     nidaqmx_grpc::WriteDigitalU16StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 
@@ -299,7 +307,8 @@ namespace nidaqmx_grpc {
      float64 timeout;
      int32 data_layout;
      bool32* reserved;
-     nidaqmx_grpc::WriteDigitalU32StreamingData data;
+     nidaqmx_grpc::WriteDigitalU32StreamingRequest request;
+     nidaqmx_grpc::WriteDigitalU32StreamingResponse response;
      std::shared_ptr<NiDAQmxLibraryInterface> library;
   };
 

--- a/generated/nifpga/nifpga.proto
+++ b/generated/nifpga/nifpga.proto
@@ -502,6 +502,15 @@ message BeginReadArrayBoolResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadArrayBoolStreamingData {
+  ReadArrayBoolStreamingDataResponse response = 2;
+}
+
+message ReadArrayBoolStreamingDataResponse {
+  int32 status = 1;
+  repeated bool array = 2;
+}
+
 message ReadArrayDblRequest {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -522,6 +531,15 @@ message BeginReadArrayDblRequest {
 message BeginReadArrayDblResponse {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadArrayDblStreamingData {
+  ReadArrayDblStreamingDataResponse response = 2;
+}
+
+message ReadArrayDblStreamingDataResponse {
+  int32 status = 1;
+  repeated double array = 2;
 }
 
 message ReadArrayI16Request {
@@ -546,6 +564,15 @@ message BeginReadArrayI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadArrayI16StreamingData {
+  ReadArrayI16StreamingDataResponse response = 2;
+}
+
+message ReadArrayI16StreamingDataResponse {
+  int32 status = 1;
+  repeated int32 array = 2;
+}
+
 message ReadArrayI32Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -566,6 +593,15 @@ message BeginReadArrayI32Request {
 message BeginReadArrayI32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadArrayI32StreamingData {
+  ReadArrayI32StreamingDataResponse response = 2;
+}
+
+message ReadArrayI32StreamingDataResponse {
+  int32 status = 1;
+  repeated int32 array = 2;
 }
 
 message ReadArrayI64Request {
@@ -590,6 +626,15 @@ message BeginReadArrayI64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadArrayI64StreamingData {
+  ReadArrayI64StreamingDataResponse response = 2;
+}
+
+message ReadArrayI64StreamingDataResponse {
+  int32 status = 1;
+  repeated int64 array = 2;
+}
+
 message ReadArrayI8Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -610,6 +655,15 @@ message BeginReadArrayI8Request {
 message BeginReadArrayI8Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadArrayI8StreamingData {
+  ReadArrayI8StreamingDataResponse response = 2;
+}
+
+message ReadArrayI8StreamingDataResponse {
+  int32 status = 1;
+  repeated int32 array = 2;
 }
 
 message ReadArraySglRequest {
@@ -634,6 +688,15 @@ message BeginReadArraySglResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadArraySglStreamingData {
+  ReadArraySglStreamingDataResponse response = 2;
+}
+
+message ReadArraySglStreamingDataResponse {
+  int32 status = 1;
+  repeated float array = 2;
+}
+
 message ReadArrayU16Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -654,6 +717,15 @@ message BeginReadArrayU16Request {
 message BeginReadArrayU16Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadArrayU16StreamingData {
+  ReadArrayU16StreamingDataResponse response = 2;
+}
+
+message ReadArrayU16StreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 array = 2;
 }
 
 message ReadArrayU32Request {
@@ -678,6 +750,15 @@ message BeginReadArrayU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadArrayU32StreamingData {
+  ReadArrayU32StreamingDataResponse response = 2;
+}
+
+message ReadArrayU32StreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 array = 2;
+}
+
 message ReadArrayU64Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -698,6 +779,15 @@ message BeginReadArrayU64Request {
 message BeginReadArrayU64Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadArrayU64StreamingData {
+  ReadArrayU64StreamingDataResponse response = 2;
+}
+
+message ReadArrayU64StreamingDataResponse {
+  int32 status = 1;
+  repeated uint64 array = 2;
 }
 
 message ReadArrayU8Request {
@@ -722,6 +812,15 @@ message BeginReadArrayU8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadArrayU8StreamingData {
+  ReadArrayU8StreamingDataResponse response = 2;
+}
+
+message ReadArrayU8StreamingDataResponse {
+  int32 status = 1;
+  repeated uint32 array = 2;
+}
+
 message ReadBoolRequest {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -742,6 +841,15 @@ message BeginReadBoolResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadBoolStreamingData {
+  ReadBoolStreamingDataResponse response = 2;
+}
+
+message ReadBoolStreamingDataResponse {
+  int32 status = 1;
+  bool value = 2;
+}
+
 message ReadDblRequest {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -760,6 +868,15 @@ message BeginReadDblRequest {
 message BeginReadDblResponse {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadDblStreamingData {
+  ReadDblStreamingDataResponse response = 2;
+}
+
+message ReadDblStreamingDataResponse {
+  int32 status = 1;
+  double value = 2;
 }
 
 message ReadFifoBoolRequest {
@@ -925,6 +1042,15 @@ message BeginReadI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadI16StreamingData {
+  ReadI16StreamingDataResponse response = 2;
+}
+
+message ReadI16StreamingDataResponse {
+  int32 status = 1;
+  int32 value = 2;
+}
+
 message ReadI32Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -943,6 +1069,15 @@ message BeginReadI32Request {
 message BeginReadI32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadI32StreamingData {
+  ReadI32StreamingDataResponse response = 2;
+}
+
+message ReadI32StreamingDataResponse {
+  int32 status = 1;
+  int32 value = 2;
 }
 
 message ReadI64Request {
@@ -965,6 +1100,15 @@ message BeginReadI64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadI64StreamingData {
+  ReadI64StreamingDataResponse response = 2;
+}
+
+message ReadI64StreamingDataResponse {
+  int32 status = 1;
+  int64 value = 2;
+}
+
 message ReadI8Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -983,6 +1127,15 @@ message BeginReadI8Request {
 message BeginReadI8Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadI8StreamingData {
+  ReadI8StreamingDataResponse response = 2;
+}
+
+message ReadI8StreamingDataResponse {
+  int32 status = 1;
+  int32 value = 2;
 }
 
 message ReadSglRequest {
@@ -1005,6 +1158,15 @@ message BeginReadSglResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadSglStreamingData {
+  ReadSglStreamingDataResponse response = 2;
+}
+
+message ReadSglStreamingDataResponse {
+  int32 status = 1;
+  float value = 2;
+}
+
 message ReadU16Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -1023,6 +1185,15 @@ message BeginReadU16Request {
 message BeginReadU16Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadU16StreamingData {
+  ReadU16StreamingDataResponse response = 2;
+}
+
+message ReadU16StreamingDataResponse {
+  int32 status = 1;
+  uint32 value = 2;
 }
 
 message ReadU32Request {
@@ -1045,6 +1216,15 @@ message BeginReadU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadU32StreamingData {
+  ReadU32StreamingDataResponse response = 2;
+}
+
+message ReadU32StreamingDataResponse {
+  int32 status = 1;
+  uint32 value = 2;
+}
+
 message ReadU64Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -1065,6 +1245,15 @@ message BeginReadU64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message ReadU64StreamingData {
+  ReadU64StreamingDataResponse response = 2;
+}
+
+message ReadU64StreamingDataResponse {
+  int32 status = 1;
+  uint64 value = 2;
+}
+
 message ReadU8Request {
   nidevice_grpc.Session session = 1;
   uint32 indicator = 2;
@@ -1083,6 +1272,15 @@ message BeginReadU8Request {
 message BeginReadU8Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message ReadU8StreamingData {
+  ReadU8StreamingDataResponse response = 2;
+}
+
+message ReadU8StreamingDataResponse {
+  int32 status = 1;
+  uint32 value = 2;
 }
 
 message ReleaseFifoElementsRequest {
@@ -1230,6 +1428,19 @@ message BeginWriteArrayBoolResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteArrayBoolStreamingData {
+  WriteArrayBoolStreamingDataRequest request = 1;
+  WriteArrayBoolStreamingDataResponse response = 2;
+}
+
+message WriteArrayBoolStreamingDataRequest {
+  repeated bool array = 1;
+}
+
+message WriteArrayBoolStreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteArrayDblRequest {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1248,6 +1459,19 @@ message BeginWriteArrayDblRequest {
 message BeginWriteArrayDblResponse {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteArrayDblStreamingData {
+  WriteArrayDblStreamingDataRequest request = 1;
+  WriteArrayDblStreamingDataResponse response = 2;
+}
+
+message WriteArrayDblStreamingDataRequest {
+  repeated double array = 1;
+}
+
+message WriteArrayDblStreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteArrayI16Request {
@@ -1270,6 +1494,19 @@ message BeginWriteArrayI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteArrayI16StreamingData {
+  WriteArrayI16StreamingDataRequest request = 1;
+  WriteArrayI16StreamingDataResponse response = 2;
+}
+
+message WriteArrayI16StreamingDataRequest {
+  repeated int32 array = 1;
+}
+
+message WriteArrayI16StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteArrayI32Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1288,6 +1525,19 @@ message BeginWriteArrayI32Request {
 message BeginWriteArrayI32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteArrayI32StreamingData {
+  WriteArrayI32StreamingDataRequest request = 1;
+  WriteArrayI32StreamingDataResponse response = 2;
+}
+
+message WriteArrayI32StreamingDataRequest {
+  repeated int32 array = 1;
+}
+
+message WriteArrayI32StreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteArrayI64Request {
@@ -1310,6 +1560,19 @@ message BeginWriteArrayI64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteArrayI64StreamingData {
+  WriteArrayI64StreamingDataRequest request = 1;
+  WriteArrayI64StreamingDataResponse response = 2;
+}
+
+message WriteArrayI64StreamingDataRequest {
+  repeated int64 array = 1;
+}
+
+message WriteArrayI64StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteArrayI8Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1328,6 +1591,19 @@ message BeginWriteArrayI8Request {
 message BeginWriteArrayI8Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteArrayI8StreamingData {
+  WriteArrayI8StreamingDataRequest request = 1;
+  WriteArrayI8StreamingDataResponse response = 2;
+}
+
+message WriteArrayI8StreamingDataRequest {
+  repeated int32 array = 1;
+}
+
+message WriteArrayI8StreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteArraySglRequest {
@@ -1350,6 +1626,19 @@ message BeginWriteArraySglResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteArraySglStreamingData {
+  WriteArraySglStreamingDataRequest request = 1;
+  WriteArraySglStreamingDataResponse response = 2;
+}
+
+message WriteArraySglStreamingDataRequest {
+  repeated float array = 1;
+}
+
+message WriteArraySglStreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteArrayU16Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1368,6 +1657,19 @@ message BeginWriteArrayU16Request {
 message BeginWriteArrayU16Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteArrayU16StreamingData {
+  WriteArrayU16StreamingDataRequest request = 1;
+  WriteArrayU16StreamingDataResponse response = 2;
+}
+
+message WriteArrayU16StreamingDataRequest {
+  repeated uint32 array = 1;
+}
+
+message WriteArrayU16StreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteArrayU32Request {
@@ -1390,6 +1692,19 @@ message BeginWriteArrayU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteArrayU32StreamingData {
+  WriteArrayU32StreamingDataRequest request = 1;
+  WriteArrayU32StreamingDataResponse response = 2;
+}
+
+message WriteArrayU32StreamingDataRequest {
+  repeated uint32 array = 1;
+}
+
+message WriteArrayU32StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteArrayU64Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1408,6 +1723,19 @@ message BeginWriteArrayU64Request {
 message BeginWriteArrayU64Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteArrayU64StreamingData {
+  WriteArrayU64StreamingDataRequest request = 1;
+  WriteArrayU64StreamingDataResponse response = 2;
+}
+
+message WriteArrayU64StreamingDataRequest {
+  repeated uint64 array = 1;
+}
+
+message WriteArrayU64StreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteArrayU8Request {
@@ -1430,6 +1758,19 @@ message BeginWriteArrayU8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteArrayU8StreamingData {
+  WriteArrayU8StreamingDataRequest request = 1;
+  WriteArrayU8StreamingDataResponse response = 2;
+}
+
+message WriteArrayU8StreamingDataRequest {
+  repeated uint32 array = 1;
+}
+
+message WriteArrayU8StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteBoolRequest {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1450,6 +1791,19 @@ message BeginWriteBoolResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteBoolStreamingData {
+  WriteBoolStreamingDataRequest request = 1;
+  WriteBoolStreamingDataResponse response = 2;
+}
+
+message WriteBoolStreamingDataRequest {
+  bool value = 1;
+}
+
+message WriteBoolStreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteDblRequest {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1468,6 +1822,19 @@ message BeginWriteDblRequest {
 message BeginWriteDblResponse {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteDblStreamingData {
+  WriteDblStreamingDataRequest request = 1;
+  WriteDblStreamingDataResponse response = 2;
+}
+
+message WriteDblStreamingDataRequest {
+  double value = 1;
+}
+
+message WriteDblStreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteFifoBoolRequest {
@@ -1622,6 +1989,19 @@ message BeginWriteI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteI16StreamingData {
+  WriteI16StreamingDataRequest request = 1;
+  WriteI16StreamingDataResponse response = 2;
+}
+
+message WriteI16StreamingDataRequest {
+  int32 value = 1;
+}
+
+message WriteI16StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteI32Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1640,6 +2020,19 @@ message BeginWriteI32Request {
 message BeginWriteI32Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteI32StreamingData {
+  WriteI32StreamingDataRequest request = 1;
+  WriteI32StreamingDataResponse response = 2;
+}
+
+message WriteI32StreamingDataRequest {
+  int32 value = 1;
+}
+
+message WriteI32StreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteI64Request {
@@ -1662,6 +2055,19 @@ message BeginWriteI64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteI64StreamingData {
+  WriteI64StreamingDataRequest request = 1;
+  WriteI64StreamingDataResponse response = 2;
+}
+
+message WriteI64StreamingDataRequest {
+  int64 value = 1;
+}
+
+message WriteI64StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteI8Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1680,6 +2086,19 @@ message BeginWriteI8Request {
 message BeginWriteI8Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteI8StreamingData {
+  WriteI8StreamingDataRequest request = 1;
+  WriteI8StreamingDataResponse response = 2;
+}
+
+message WriteI8StreamingDataRequest {
+  int32 value = 1;
+}
+
+message WriteI8StreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteSglRequest {
@@ -1702,6 +2121,19 @@ message BeginWriteSglResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteSglStreamingData {
+  WriteSglStreamingDataRequest request = 1;
+  WriteSglStreamingDataResponse response = 2;
+}
+
+message WriteSglStreamingDataRequest {
+  float value = 1;
+}
+
+message WriteSglStreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteU16Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1720,6 +2152,19 @@ message BeginWriteU16Request {
 message BeginWriteU16Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteU16StreamingData {
+  WriteU16StreamingDataRequest request = 1;
+  WriteU16StreamingDataResponse response = 2;
+}
+
+message WriteU16StreamingDataRequest {
+  uint32 value = 1;
+}
+
+message WriteU16StreamingDataResponse {
+  int32 status = 1;
 }
 
 message WriteU32Request {
@@ -1742,6 +2187,19 @@ message BeginWriteU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteU32StreamingData {
+  WriteU32StreamingDataRequest request = 1;
+  WriteU32StreamingDataResponse response = 2;
+}
+
+message WriteU32StreamingDataRequest {
+  uint32 value = 1;
+}
+
+message WriteU32StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteU64Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1762,6 +2220,19 @@ message BeginWriteU64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
+message WriteU64StreamingData {
+  WriteU64StreamingDataRequest request = 1;
+  WriteU64StreamingDataResponse response = 2;
+}
+
+message WriteU64StreamingDataRequest {
+  uint64 value = 1;
+}
+
+message WriteU64StreamingDataResponse {
+  int32 status = 1;
+}
+
 message WriteU8Request {
   nidevice_grpc.Session session = 1;
   uint32 control = 2;
@@ -1780,5 +2251,18 @@ message BeginWriteU8Request {
 message BeginWriteU8Response {
   int32 status = 1;
   ni.data_monikers.Moniker moniker = 2;
+}
+
+message WriteU8StreamingData {
+  WriteU8StreamingDataRequest request = 1;
+  WriteU8StreamingDataResponse response = 2;
+}
+
+message WriteU8StreamingDataRequest {
+  uint32 value = 1;
+}
+
+message WriteU8StreamingDataResponse {
+  int32 status = 1;
 }
 

--- a/generated/nifpga/nifpga.proto
+++ b/generated/nifpga/nifpga.proto
@@ -502,11 +502,7 @@ message BeginReadArrayBoolResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayBoolStreamingData {
-  ReadArrayBoolStreamingDataResponse response = 2;
-}
-
-message ReadArrayBoolStreamingDataResponse {
+message ReadArrayBoolStreamingResponse {
   int32 status = 1;
   repeated bool array = 2;
 }
@@ -533,11 +529,7 @@ message BeginReadArrayDblResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayDblStreamingData {
-  ReadArrayDblStreamingDataResponse response = 2;
-}
-
-message ReadArrayDblStreamingDataResponse {
+message ReadArrayDblStreamingResponse {
   int32 status = 1;
   repeated double array = 2;
 }
@@ -564,11 +556,7 @@ message BeginReadArrayI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayI16StreamingData {
-  ReadArrayI16StreamingDataResponse response = 2;
-}
-
-message ReadArrayI16StreamingDataResponse {
+message ReadArrayI16StreamingResponse {
   int32 status = 1;
   repeated int32 array = 2;
 }
@@ -595,11 +583,7 @@ message BeginReadArrayI32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayI32StreamingData {
-  ReadArrayI32StreamingDataResponse response = 2;
-}
-
-message ReadArrayI32StreamingDataResponse {
+message ReadArrayI32StreamingResponse {
   int32 status = 1;
   repeated int32 array = 2;
 }
@@ -626,11 +610,7 @@ message BeginReadArrayI64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayI64StreamingData {
-  ReadArrayI64StreamingDataResponse response = 2;
-}
-
-message ReadArrayI64StreamingDataResponse {
+message ReadArrayI64StreamingResponse {
   int32 status = 1;
   repeated int64 array = 2;
 }
@@ -657,11 +637,7 @@ message BeginReadArrayI8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayI8StreamingData {
-  ReadArrayI8StreamingDataResponse response = 2;
-}
-
-message ReadArrayI8StreamingDataResponse {
+message ReadArrayI8StreamingResponse {
   int32 status = 1;
   repeated int32 array = 2;
 }
@@ -688,11 +664,7 @@ message BeginReadArraySglResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArraySglStreamingData {
-  ReadArraySglStreamingDataResponse response = 2;
-}
-
-message ReadArraySglStreamingDataResponse {
+message ReadArraySglStreamingResponse {
   int32 status = 1;
   repeated float array = 2;
 }
@@ -719,11 +691,7 @@ message BeginReadArrayU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayU16StreamingData {
-  ReadArrayU16StreamingDataResponse response = 2;
-}
-
-message ReadArrayU16StreamingDataResponse {
+message ReadArrayU16StreamingResponse {
   int32 status = 1;
   repeated uint32 array = 2;
 }
@@ -750,11 +718,7 @@ message BeginReadArrayU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayU32StreamingData {
-  ReadArrayU32StreamingDataResponse response = 2;
-}
-
-message ReadArrayU32StreamingDataResponse {
+message ReadArrayU32StreamingResponse {
   int32 status = 1;
   repeated uint32 array = 2;
 }
@@ -781,11 +745,7 @@ message BeginReadArrayU64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayU64StreamingData {
-  ReadArrayU64StreamingDataResponse response = 2;
-}
-
-message ReadArrayU64StreamingDataResponse {
+message ReadArrayU64StreamingResponse {
   int32 status = 1;
   repeated uint64 array = 2;
 }
@@ -812,11 +772,7 @@ message BeginReadArrayU8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadArrayU8StreamingData {
-  ReadArrayU8StreamingDataResponse response = 2;
-}
-
-message ReadArrayU8StreamingDataResponse {
+message ReadArrayU8StreamingResponse {
   int32 status = 1;
   repeated uint32 array = 2;
 }
@@ -841,11 +797,7 @@ message BeginReadBoolResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadBoolStreamingData {
-  ReadBoolStreamingDataResponse response = 2;
-}
-
-message ReadBoolStreamingDataResponse {
+message ReadBoolStreamingResponse {
   int32 status = 1;
   bool value = 2;
 }
@@ -870,11 +822,7 @@ message BeginReadDblResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadDblStreamingData {
-  ReadDblStreamingDataResponse response = 2;
-}
-
-message ReadDblStreamingDataResponse {
+message ReadDblStreamingResponse {
   int32 status = 1;
   double value = 2;
 }
@@ -1042,11 +990,7 @@ message BeginReadI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadI16StreamingData {
-  ReadI16StreamingDataResponse response = 2;
-}
-
-message ReadI16StreamingDataResponse {
+message ReadI16StreamingResponse {
   int32 status = 1;
   int32 value = 2;
 }
@@ -1071,11 +1015,7 @@ message BeginReadI32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadI32StreamingData {
-  ReadI32StreamingDataResponse response = 2;
-}
-
-message ReadI32StreamingDataResponse {
+message ReadI32StreamingResponse {
   int32 status = 1;
   int32 value = 2;
 }
@@ -1100,11 +1040,7 @@ message BeginReadI64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadI64StreamingData {
-  ReadI64StreamingDataResponse response = 2;
-}
-
-message ReadI64StreamingDataResponse {
+message ReadI64StreamingResponse {
   int32 status = 1;
   int64 value = 2;
 }
@@ -1129,11 +1065,7 @@ message BeginReadI8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadI8StreamingData {
-  ReadI8StreamingDataResponse response = 2;
-}
-
-message ReadI8StreamingDataResponse {
+message ReadI8StreamingResponse {
   int32 status = 1;
   int32 value = 2;
 }
@@ -1158,11 +1090,7 @@ message BeginReadSglResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadSglStreamingData {
-  ReadSglStreamingDataResponse response = 2;
-}
-
-message ReadSglStreamingDataResponse {
+message ReadSglStreamingResponse {
   int32 status = 1;
   float value = 2;
 }
@@ -1187,11 +1115,7 @@ message BeginReadU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadU16StreamingData {
-  ReadU16StreamingDataResponse response = 2;
-}
-
-message ReadU16StreamingDataResponse {
+message ReadU16StreamingResponse {
   int32 status = 1;
   uint32 value = 2;
 }
@@ -1216,11 +1140,7 @@ message BeginReadU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadU32StreamingData {
-  ReadU32StreamingDataResponse response = 2;
-}
-
-message ReadU32StreamingDataResponse {
+message ReadU32StreamingResponse {
   int32 status = 1;
   uint32 value = 2;
 }
@@ -1245,11 +1165,7 @@ message BeginReadU64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadU64StreamingData {
-  ReadU64StreamingDataResponse response = 2;
-}
-
-message ReadU64StreamingDataResponse {
+message ReadU64StreamingResponse {
   int32 status = 1;
   uint64 value = 2;
 }
@@ -1274,11 +1190,7 @@ message BeginReadU8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message ReadU8StreamingData {
-  ReadU8StreamingDataResponse response = 2;
-}
-
-message ReadU8StreamingDataResponse {
+message ReadU8StreamingResponse {
   int32 status = 1;
   uint32 value = 2;
 }
@@ -1428,16 +1340,11 @@ message BeginWriteArrayBoolResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayBoolStreamingData {
-  WriteArrayBoolStreamingDataRequest request = 1;
-  WriteArrayBoolStreamingDataResponse response = 2;
-}
-
-message WriteArrayBoolStreamingDataRequest {
+message WriteArrayBoolStreamingRequest {
   repeated bool array = 1;
 }
 
-message WriteArrayBoolStreamingDataResponse {
+message WriteArrayBoolStreamingResponse {
   int32 status = 1;
 }
 
@@ -1461,16 +1368,11 @@ message BeginWriteArrayDblResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayDblStreamingData {
-  WriteArrayDblStreamingDataRequest request = 1;
-  WriteArrayDblStreamingDataResponse response = 2;
-}
-
-message WriteArrayDblStreamingDataRequest {
+message WriteArrayDblStreamingRequest {
   repeated double array = 1;
 }
 
-message WriteArrayDblStreamingDataResponse {
+message WriteArrayDblStreamingResponse {
   int32 status = 1;
 }
 
@@ -1494,16 +1396,11 @@ message BeginWriteArrayI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayI16StreamingData {
-  WriteArrayI16StreamingDataRequest request = 1;
-  WriteArrayI16StreamingDataResponse response = 2;
-}
-
-message WriteArrayI16StreamingDataRequest {
+message WriteArrayI16StreamingRequest {
   repeated int32 array = 1;
 }
 
-message WriteArrayI16StreamingDataResponse {
+message WriteArrayI16StreamingResponse {
   int32 status = 1;
 }
 
@@ -1527,16 +1424,11 @@ message BeginWriteArrayI32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayI32StreamingData {
-  WriteArrayI32StreamingDataRequest request = 1;
-  WriteArrayI32StreamingDataResponse response = 2;
-}
-
-message WriteArrayI32StreamingDataRequest {
+message WriteArrayI32StreamingRequest {
   repeated int32 array = 1;
 }
 
-message WriteArrayI32StreamingDataResponse {
+message WriteArrayI32StreamingResponse {
   int32 status = 1;
 }
 
@@ -1560,16 +1452,11 @@ message BeginWriteArrayI64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayI64StreamingData {
-  WriteArrayI64StreamingDataRequest request = 1;
-  WriteArrayI64StreamingDataResponse response = 2;
-}
-
-message WriteArrayI64StreamingDataRequest {
+message WriteArrayI64StreamingRequest {
   repeated int64 array = 1;
 }
 
-message WriteArrayI64StreamingDataResponse {
+message WriteArrayI64StreamingResponse {
   int32 status = 1;
 }
 
@@ -1593,16 +1480,11 @@ message BeginWriteArrayI8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayI8StreamingData {
-  WriteArrayI8StreamingDataRequest request = 1;
-  WriteArrayI8StreamingDataResponse response = 2;
-}
-
-message WriteArrayI8StreamingDataRequest {
+message WriteArrayI8StreamingRequest {
   repeated int32 array = 1;
 }
 
-message WriteArrayI8StreamingDataResponse {
+message WriteArrayI8StreamingResponse {
   int32 status = 1;
 }
 
@@ -1626,16 +1508,11 @@ message BeginWriteArraySglResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArraySglStreamingData {
-  WriteArraySglStreamingDataRequest request = 1;
-  WriteArraySglStreamingDataResponse response = 2;
-}
-
-message WriteArraySglStreamingDataRequest {
+message WriteArraySglStreamingRequest {
   repeated float array = 1;
 }
 
-message WriteArraySglStreamingDataResponse {
+message WriteArraySglStreamingResponse {
   int32 status = 1;
 }
 
@@ -1659,16 +1536,11 @@ message BeginWriteArrayU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayU16StreamingData {
-  WriteArrayU16StreamingDataRequest request = 1;
-  WriteArrayU16StreamingDataResponse response = 2;
-}
-
-message WriteArrayU16StreamingDataRequest {
+message WriteArrayU16StreamingRequest {
   repeated uint32 array = 1;
 }
 
-message WriteArrayU16StreamingDataResponse {
+message WriteArrayU16StreamingResponse {
   int32 status = 1;
 }
 
@@ -1692,16 +1564,11 @@ message BeginWriteArrayU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayU32StreamingData {
-  WriteArrayU32StreamingDataRequest request = 1;
-  WriteArrayU32StreamingDataResponse response = 2;
-}
-
-message WriteArrayU32StreamingDataRequest {
+message WriteArrayU32StreamingRequest {
   repeated uint32 array = 1;
 }
 
-message WriteArrayU32StreamingDataResponse {
+message WriteArrayU32StreamingResponse {
   int32 status = 1;
 }
 
@@ -1725,16 +1592,11 @@ message BeginWriteArrayU64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayU64StreamingData {
-  WriteArrayU64StreamingDataRequest request = 1;
-  WriteArrayU64StreamingDataResponse response = 2;
-}
-
-message WriteArrayU64StreamingDataRequest {
+message WriteArrayU64StreamingRequest {
   repeated uint64 array = 1;
 }
 
-message WriteArrayU64StreamingDataResponse {
+message WriteArrayU64StreamingResponse {
   int32 status = 1;
 }
 
@@ -1758,16 +1620,11 @@ message BeginWriteArrayU8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteArrayU8StreamingData {
-  WriteArrayU8StreamingDataRequest request = 1;
-  WriteArrayU8StreamingDataResponse response = 2;
-}
-
-message WriteArrayU8StreamingDataRequest {
+message WriteArrayU8StreamingRequest {
   repeated uint32 array = 1;
 }
 
-message WriteArrayU8StreamingDataResponse {
+message WriteArrayU8StreamingResponse {
   int32 status = 1;
 }
 
@@ -1791,16 +1648,11 @@ message BeginWriteBoolResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteBoolStreamingData {
-  WriteBoolStreamingDataRequest request = 1;
-  WriteBoolStreamingDataResponse response = 2;
-}
-
-message WriteBoolStreamingDataRequest {
+message WriteBoolStreamingRequest {
   bool value = 1;
 }
 
-message WriteBoolStreamingDataResponse {
+message WriteBoolStreamingResponse {
   int32 status = 1;
 }
 
@@ -1824,16 +1676,11 @@ message BeginWriteDblResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteDblStreamingData {
-  WriteDblStreamingDataRequest request = 1;
-  WriteDblStreamingDataResponse response = 2;
-}
-
-message WriteDblStreamingDataRequest {
+message WriteDblStreamingRequest {
   double value = 1;
 }
 
-message WriteDblStreamingDataResponse {
+message WriteDblStreamingResponse {
   int32 status = 1;
 }
 
@@ -1989,16 +1836,11 @@ message BeginWriteI16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteI16StreamingData {
-  WriteI16StreamingDataRequest request = 1;
-  WriteI16StreamingDataResponse response = 2;
-}
-
-message WriteI16StreamingDataRequest {
+message WriteI16StreamingRequest {
   int32 value = 1;
 }
 
-message WriteI16StreamingDataResponse {
+message WriteI16StreamingResponse {
   int32 status = 1;
 }
 
@@ -2022,16 +1864,11 @@ message BeginWriteI32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteI32StreamingData {
-  WriteI32StreamingDataRequest request = 1;
-  WriteI32StreamingDataResponse response = 2;
-}
-
-message WriteI32StreamingDataRequest {
+message WriteI32StreamingRequest {
   int32 value = 1;
 }
 
-message WriteI32StreamingDataResponse {
+message WriteI32StreamingResponse {
   int32 status = 1;
 }
 
@@ -2055,16 +1892,11 @@ message BeginWriteI64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteI64StreamingData {
-  WriteI64StreamingDataRequest request = 1;
-  WriteI64StreamingDataResponse response = 2;
-}
-
-message WriteI64StreamingDataRequest {
+message WriteI64StreamingRequest {
   int64 value = 1;
 }
 
-message WriteI64StreamingDataResponse {
+message WriteI64StreamingResponse {
   int32 status = 1;
 }
 
@@ -2088,16 +1920,11 @@ message BeginWriteI8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteI8StreamingData {
-  WriteI8StreamingDataRequest request = 1;
-  WriteI8StreamingDataResponse response = 2;
-}
-
-message WriteI8StreamingDataRequest {
+message WriteI8StreamingRequest {
   int32 value = 1;
 }
 
-message WriteI8StreamingDataResponse {
+message WriteI8StreamingResponse {
   int32 status = 1;
 }
 
@@ -2121,16 +1948,11 @@ message BeginWriteSglResponse {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteSglStreamingData {
-  WriteSglStreamingDataRequest request = 1;
-  WriteSglStreamingDataResponse response = 2;
-}
-
-message WriteSglStreamingDataRequest {
+message WriteSglStreamingRequest {
   float value = 1;
 }
 
-message WriteSglStreamingDataResponse {
+message WriteSglStreamingResponse {
   int32 status = 1;
 }
 
@@ -2154,16 +1976,11 @@ message BeginWriteU16Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteU16StreamingData {
-  WriteU16StreamingDataRequest request = 1;
-  WriteU16StreamingDataResponse response = 2;
-}
-
-message WriteU16StreamingDataRequest {
+message WriteU16StreamingRequest {
   uint32 value = 1;
 }
 
-message WriteU16StreamingDataResponse {
+message WriteU16StreamingResponse {
   int32 status = 1;
 }
 
@@ -2187,16 +2004,11 @@ message BeginWriteU32Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteU32StreamingData {
-  WriteU32StreamingDataRequest request = 1;
-  WriteU32StreamingDataResponse response = 2;
-}
-
-message WriteU32StreamingDataRequest {
+message WriteU32StreamingRequest {
   uint32 value = 1;
 }
 
-message WriteU32StreamingDataResponse {
+message WriteU32StreamingResponse {
   int32 status = 1;
 }
 
@@ -2220,16 +2032,11 @@ message BeginWriteU64Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteU64StreamingData {
-  WriteU64StreamingDataRequest request = 1;
-  WriteU64StreamingDataResponse response = 2;
-}
-
-message WriteU64StreamingDataRequest {
+message WriteU64StreamingRequest {
   uint64 value = 1;
 }
 
-message WriteU64StreamingDataResponse {
+message WriteU64StreamingResponse {
   int32 status = 1;
 }
 
@@ -2253,16 +2060,11 @@ message BeginWriteU8Response {
   ni.data_monikers.Moniker moniker = 2;
 }
 
-message WriteU8StreamingData {
-  WriteU8StreamingDataRequest request = 1;
-  WriteU8StreamingDataResponse response = 2;
-}
-
-message WriteU8StreamingDataRequest {
+message WriteU8StreamingRequest {
   uint32 value = 1;
 }
 
-message WriteU8StreamingDataResponse {
+message WriteU8StreamingResponse {
   int32 status = 1;
 }
 

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -27,7 +27,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayBoolData data;
+     nifpga_grpc::ReadArrayBoolStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -36,7 +36,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayDoubleData data;
+     nifpga_grpc::ReadArrayDblStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -45,7 +45,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayI32Data data;
+     nifpga_grpc::ReadArrayI16StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -54,7 +54,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayI32Data data;
+     nifpga_grpc::ReadArrayI32StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -63,7 +63,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayI64Data data;
+     nifpga_grpc::ReadArrayI64StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -72,7 +72,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayI32Data data;
+     nifpga_grpc::ReadArrayI8StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -81,7 +81,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayFloatData data;
+     nifpga_grpc::ReadArraySglStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -90,7 +90,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayU32Data data;
+     nifpga_grpc::ReadArrayU16StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -99,7 +99,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayU32Data data;
+     nifpga_grpc::ReadArrayU32StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -108,7 +108,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayU64Data data;
+     nifpga_grpc::ReadArrayU64StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -117,7 +117,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ArrayU32Data data;
+     nifpga_grpc::ReadArrayU8StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -125,7 +125,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::BoolData data;
+     nifpga_grpc::ReadBoolStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -133,7 +133,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::DoubleData data;
+     nifpga_grpc::ReadDblStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -141,7 +141,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::I32Data data;
+     nifpga_grpc::ReadI16StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -149,7 +149,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::I32Data data;
+     nifpga_grpc::ReadI32StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -157,7 +157,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::I64Data data;
+     nifpga_grpc::ReadI64StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -165,7 +165,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::I32Data data;
+     nifpga_grpc::ReadI8StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -173,7 +173,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::FloatData data;
+     nifpga_grpc::ReadSglStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -181,7 +181,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::U32Data data;
+     nifpga_grpc::ReadU16StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -189,7 +189,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::U32Data data;
+     nifpga_grpc::ReadU32StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -197,7 +197,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::U64Data data;
+     nifpga_grpc::ReadU64StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -205,7 +205,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::U32Data data;
+     nifpga_grpc::ReadU8StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -213,7 +213,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayBoolData data;
+     nifpga_grpc::WriteArrayBoolStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -221,7 +221,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayDoubleData data;
+     nifpga_grpc::WriteArrayDblStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -229,7 +229,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayI32Data data;
+     nifpga_grpc::WriteArrayI16StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -237,7 +237,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayI32Data data;
+     nifpga_grpc::WriteArrayI32StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -245,7 +245,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayI64Data data;
+     nifpga_grpc::WriteArrayI64StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -253,7 +253,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayI32Data data;
+     nifpga_grpc::WriteArrayI8StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -261,7 +261,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayFloatData data;
+     nifpga_grpc::WriteArraySglStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -269,7 +269,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayU32Data data;
+     nifpga_grpc::WriteArrayU16StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -277,7 +277,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayU32Data data;
+     nifpga_grpc::WriteArrayU32StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -285,7 +285,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayU64Data data;
+     nifpga_grpc::WriteArrayU64StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -293,7 +293,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::ArrayU32Data data;
+     nifpga_grpc::WriteArrayU8StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -301,7 +301,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::BoolData data;
+     nifpga_grpc::WriteBoolStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -309,7 +309,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::DoubleData data;
+     nifpga_grpc::WriteDblStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -317,7 +317,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::I32Data data;
+     nifpga_grpc::WriteI16StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -325,7 +325,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::I32Data data;
+     nifpga_grpc::WriteI32StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -333,7 +333,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::I64Data data;
+     nifpga_grpc::WriteI64StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -341,7 +341,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::I32Data data;
+     nifpga_grpc::WriteI8StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -349,7 +349,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::FloatData data;
+     nifpga_grpc::WriteSglStreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -357,7 +357,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::U32Data data;
+     nifpga_grpc::WriteU16StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -365,7 +365,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::U32Data data;
+     nifpga_grpc::WriteU32StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -373,7 +373,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::U64Data data;
+     nifpga_grpc::WriteU64StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -381,7 +381,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::U32Data data;
+     nifpga_grpc::WriteU8StreamingData data;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -6,948 +6,1206 @@
 //---------------------------------------------------------------------
 #include "nifpga_service.h"
 
+#include <sstream>
+#include <fstream>
+#include <iostream>
+#include <atomic>
+#include <vector>
 #include <server/converters.h>
 #include <server/data_moniker_service.h>
 
-#include <atomic>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <vector>
-
 namespace nifpga_grpc {
 
-using nidevice_grpc::converters::allocate_output_storage;
-using nidevice_grpc::converters::calculate_linked_array_size;
-using nidevice_grpc::converters::convert_from_grpc;
-using nidevice_grpc::converters::convert_to_grpc;
-using nidevice_grpc::converters::MatchState;
+  using nidevice_grpc::converters::allocate_output_storage;
+  using nidevice_grpc::converters::calculate_linked_array_size;
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
+  using nidevice_grpc::converters::MatchState;
 
-struct MonikerReadArrayBoolData {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayBoolStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayBoolData
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayBoolStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayDblData {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayDblStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayDblData
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayDblStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayI16Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayI16StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayI16Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayI16StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayI32Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayI32StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayI32Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayI32StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayI64Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayI64StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayI64Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayI64StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayI8Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayI8StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayI8Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayI8StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArraySglData {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArraySglStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArraySglData
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArraySglStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayU16Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayU16StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayU16Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayU16StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayU32Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayU32StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayU32Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayU32StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayU64Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayU64StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayU64Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayU64StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadArrayU8Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  size_t size;
-  nifpga_grpc::ReadArrayU8StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadArrayU8Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     size_t size;
+     nifpga_grpc::ReadArrayU8StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadBoolData {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadBoolStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadBoolData
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadBoolStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadDblData {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadDblStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadDblData
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadDblStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadI16Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadI16StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadI16Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadI16StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadI32Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadI32StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadI32Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadI32StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadI64Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadI64StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadI64Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadI64StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadI8Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadI8StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadI8Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadI8StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadSglData {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadSglStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadSglData
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadSglStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadU16Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadU16StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadU16Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadU16StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadU32Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadU32StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadU32Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadU32StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadU64Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadU64StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadU64Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadU64StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerReadU8Data {
-  NiFpga_Session session;
-  uint32_t indicator;
-  nifpga_grpc::ReadU8StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerReadU8Data
+  {
+     NiFpga_Session session;
+     uint32_t indicator;
+     nifpga_grpc::ReadU8StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayBoolData {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayBoolStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayBoolData
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayBoolStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayDblData {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayDblStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayDblData
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayDblStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayI16Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayI16StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayI16Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayI16StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayI32Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayI32StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayI32Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayI32StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayI64Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayI64StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayI64Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayI64StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayI8Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayI8StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayI8Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayI8StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArraySglData {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArraySglStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArraySglData
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArraySglStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayU16Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayU16StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayU16Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayU16StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayU32Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayU32StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayU32Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayU32StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayU64Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayU64StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayU64Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayU64StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteArrayU8Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteArrayU8StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteArrayU8Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteArrayU8StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteBoolData {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteBoolStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteBoolData
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteBoolStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteDblData {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteDblStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteDblData
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteDblStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteI16Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteI16StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteI16Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteI16StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteI32Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteI32StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteI32Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteI32StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteI64Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteI64StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteI64Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteI64StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteI8Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteI8StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteI8Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteI8StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteSglData {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteSglStreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteSglData
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteSglStreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteU16Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteU16StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteU16Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteU16StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteU32Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteU32StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteU32Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteU32StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteU64Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteU64StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteU64Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteU64StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-struct MonikerWriteU8Data {
-  NiFpga_Session session;
-  uint32_t control;
-  nifpga_grpc::WriteU8StreamingData data;
-  std::shared_ptr<NiFpgaLibraryInterface> library;
-};
+  struct MonikerWriteU8Data
+  {
+     NiFpga_Session session;
+     uint32_t control;
+     nifpga_grpc::WriteU8StreamingData data;
+     std::shared_ptr<NiFpgaLibraryInterface> library;
+  };
 
-NiFpgaService::NiFpgaService(
-    LibrarySharedPtr library,
-    ResourceRepositorySharedPtr resource_repository,
-    const NiFpgaFeatureToggles& feature_toggles)
-    : library_(library),
+  NiFpgaService::NiFpgaService(
+      LibrarySharedPtr library,
+      ResourceRepositorySharedPtr resource_repository,
+      const NiFpgaFeatureToggles& feature_toggles)
+      : library_(library),
       session_repository_(resource_repository),
       feature_toggles_(feature_toggles)
-{
-}
+  {
+  }
 
-NiFpgaService::~NiFpgaService()
-{
-}
+  NiFpgaService::~NiFpgaService()
+  {
+  }
 
-// Returns true if it's safe to use outputs of a method with the given status.
-inline bool status_ok(int32 status)
-{
-  return status >= 0;
-}
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
 
-void RegisterMonikerEndpoints()
-{
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayBool", MonikerReadArrayBool);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayDbl", MonikerReadArrayDbl);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI16", MonikerReadArrayI16);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI32", MonikerReadArrayI32);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI64", MonikerReadArrayI64);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI8", MonikerReadArrayI8);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArraySgl", MonikerReadArraySgl);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU16", MonikerReadArrayU16);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU32", MonikerReadArrayU32);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU64", MonikerReadArrayU64);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU8", MonikerReadArrayU8);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadBool", MonikerReadBool);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadDbl", MonikerReadDbl);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI16", MonikerReadI16);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI32", MonikerReadI32);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI64", MonikerReadI64);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI8", MonikerReadI8);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadSgl", MonikerReadSgl);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU16", MonikerReadU16);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU32", MonikerReadU32);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU64", MonikerReadU64);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU8", MonikerReadU8);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayBool", MonikerWriteArrayBool);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayDbl", MonikerWriteArrayDbl);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI16", MonikerWriteArrayI16);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI32", MonikerWriteArrayI32);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI64", MonikerWriteArrayI64);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI8", MonikerWriteArrayI8);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArraySgl", MonikerWriteArraySgl);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU16", MonikerWriteArrayU16);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU32", MonikerWriteArrayU32);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU64", MonikerWriteArrayU64);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU8", MonikerWriteArrayU8);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteBool", MonikerWriteBool);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteDbl", MonikerWriteDbl);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI16", MonikerWriteI16);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI32", MonikerWriteI32);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI64", MonikerWriteI64);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI8", MonikerWriteI8);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteSgl", MonikerWriteSgl);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU16", MonikerWriteU16);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU32", MonikerWriteU32);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU64", MonikerWriteU64);
-  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU8", MonikerWriteU8);
-}
+  void RegisterMonikerEndpoints()
+  {
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayBool", MonikerReadArrayBool);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayDbl", MonikerReadArrayDbl);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI16", MonikerReadArrayI16);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI32", MonikerReadArrayI32);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI64", MonikerReadArrayI64);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI8", MonikerReadArrayI8);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArraySgl", MonikerReadArraySgl);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU16", MonikerReadArrayU16);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU32", MonikerReadArrayU32);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU64", MonikerReadArrayU64);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU8", MonikerReadArrayU8);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadBool", MonikerReadBool);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadDbl", MonikerReadDbl);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI16", MonikerReadI16);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI32", MonikerReadI32);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI64", MonikerReadI64);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI8", MonikerReadI8);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadSgl", MonikerReadSgl);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU16", MonikerReadU16);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU32", MonikerReadU32);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU64", MonikerReadU64);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU8", MonikerReadU8);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayBool", MonikerWriteArrayBool);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayDbl", MonikerWriteArrayDbl);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI16", MonikerWriteArrayI16);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI32", MonikerWriteArrayI32);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI64", MonikerWriteArrayI64);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI8", MonikerWriteArrayI8);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArraySgl", MonikerWriteArraySgl);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU16", MonikerWriteArrayU16);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU32", MonikerWriteArrayU32);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU64", MonikerWriteArrayU64);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU8", MonikerWriteArrayU8);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteBool", MonikerWriteBool);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteDbl", MonikerWriteDbl);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI16", MonikerWriteI16);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI32", MonikerWriteI32);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI64", MonikerWriteI64);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI8", MonikerWriteI8);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteSgl", MonikerWriteSgl);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU16", MonikerWriteU16);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU32", MonikerWriteU32);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU64", MonikerWriteU64);
+      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU8", MonikerWriteU8);
+  }
 
 ::grpc::Status MonikerReadArrayBool(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayBoolData* function_data = static_cast<MonikerReadArrayBoolData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayBoolData* function_data = static_cast<MonikerReadArrayBoolData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
+    auto status = library->ReadArrayBool(session, indicator, array.data(), size);
 
-  std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
-  auto status = library->ReadArrayBool(session, indicator, array.data(), size);
-  if (status >= 0) {
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-          return x;
-        });
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayBool error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      convert_to_grpc(array, response->mutable_array());
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      convert_to_grpc(array, response->mutable_array());
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayDbl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayDblData* function_data = static_cast<MonikerReadArrayDblData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayDblData* function_data = static_cast<MonikerReadArrayDblData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    function_data->data.mutable_array()->Resize(size, 0);
+    auto array = response->mutable_array()->mutable_data();
+    auto status = library->ReadArrayDbl(session, indicator, array, size);
 
-  function_data->data.mutable_value()->Resize(size, 0);
-  auto array = function_data->data.mutable_value()->mutable_data();
-  auto status = library->ReadArrayDbl(session, indicator, array, size);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayDbl error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayI16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayI16Data* function_data = static_cast<MonikerReadArrayI16Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayI16Data* function_data = static_cast<MonikerReadArrayI16Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    std::vector<int16_t> array(size);
+    auto status = library->ReadArrayI16(session, indicator, array.data(), size);
 
-  std::vector<int16_t> array(size);
-  auto status = library->ReadArrayI16(session, indicator, array.data(), size);
-  if (status >= 0) {
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-          return x;
-        });
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayI16 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayI32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayI32Data* function_data = static_cast<MonikerReadArrayI32Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayI32Data* function_data = static_cast<MonikerReadArrayI32Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    function_data->data.mutable_array()->Resize(size, 0);
+    auto array = response->mutable_array()->mutable_data();
+    auto status = library->ReadArrayI32(session, indicator, array, size);
 
-  function_data->data.mutable_value()->Resize(size, 0);
-  auto array = function_data->data.mutable_value()->mutable_data();
-  auto status = library->ReadArrayI32(session, indicator, array, size);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayI32 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayI64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayI64Data* function_data = static_cast<MonikerReadArrayI64Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayI64Data* function_data = static_cast<MonikerReadArrayI64Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    function_data->data.mutable_array()->Resize(size, 0);
+    auto array = response->mutable_array()->mutable_data();
+    auto status = library->ReadArrayI64(session, indicator, array, size);
 
-  function_data->data.mutable_value()->Resize(size, 0);
-  auto array = function_data->data.mutable_value()->mutable_data();
-  auto status = library->ReadArrayI64(session, indicator, array, size);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayI64 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayI8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayI8Data* function_data = static_cast<MonikerReadArrayI8Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayI8Data* function_data = static_cast<MonikerReadArrayI8Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    std::vector<int8_t> array(size);
+    auto status = library->ReadArrayI8(session, indicator, array.data(), size);
 
-  std::vector<int8_t> array(size);
-  auto status = library->ReadArrayI8(session, indicator, array.data(), size);
-  if (status >= 0) {
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-          return x;
-        });
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayI8 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArraySgl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArraySglData* function_data = static_cast<MonikerReadArraySglData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArraySglData* function_data = static_cast<MonikerReadArraySglData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    function_data->data.mutable_array()->Resize(size, 0);
+    auto array = response->mutable_array()->mutable_data();
+    auto status = library->ReadArraySgl(session, indicator, array, size);
 
-  function_data->data.mutable_value()->Resize(size, 0);
-  auto array = function_data->data.mutable_value()->mutable_data();
-  auto status = library->ReadArraySgl(session, indicator, array, size);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArraySgl error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayU16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayU16Data* function_data = static_cast<MonikerReadArrayU16Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayU16Data* function_data = static_cast<MonikerReadArrayU16Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    std::vector<uint16_t> array(size);
+    auto status = library->ReadArrayU16(session, indicator, array.data(), size);
 
-  std::vector<uint16_t> array(size);
-  auto status = library->ReadArrayU16(session, indicator, array.data(), size);
-  if (status >= 0) {
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-          return x;
-        });
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayU16 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayU32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayU32Data* function_data = static_cast<MonikerReadArrayU32Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayU32Data* function_data = static_cast<MonikerReadArrayU32Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    function_data->data.mutable_array()->Resize(size, 0);
+    auto array = response->mutable_array()->mutable_data();
+    auto status = library->ReadArrayU32(session, indicator, array, size);
 
-  function_data->data.mutable_value()->Resize(size, 0);
-  auto array = function_data->data.mutable_value()->mutable_data();
-  auto status = library->ReadArrayU32(session, indicator, array, size);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayU32 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayU64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayU64Data* function_data = static_cast<MonikerReadArrayU64Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayU64Data* function_data = static_cast<MonikerReadArrayU64Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    function_data->data.mutable_array()->Resize(size, 0);
+    auto array = response->mutable_array()->mutable_data();
+    auto status = library->ReadArrayU64(session, indicator, array, size);
 
-  function_data->data.mutable_value()->Resize(size, 0);
-  auto array = function_data->data.mutable_value()->mutable_data();
-  auto status = library->ReadArrayU64(session, indicator, array, size);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayU64 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayU8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadArrayU8Data* function_data = static_cast<MonikerReadArrayU8Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
-  auto size = function_data->size;
+    MonikerReadArrayU8Data* function_data = static_cast<MonikerReadArrayU8Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+    auto size = function_data->size;
+        
+    std::vector<uint8_t> array(size);
+    auto status = library->ReadArrayU8(session, indicator, array.data(), size);
 
-  std::vector<uint8_t> array(size);
-  auto status = library->ReadArrayU8(session, indicator, array.data(), size);
-  if (status >= 0) {
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        function_data->data.mutable_value()->begin(),
-        [&](auto x) {
-          return x;
-        });
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadArrayU8 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadBool(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadBoolData* function_data = static_cast<MonikerReadBoolData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadBoolData* function_data = static_cast<MonikerReadBoolData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+NiFpga_Bool value {};
+    auto status = library->ReadBool(session, indicator, &value);
 
-  NiFpga_Bool value{};
-  auto status = library->ReadBool(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadBool error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadDbl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadDblData* function_data = static_cast<MonikerReadDblData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadDblData* function_data = static_cast<MonikerReadDblData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+double value {};
+    auto status = library->ReadDbl(session, indicator, &value);
 
-  double value{};
-  auto status = library->ReadDbl(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadDbl error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadI16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadI16Data* function_data = static_cast<MonikerReadI16Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadI16Data* function_data = static_cast<MonikerReadI16Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+int16_t value {};
+    auto status = library->ReadI16(session, indicator, &value);
 
-  int16_t value{};
-  auto status = library->ReadI16(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadI16 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadI32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadI32Data* function_data = static_cast<MonikerReadI32Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadI32Data* function_data = static_cast<MonikerReadI32Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+int32_t value {};
+    auto status = library->ReadI32(session, indicator, &value);
 
-  int32_t value{};
-  auto status = library->ReadI32(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadI32 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadI64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadI64Data* function_data = static_cast<MonikerReadI64Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadI64Data* function_data = static_cast<MonikerReadI64Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+int64_t value {};
+    auto status = library->ReadI64(session, indicator, &value);
 
-  int64_t value{};
-  auto status = library->ReadI64(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadI64 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadI8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadI8Data* function_data = static_cast<MonikerReadI8Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadI8Data* function_data = static_cast<MonikerReadI8Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+int8_t value {};
+    auto status = library->ReadI8(session, indicator, &value);
 
-  int8_t value{};
-  auto status = library->ReadI8(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadI8 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadSgl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadSglData* function_data = static_cast<MonikerReadSglData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadSglData* function_data = static_cast<MonikerReadSglData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+float value {};
+    auto status = library->ReadSgl(session, indicator, &value);
 
-  float value{};
-  auto status = library->ReadSgl(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadSgl error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadU16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadU16Data* function_data = static_cast<MonikerReadU16Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadU16Data* function_data = static_cast<MonikerReadU16Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+uint16_t value {};
+    auto status = library->ReadU16(session, indicator, &value);
 
-  uint16_t value{};
-  auto status = library->ReadU16(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadU16 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadU32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadU32Data* function_data = static_cast<MonikerReadU32Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadU32Data* function_data = static_cast<MonikerReadU32Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+uint32_t value {};
+    auto status = library->ReadU32(session, indicator, &value);
 
-  uint32_t value{};
-  auto status = library->ReadU32(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadU32 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadU64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadU64Data* function_data = static_cast<MonikerReadU64Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadU64Data* function_data = static_cast<MonikerReadU64Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+uint64_t value {};
+    auto status = library->ReadU64(session, indicator, &value);
 
-  uint64_t value{};
-  auto status = library->ReadU64(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadU64 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadU8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerReadU8Data* function_data = static_cast<MonikerReadU8Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto indicator = function_data->indicator;
+    MonikerReadU8Data* function_data = static_cast<MonikerReadU8Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto indicator = function_data->indicator;
+        
+uint8_t value {};
+    auto status = library->ReadU8(session, indicator, &value);
 
-  uint8_t value{};
-  auto status = library->ReadU8(session, indicator, &value);
-  function_data->data.set_value(value);
-  if (status >= 0) {
-    packedData.PackFrom(function_data->data);
-  }
-
-  if (status < 0) {
-    std::cout << "MonikerReadU8 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+    */
+    if (status >= 0)
+    {
+      response->set_status(status);
+      response->set_value(value);
+      packedData.PackFrom(function_data->data);
+    }
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayBool(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayBoolData* function_data = static_cast<MonikerWriteArrayBoolData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteArrayBoolData* function_data = static_cast<MonikerWriteArrayBoolData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayBoolData arraybooldata_message;
+    packedData.UnpackTo(&arraybooldata_message);
+    
+    auto data_array = arraybooldata_message.value();
+    std::vector<NiFpga_Bool> array(data_array.begin(), data_array.end());
+    auto size = data_array.size();
 
-  ArrayBoolData arraybooldata_message;
-  packedData.UnpackTo(&arraybooldata_message);
-
-  auto data_array = arraybooldata_message.value();
-  std::vector<NiFpga_Bool> array(data_array.begin(), data_array.end());
-  auto size = data_array.size();
-
-  auto status = library->WriteArrayBool(session, control, array.data(), size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayBool error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayBool(session, control, array.data(), size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayDbl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayDblData* function_data = static_cast<MonikerWriteArrayDblData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteArrayDblData* function_data = static_cast<MonikerWriteArrayDblData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayDoubleData arraydoubledata_message;
+    packedData.UnpackTo(&arraydoubledata_message);
+    
+    auto data_array = arraydoubledata_message.value();
+    auto array = const_cast<double*>(arraydoubledata_message.value().data());
+    auto size = data_array.size();
 
-  ArrayDoubleData arraydoubledata_message;
-  packedData.UnpackTo(&arraydoubledata_message);
-
-  auto data_array = arraydoubledata_message.value();
-  auto array = const_cast<double*>(arraydoubledata_message.value().data());
-  auto size = data_array.size();
-
-  auto status = library->WriteArrayDbl(session, control, array, size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayDbl error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayDbl(session, control, array, size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayI16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayI16Data* function_data = static_cast<MonikerWriteArrayI16Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
-
-  ArrayI32Data arrayi32data_message;
-  packedData.UnpackTo(&arrayi32data_message);
-
-  auto data_array = arrayi32data_message.value();
-  auto array = std::vector<int16_t>();
-  auto size = data_array.size();
-  array.reserve(size);
-  std::transform(
+    MonikerWriteArrayI16Data* function_data = static_cast<MonikerWriteArrayI16Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayI32Data arrayi32data_message;
+    packedData.UnpackTo(&arrayi32data_message);
+    
+    auto data_array = arrayi32data_message.value();
+    auto array = std::vector<int16_t>();
+    auto size = data_array.size();
+    array.reserve(size);
+    std::transform(
       data_array.begin(),
       data_array.end(),
       std::back_inserter(array),
@@ -959,70 +1217,85 @@ void RegisterMonikerEndpoints()
         return static_cast<int16_t>(x);
       });
 
-  auto status = library->WriteArrayI16(session, control, array.data(), size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayI16 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayI16(session, control, array.data(), size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayI32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayI32Data* function_data = static_cast<MonikerWriteArrayI32Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteArrayI32Data* function_data = static_cast<MonikerWriteArrayI32Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayI32Data arrayi32data_message;
+    packedData.UnpackTo(&arrayi32data_message);
+    
+    auto data_array = arrayi32data_message.value();
+    auto array = const_cast<int32_t*>(arrayi32data_message.value().data());
+    auto size = data_array.size();
 
-  ArrayI32Data arrayi32data_message;
-  packedData.UnpackTo(&arrayi32data_message);
-
-  auto data_array = arrayi32data_message.value();
-  auto array = const_cast<int32_t*>(arrayi32data_message.value().data());
-  auto size = data_array.size();
-
-  auto status = library->WriteArrayI32(session, control, array, size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayI32 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayI32(session, control, array, size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayI64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayI64Data* function_data = static_cast<MonikerWriteArrayI64Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteArrayI64Data* function_data = static_cast<MonikerWriteArrayI64Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayI64Data arrayi64data_message;
+    packedData.UnpackTo(&arrayi64data_message);
+    
+    auto data_array = arrayi64data_message.value();
+    auto array = const_cast<int64_t*>(arrayi64data_message.value().data());
+    auto size = data_array.size();
 
-  ArrayI64Data arrayi64data_message;
-  packedData.UnpackTo(&arrayi64data_message);
-
-  auto data_array = arrayi64data_message.value();
-  auto array = const_cast<int64_t*>(arrayi64data_message.value().data());
-  auto size = data_array.size();
-
-  auto status = library->WriteArrayI64(session, control, array, size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayI64 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayI64(session, control, array, size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayI8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayI8Data* function_data = static_cast<MonikerWriteArrayI8Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
-
-  ArrayI32Data arrayi32data_message;
-  packedData.UnpackTo(&arrayi32data_message);
-
-  auto data_array = arrayi32data_message.value();
-  auto array = std::vector<int8_t>();
-  auto size = data_array.size();
-  array.reserve(size);
-  std::transform(
+    MonikerWriteArrayI8Data* function_data = static_cast<MonikerWriteArrayI8Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayI32Data arrayi32data_message;
+    packedData.UnpackTo(&arrayi32data_message);
+    
+    auto data_array = arrayi32data_message.value();
+    auto array = std::vector<int8_t>();
+    auto size = data_array.size();
+    array.reserve(size);
+    std::transform(
       data_array.begin(),
       data_array.end(),
       std::back_inserter(array),
@@ -1034,49 +1307,59 @@ void RegisterMonikerEndpoints()
         return static_cast<int8_t>(x);
       });
 
-  auto status = library->WriteArrayI8(session, control, array.data(), size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayI8 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayI8(session, control, array.data(), size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArraySgl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArraySglData* function_data = static_cast<MonikerWriteArraySglData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteArraySglData* function_data = static_cast<MonikerWriteArraySglData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayFloatData arrayfloatdata_message;
+    packedData.UnpackTo(&arrayfloatdata_message);
+    
+    auto data_array = arrayfloatdata_message.value();
+    auto array = const_cast<float*>(arrayfloatdata_message.value().data());
+    auto size = data_array.size();
 
-  ArrayFloatData arrayfloatdata_message;
-  packedData.UnpackTo(&arrayfloatdata_message);
-
-  auto data_array = arrayfloatdata_message.value();
-  auto array = const_cast<float*>(arrayfloatdata_message.value().data());
-  auto size = data_array.size();
-
-  auto status = library->WriteArraySgl(session, control, array, size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArraySgl error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArraySgl(session, control, array, size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayU16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayU16Data* function_data = static_cast<MonikerWriteArrayU16Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
-
-  ArrayU32Data arrayu32data_message;
-  packedData.UnpackTo(&arrayu32data_message);
-
-  auto data_array = arrayu32data_message.value();
-  auto array = std::vector<uint16_t>();
-  auto size = data_array.size();
-  array.reserve(size);
-  std::transform(
+    MonikerWriteArrayU16Data* function_data = static_cast<MonikerWriteArrayU16Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayU32Data arrayu32data_message;
+    packedData.UnpackTo(&arrayu32data_message);
+    
+    auto data_array = arrayu32data_message.value();
+    auto array = std::vector<uint16_t>();
+    auto size = data_array.size();
+    array.reserve(size);
+    std::transform(
       data_array.begin(),
       data_array.end(),
       std::back_inserter(array),
@@ -1088,70 +1371,85 @@ void RegisterMonikerEndpoints()
         return static_cast<uint16_t>(x);
       });
 
-  auto status = library->WriteArrayU16(session, control, array.data(), size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayU16 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayU16(session, control, array.data(), size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayU32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayU32Data* function_data = static_cast<MonikerWriteArrayU32Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteArrayU32Data* function_data = static_cast<MonikerWriteArrayU32Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayU32Data arrayu32data_message;
+    packedData.UnpackTo(&arrayu32data_message);
+    
+    auto data_array = arrayu32data_message.value();
+    auto array = const_cast<uint32_t*>(arrayu32data_message.value().data());
+    auto size = data_array.size();
 
-  ArrayU32Data arrayu32data_message;
-  packedData.UnpackTo(&arrayu32data_message);
-
-  auto data_array = arrayu32data_message.value();
-  auto array = const_cast<uint32_t*>(arrayu32data_message.value().data());
-  auto size = data_array.size();
-
-  auto status = library->WriteArrayU32(session, control, array, size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayU32 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayU32(session, control, array, size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayU64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayU64Data* function_data = static_cast<MonikerWriteArrayU64Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteArrayU64Data* function_data = static_cast<MonikerWriteArrayU64Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayU64Data arrayu64data_message;
+    packedData.UnpackTo(&arrayu64data_message);
+    
+    auto data_array = arrayu64data_message.value();
+    auto array = const_cast<uint64_t*>(arrayu64data_message.value().data());
+    auto size = data_array.size();
 
-  ArrayU64Data arrayu64data_message;
-  packedData.UnpackTo(&arrayu64data_message);
-
-  auto data_array = arrayu64data_message.value();
-  auto array = const_cast<uint64_t*>(arrayu64data_message.value().data());
-  auto size = data_array.size();
-
-  auto status = library->WriteArrayU64(session, control, array, size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayU64 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayU64(session, control, array, size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayU8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteArrayU8Data* function_data = static_cast<MonikerWriteArrayU8Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
-
-  ArrayU32Data arrayu32data_message;
-  packedData.UnpackTo(&arrayu32data_message);
-
-  auto data_array = arrayu32data_message.value();
-  auto array = std::vector<uint8_t>();
-  auto size = data_array.size();
-  array.reserve(size);
-  std::transform(
+    MonikerWriteArrayU8Data* function_data = static_cast<MonikerWriteArrayU8Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    ArrayU32Data arrayu32data_message;
+    packedData.UnpackTo(&arrayu32data_message);
+    
+    auto data_array = arrayu32data_message.value();
+    auto array = std::vector<uint8_t>();
+    auto size = data_array.size();
+    array.reserve(size);
+    std::transform(
       data_array.begin(),
       data_array.end(),
       std::back_inserter(array),
@@ -1163,4317 +1461,4379 @@ void RegisterMonikerEndpoints()
         return static_cast<uint8_t>(x);
       });
 
-  auto status = library->WriteArrayU8(session, control, array.data(), size);
-  if (status < 0) {
-    std::cout << "MonikerWriteArrayU8 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteArrayU8(session, control, array.data(), size);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteBool(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteBoolData* function_data = static_cast<MonikerWriteBoolData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteBoolData* function_data = static_cast<MonikerWriteBoolData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    BoolData booldata_message;
+    packedData.UnpackTo(&booldata_message);
+    auto value = booldata_message.value();
 
-  BoolData booldata_message;
-  packedData.UnpackTo(&booldata_message);
-  auto value = booldata_message.value();
-
-  auto status = library->WriteBool(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteBool error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteBool(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteDbl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteDblData* function_data = static_cast<MonikerWriteDblData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteDblData* function_data = static_cast<MonikerWriteDblData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    DoubleData doubledata_message;
+    packedData.UnpackTo(&doubledata_message);
+    auto value = doubledata_message.value();
 
-  DoubleData doubledata_message;
-  packedData.UnpackTo(&doubledata_message);
-  auto value = doubledata_message.value();
-
-  auto status = library->WriteDbl(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteDbl error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteDbl(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteI16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteI16Data* function_data = static_cast<MonikerWriteI16Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteI16Data* function_data = static_cast<MonikerWriteI16Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    I32Data i32data_message;
+    packedData.UnpackTo(&i32data_message);
+    auto value = i32data_message.value();
+    if (value < std::numeric_limits<int16_t>::min() || value > std::numeric_limits<int16_t>::max()) {
+      std::string message("value " + std::to_string(value) + " doesn't fit in datatype int16_t");
+      throw nidevice_grpc::ValueOutOfRangeException(message);
+    }
 
-  I32Data i32data_message;
-  packedData.UnpackTo(&i32data_message);
-  auto value = i32data_message.value();
-  if (value < std::numeric_limits<int16_t>::min() || value > std::numeric_limits<int16_t>::max()) {
-    std::string message("value " + std::to_string(value) + " doesn't fit in datatype int16_t");
-    throw nidevice_grpc::ValueOutOfRangeException(message);
-  }
-
-  auto status = library->WriteI16(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteI16 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteI16(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteI32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteI32Data* function_data = static_cast<MonikerWriteI32Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteI32Data* function_data = static_cast<MonikerWriteI32Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    I32Data i32data_message;
+    packedData.UnpackTo(&i32data_message);
+    auto value = i32data_message.value();
 
-  I32Data i32data_message;
-  packedData.UnpackTo(&i32data_message);
-  auto value = i32data_message.value();
-
-  auto status = library->WriteI32(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteI32 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteI32(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteI64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteI64Data* function_data = static_cast<MonikerWriteI64Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteI64Data* function_data = static_cast<MonikerWriteI64Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    I64Data i64data_message;
+    packedData.UnpackTo(&i64data_message);
+    auto value = i64data_message.value();
 
-  I64Data i64data_message;
-  packedData.UnpackTo(&i64data_message);
-  auto value = i64data_message.value();
-
-  auto status = library->WriteI64(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteI64 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteI64(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteI8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteI8Data* function_data = static_cast<MonikerWriteI8Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteI8Data* function_data = static_cast<MonikerWriteI8Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    I32Data i32data_message;
+    packedData.UnpackTo(&i32data_message);
+    auto value = i32data_message.value();
+    if (value < std::numeric_limits<int8_t>::min() || value > std::numeric_limits<int8_t>::max()) {
+      std::string message("value " + std::to_string(value) + " doesn't fit in datatype int8_t");
+      throw nidevice_grpc::ValueOutOfRangeException(message);
+    }
 
-  I32Data i32data_message;
-  packedData.UnpackTo(&i32data_message);
-  auto value = i32data_message.value();
-  if (value < std::numeric_limits<int8_t>::min() || value > std::numeric_limits<int8_t>::max()) {
-    std::string message("value " + std::to_string(value) + " doesn't fit in datatype int8_t");
-    throw nidevice_grpc::ValueOutOfRangeException(message);
-  }
-
-  auto status = library->WriteI8(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteI8 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteI8(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteSgl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteSglData* function_data = static_cast<MonikerWriteSglData*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteSglData* function_data = static_cast<MonikerWriteSglData*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    FloatData floatdata_message;
+    packedData.UnpackTo(&floatdata_message);
+    auto value = floatdata_message.value();
 
-  FloatData floatdata_message;
-  packedData.UnpackTo(&floatdata_message);
-  auto value = floatdata_message.value();
-
-  auto status = library->WriteSgl(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteSgl error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteSgl(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteU16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteU16Data* function_data = static_cast<MonikerWriteU16Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteU16Data* function_data = static_cast<MonikerWriteU16Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    U32Data u32data_message;
+    packedData.UnpackTo(&u32data_message);
+    auto value = u32data_message.value();
+    if (value < std::numeric_limits<uint16_t>::min() || value > std::numeric_limits<uint16_t>::max()) {
+      std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint16_t");
+      throw nidevice_grpc::ValueOutOfRangeException(message);
+    }
 
-  U32Data u32data_message;
-  packedData.UnpackTo(&u32data_message);
-  auto value = u32data_message.value();
-  if (value < std::numeric_limits<uint16_t>::min() || value > std::numeric_limits<uint16_t>::max()) {
-    std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint16_t");
-    throw nidevice_grpc::ValueOutOfRangeException(message);
-  }
-
-  auto status = library->WriteU16(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteU16 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteU16(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteU32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteU32Data* function_data = static_cast<MonikerWriteU32Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteU32Data* function_data = static_cast<MonikerWriteU32Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    U32Data u32data_message;
+    packedData.UnpackTo(&u32data_message);
+    auto value = u32data_message.value();
 
-  U32Data u32data_message;
-  packedData.UnpackTo(&u32data_message);
-  auto value = u32data_message.value();
-
-  auto status = library->WriteU32(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteU32 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteU32(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteU64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteU64Data* function_data = static_cast<MonikerWriteU64Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
+    MonikerWriteU64Data* function_data = static_cast<MonikerWriteU64Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    U64Data u64data_message;
+    packedData.UnpackTo(&u64data_message);
+    auto value = u64data_message.value();
 
-  U64Data u64data_message;
-  packedData.UnpackTo(&u64data_message);
-  auto value = u64data_message.value();
-
-  auto status = library->WriteU64(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteU64 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
+    auto status = library->WriteU64(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+    */
+    return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteU8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-  MonikerWriteU8Data* function_data = static_cast<MonikerWriteU8Data*>(data);
-  auto library = function_data->library;
-  auto session = function_data->session;
-  auto control = function_data->control;
-
-  U32Data u32data_message;
-  packedData.UnpackTo(&u32data_message);
-  auto value = u32data_message.value();
-  if (value < std::numeric_limits<uint8_t>::min() || value > std::numeric_limits<uint8_t>::max()) {
-    std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint8_t");
-    throw nidevice_grpc::ValueOutOfRangeException(message);
-  }
-
-  auto status = library->WriteU8(session, control, value);
-  if (status < 0) {
-    std::cout << "MonikerWriteU8 error: " << status << std::endl;
-  }
-  return ::grpc::Status::OK;
-}
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    auto status = library_->Abort(session);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    MonikerWriteU8Data* function_data = static_cast<MonikerWriteU8Data*>(data);
+    auto library = function_data->library;
+    auto response = function_data->data.mutable_response();    
+    auto session = function_data->session;
+    auto control = function_data->control;
+        
+    U32Data u32data_message;
+    packedData.UnpackTo(&u32data_message);
+    auto value = u32data_message.value();
+    if (value < std::numeric_limits<uint8_t>::min() || value > std::numeric_limits<uint8_t>::max()) {
+      std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint8_t");
+      throw nidevice_grpc::ValueOutOfRangeException(message);
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::AcknowledgeIrqs(::grpc::ServerContext* context, const AcknowledgeIrqsRequest* request, AcknowledgeIrqsResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t irqs = request->irqs();
-    auto status = library_->AcknowledgeIrqs(session, irqs);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t attribute;
-    switch (request->attribute_enum_case()) {
-      case nifpga_grpc::CloseRequest::AttributeEnumCase::kAttribute: {
-        attribute = static_cast<uint32_t>(request->attribute());
-        break;
+    auto status = library->WriteU8(session, control, value);
+    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
+    ::grpc::ServerContext* context = NULL;
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::CloseRequest::AttributeEnumCase::kAttributeRaw: {
-        attribute = static_cast<uint32_t>(request->attribute_raw());
-        break;
-      }
-      case nifpga_grpc::CloseRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
-        break;
-      }
-    }
-
-    session_repository_->remove_session(session_grpc_session.name());
-    auto status = library_->Close(session, attribute);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
+      response->set_status(status);
+    */
     return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
 }
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::CommitFifoConfiguration(::grpc::ServerContext* context, const CommitFifoConfigurationRequest* request, CommitFifoConfigurationResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto status = library_->CommitFifoConfiguration(session, fifo);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ConfigureFifo(::grpc::ServerContext* context, const ConfigureFifoRequest* request, ConfigureFifoResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t depth = request->depth();
-    auto status = library_->ConfigureFifo(session, fifo, depth);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ConfigureFifo2(::grpc::ServerContext* context, const ConfigureFifo2Request* request, ConfigureFifo2Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t requested_depth = request->requested_depth();
-    size_t actual_depth{};
-    auto status = library_->ConfigureFifo2(session, fifo, requested_depth, &actual_depth);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_actual_depth(actual_depth);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::Download(::grpc::ServerContext* context, const DownloadRequest* request, DownloadResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    auto status = library_->Download(session);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::FindFifo(::grpc::ServerContext* context, const FindFifoRequest* request, FindFifoResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    auto fifo_name_mbcs = convert_from_grpc<std::string>(request->fifo_name());
-    char* fifo_name = (char*)fifo_name_mbcs.c_str();
-    uint32_t fifo_number{};
-    auto status = library_->FindFifo(session, fifo_name, &fifo_number);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_fifo_number(fifo_number);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::FindRegister(::grpc::ServerContext* context, const FindRegisterRequest* request, FindRegisterResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    auto register_name_mbcs = convert_from_grpc<std::string>(request->register_name());
-    char* register_name = (char*)register_name_mbcs.c_str();
-    uint32_t register_offset{};
-    auto status = library_->FindRegister(session, register_name, &register_offset);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_register_offset(register_offset);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::GetBitfileSignature(::grpc::ServerContext* context, const GetBitfileSignatureRequest* request, GetBitfileSignatureResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t signature{};
-    size_t signature_size{};
-    auto status = library_->GetBitfileSignature(session, &signature, &signature_size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_signature(signature);
-    response->set_signature_size(signature_size);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::GetFifoPropertyI32(::grpc::ServerContext* context, const GetFifoPropertyI32Request* request, GetFifoPropertyI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    NiFpga_FifoProperty property;
-    switch (request->property_enum_case()) {
-      case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::kProperty: {
-        property = static_cast<NiFpga_FifoProperty>(request->property());
-        break;
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      auto status = library_->Abort(session);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::kPropertyRaw: {
-        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-        break;
-      }
-      case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-        break;
-      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-
-    int32_t value{};
-    auto status = library_->GetFifoPropertyI32(session, fifo, property, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::GetFifoPropertyI64(::grpc::ServerContext* context, const GetFifoPropertyI64Request* request, GetFifoPropertyI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    NiFpga_FifoProperty property;
-    switch (request->property_enum_case()) {
-      case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::kProperty: {
-        property = static_cast<NiFpga_FifoProperty>(request->property());
-        break;
-      }
-      case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::kPropertyRaw: {
-        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-        break;
-      }
-      case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-        break;
-      }
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::AcknowledgeIrqs(::grpc::ServerContext* context, const AcknowledgeIrqsRequest* request, AcknowledgeIrqsResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-
-    int64_t value{};
-    auto status = library_->GetFifoPropertyI64(session, fifo, property, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::GetFifoPropertyU32(::grpc::ServerContext* context, const GetFifoPropertyU32Request* request, GetFifoPropertyU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    NiFpga_FifoProperty property;
-    switch (request->property_enum_case()) {
-      case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::kProperty: {
-        property = static_cast<NiFpga_FifoProperty>(request->property());
-        break;
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t irqs = request->irqs();
+      auto status = library_->AcknowledgeIrqs(session, irqs);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::kPropertyRaw: {
-        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-        break;
-      }
-      case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-        break;
-      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-
-    uint32_t value{};
-    auto status = library_->GetFifoPropertyU32(session, fifo, property, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::GetFifoPropertyU64(::grpc::ServerContext* context, const GetFifoPropertyU64Request* request, GetFifoPropertyU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    NiFpga_FifoProperty property;
-    switch (request->property_enum_case()) {
-      case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::kProperty: {
-        property = static_cast<NiFpga_FifoProperty>(request->property());
-        break;
-      }
-      case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::kPropertyRaw: {
-        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-        break;
-      }
-      case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-        break;
-      }
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-
-    uint64_t value{};
-    auto status = library_->GetFifoPropertyU64(session, fifo, property, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::GetFpgaViState(::grpc::ServerContext* context, const GetFpgaViStateRequest* request, GetFpgaViStateResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t state{};
-    auto status = library_->GetFpgaViState(session, &state);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_state(static_cast<nifpga_grpc::FpgaViState>(state));
-    response->set_state_raw(state);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::Open(::grpc::ServerContext* context, const OpenRequest* request, OpenResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto bitfile_mbcs = convert_from_grpc<std::string>(request->bitfile());
-    char* bitfile = (char*)bitfile_mbcs.c_str();
-    auto signature_mbcs = convert_from_grpc<std::string>(request->signature());
-    char* signature = (char*)signature_mbcs.c_str();
-    auto resource_mbcs = convert_from_grpc<std::string>(request->resource());
-    char* resource = (char*)resource_mbcs.c_str();
-    uint32_t attribute;
-    switch (request->attribute_enum_case()) {
-      case nifpga_grpc::OpenRequest::AttributeEnumCase::kAttributeMapped: {
-        auto attribute_imap_it = openattribute_input_map_.find(request->attribute_mapped());
-        if (attribute_imap_it == openattribute_input_map_.end()) {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute_mapped was not specified or out of range.");
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t attribute;
+      switch (request->attribute_enum_case()) {
+        case nifpga_grpc::CloseRequest::AttributeEnumCase::kAttribute: {
+          attribute = static_cast<uint32_t>(request->attribute());
+          break;
         }
-        attribute = static_cast<uint32_t>(attribute_imap_it->second);
-        break;
+        case nifpga_grpc::CloseRequest::AttributeEnumCase::kAttributeRaw: {
+          attribute = static_cast<uint32_t>(request->attribute_raw());
+          break;
+        }
+        case nifpga_grpc::CloseRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
+          break;
+        }
       }
-      case nifpga_grpc::OpenRequest::AttributeEnumCase::kAttributeRaw: {
-        attribute = static_cast<uint32_t>(request->attribute_raw());
-        break;
+
+      session_repository_->remove_session(session_grpc_session.name());
+      auto status = library_->Close(session, attribute);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::OpenRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
-        break;
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::CommitFifoConfiguration(::grpc::ServerContext* context, const CommitFifoConfigurationRequest* request, CommitFifoConfigurationResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto status = library_->CommitFifoConfiguration(session, fifo);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-
-    auto initialization_behavior = request->initialization_behavior();
-
-    bool new_session_initialized{};
-    auto init_lambda = [&]() {
-      NiFpga_Session session;
-      auto status = library_->Open(bitfile, signature, resource, attribute, &session);
-      return std::make_tuple(status, session);
-    };
-    std::string grpc_device_session_name = request->session_name();
-    // Capture the library shared_ptr by value. Do not capture `this` or any references.
-    LibrarySharedPtr library = library_;
-    auto cleanup_lambda = [library](NiFpga_Session id) { library->Close(id, 0); };
-    int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, 0);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    response->mutable_session()->set_name(grpc_device_session_name);
-    response->set_new_session_initialized(new_session_initialized);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayBool(::grpc::ServerContext* context, const ReadArrayBoolRequest* request, ReadArrayBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
-    auto status = library_->ReadArrayBool(session, indicator, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ConfigureFifo(::grpc::ServerContext* context, const ConfigureFifoRequest* request, ConfigureFifoResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    convert_to_grpc(array, response->mutable_array());
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayBool(::grpc::ServerContext* context, const BeginReadArrayBoolRequest* request, BeginReadArrayBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayBoolData>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayBool", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayDbl(::grpc::ServerContext* context, const ReadArrayDblRequest* request, ReadArrayDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    response->mutable_array()->Resize(size, 0);
-    double* array = response->mutable_array()->mutable_data();
-    auto status = library_->ReadArrayDbl(session, indicator, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayDbl(::grpc::ServerContext* context, const BeginReadArrayDblRequest* request, BeginReadArrayDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayDblData>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayDbl", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayI16(::grpc::ServerContext* context, const ReadArrayI16Request* request, ReadArrayI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    std::vector<int16_t> array(size);
-    auto status = library_->ReadArrayI16(session, indicator, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->mutable_array()->Clear();
-    response->mutable_array()->Reserve(size);
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-        [&](auto x) {
-          return x;
-        });
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayI16(::grpc::ServerContext* context, const BeginReadArrayI16Request* request, BeginReadArrayI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayI16Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI16", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayI32(::grpc::ServerContext* context, const ReadArrayI32Request* request, ReadArrayI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    response->mutable_array()->Resize(size, 0);
-    int32_t* array = response->mutable_array()->mutable_data();
-    auto status = library_->ReadArrayI32(session, indicator, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayI32(::grpc::ServerContext* context, const BeginReadArrayI32Request* request, BeginReadArrayI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayI32Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI32", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayI64(::grpc::ServerContext* context, const ReadArrayI64Request* request, ReadArrayI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    response->mutable_array()->Resize(size, 0);
-    int64_t* array = response->mutable_array()->mutable_data();
-    auto status = library_->ReadArrayI64(session, indicator, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayI64(::grpc::ServerContext* context, const BeginReadArrayI64Request* request, BeginReadArrayI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayI64Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI64", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayI8(::grpc::ServerContext* context, const ReadArrayI8Request* request, ReadArrayI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    std::vector<int8_t> array(size);
-    auto status = library_->ReadArrayI8(session, indicator, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->mutable_array()->Clear();
-    response->mutable_array()->Reserve(size);
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-        [&](auto x) {
-          return x;
-        });
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayI8(::grpc::ServerContext* context, const BeginReadArrayI8Request* request, BeginReadArrayI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayI8Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI8", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArraySgl(::grpc::ServerContext* context, const ReadArraySglRequest* request, ReadArraySglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    response->mutable_array()->Resize(size, 0);
-    float* array = response->mutable_array()->mutable_data();
-    auto status = library_->ReadArraySgl(session, indicator, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArraySgl(::grpc::ServerContext* context, const BeginReadArraySglRequest* request, BeginReadArraySglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArraySglData>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArraySgl", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayU16(::grpc::ServerContext* context, const ReadArrayU16Request* request, ReadArrayU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    std::vector<uint16_t> array(size);
-    auto status = library_->ReadArrayU16(session, indicator, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->mutable_array()->Clear();
-    response->mutable_array()->Reserve(size);
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-        [&](auto x) {
-          return x;
-        });
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayU16(::grpc::ServerContext* context, const BeginReadArrayU16Request* request, BeginReadArrayU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayU16Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU16", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayU32(::grpc::ServerContext* context, const ReadArrayU32Request* request, ReadArrayU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    response->mutable_array()->Resize(size, 0);
-    uint32_t* array = response->mutable_array()->mutable_data();
-    auto status = library_->ReadArrayU32(session, indicator, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayU32(::grpc::ServerContext* context, const BeginReadArrayU32Request* request, BeginReadArrayU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayU32Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU32", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayU64(::grpc::ServerContext* context, const ReadArrayU64Request* request, ReadArrayU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    response->mutable_array()->Resize(size, 0);
-    uint64_t* array = response->mutable_array()->mutable_data();
-    auto status = library_->ReadArrayU64(session, indicator, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayU64(::grpc::ServerContext* context, const BeginReadArrayU64Request* request, BeginReadArrayU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayU64Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU64", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadArrayU8(::grpc::ServerContext* context, const ReadArrayU8Request* request, ReadArrayU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-    std::vector<uint8_t> array(size);
-    auto status = library_->ReadArrayU8(session, indicator, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->mutable_array()->Clear();
-    response->mutable_array()->Reserve(size);
-    std::transform(
-        array.begin(),
-        array.begin() + size,
-        google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-        [&](auto x) {
-          return x;
-        });
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadArrayU8(::grpc::ServerContext* context, const BeginReadArrayU8Request* request, BeginReadArrayU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    size_t size = request->size();
-
-    auto data = std::make_unique<MonikerReadArrayU8Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->size = size;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    data->data.mutable_value()->Reserve(request->size());
-    data->data.mutable_value()->Resize(request->size(), 0);
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU8", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadBool(::grpc::ServerContext* context, const ReadBoolRequest* request, ReadBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    NiFpga_Bool value{};
-    auto status = library_->ReadBool(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadBool(::grpc::ServerContext* context, const BeginReadBoolRequest* request, BeginReadBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadBoolData>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBool", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadDbl(::grpc::ServerContext* context, const ReadDblRequest* request, ReadDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    double value{};
-    auto status = library_->ReadDbl(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadDbl(::grpc::ServerContext* context, const BeginReadDblRequest* request, BeginReadDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadDblData>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDbl", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoBool(::grpc::ServerContext* context, const ReadFifoBoolRequest* request, ReadFifoBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    std::vector<NiFpga_Bool> data(number_of_elements, NiFpga_Bool());
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoBool(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    convert_to_grpc(data, response->mutable_data());
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoDbl(::grpc::ServerContext* context, const ReadFifoDblRequest* request, ReadFifoDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    response->mutable_data()->Resize(number_of_elements, 0);
-    double* data = response->mutable_data()->mutable_data();
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoDbl(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoI16(::grpc::ServerContext* context, const ReadFifoI16Request* request, ReadFifoI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    std::vector<int16_t> data(number_of_elements);
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoI16(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->mutable_data()->Clear();
-    response->mutable_data()->Reserve(number_of_elements);
-    std::transform(
-        data.begin(),
-        data.begin() + number_of_elements,
-        google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
-        [&](auto x) {
-          return x;
-        });
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoI32(::grpc::ServerContext* context, const ReadFifoI32Request* request, ReadFifoI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    response->mutable_data()->Resize(number_of_elements, 0);
-    int32_t* data = response->mutable_data()->mutable_data();
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoI32(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoI64(::grpc::ServerContext* context, const ReadFifoI64Request* request, ReadFifoI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    response->mutable_data()->Resize(number_of_elements, 0);
-    int64_t* data = response->mutable_data()->mutable_data();
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoI64(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoI8(::grpc::ServerContext* context, const ReadFifoI8Request* request, ReadFifoI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    std::vector<int8_t> data(number_of_elements);
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoI8(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->mutable_data()->Clear();
-    response->mutable_data()->Reserve(number_of_elements);
-    std::transform(
-        data.begin(),
-        data.begin() + number_of_elements,
-        google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
-        [&](auto x) {
-          return x;
-        });
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoSgl(::grpc::ServerContext* context, const ReadFifoSglRequest* request, ReadFifoSglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    response->mutable_data()->Resize(number_of_elements, 0);
-    float* data = response->mutable_data()->mutable_data();
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoSgl(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoU16(::grpc::ServerContext* context, const ReadFifoU16Request* request, ReadFifoU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    std::vector<uint16_t> data(number_of_elements);
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoU16(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->mutable_data()->Clear();
-    response->mutable_data()->Reserve(number_of_elements);
-    std::transform(
-        data.begin(),
-        data.begin() + number_of_elements,
-        google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
-        [&](auto x) {
-          return x;
-        });
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoU32(::grpc::ServerContext* context, const ReadFifoU32Request* request, ReadFifoU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    response->mutable_data()->Resize(number_of_elements, 0);
-    uint32_t* data = response->mutable_data()->mutable_data();
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoU32(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoU64(::grpc::ServerContext* context, const ReadFifoU64Request* request, ReadFifoU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    response->mutable_data()->Resize(number_of_elements, 0);
-    uint64_t* data = response->mutable_data()->mutable_data();
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoU64(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadFifoU8(::grpc::ServerContext* context, const ReadFifoU8Request* request, ReadFifoU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t number_of_elements = request->number_of_elements();
-    uint32_t timeout = request->timeout();
-    std::vector<uint8_t> data(number_of_elements);
-    size_t elements_remaining{};
-    auto status = library_->ReadFifoU8(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->mutable_data()->Clear();
-    response->mutable_data()->Reserve(number_of_elements);
-    std::transform(
-        data.begin(),
-        data.begin() + number_of_elements,
-        google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
-        [&](auto x) {
-          return x;
-        });
-    response->set_elements_remaining(elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadI16(::grpc::ServerContext* context, const ReadI16Request* request, ReadI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    int16_t value{};
-    auto status = library_->ReadI16(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadI16(::grpc::ServerContext* context, const BeginReadI16Request* request, BeginReadI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadI16Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI16", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadI32(::grpc::ServerContext* context, const ReadI32Request* request, ReadI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    int32_t value{};
-    auto status = library_->ReadI32(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadI32(::grpc::ServerContext* context, const BeginReadI32Request* request, BeginReadI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadI32Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI32", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadI64(::grpc::ServerContext* context, const ReadI64Request* request, ReadI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    int64_t value{};
-    auto status = library_->ReadI64(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadI64(::grpc::ServerContext* context, const BeginReadI64Request* request, BeginReadI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadI64Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI64", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadI8(::grpc::ServerContext* context, const ReadI8Request* request, ReadI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    int8_t value{};
-    auto status = library_->ReadI8(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadI8(::grpc::ServerContext* context, const BeginReadI8Request* request, BeginReadI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadI8Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI8", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadSgl(::grpc::ServerContext* context, const ReadSglRequest* request, ReadSglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    float value{};
-    auto status = library_->ReadSgl(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadSgl(::grpc::ServerContext* context, const BeginReadSglRequest* request, BeginReadSglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadSglData>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadSgl", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadU16(::grpc::ServerContext* context, const ReadU16Request* request, ReadU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    uint16_t value{};
-    auto status = library_->ReadU16(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadU16(::grpc::ServerContext* context, const BeginReadU16Request* request, BeginReadU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadU16Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU16", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadU32(::grpc::ServerContext* context, const ReadU32Request* request, ReadU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    uint32_t value{};
-    auto status = library_->ReadU32(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadU32(::grpc::ServerContext* context, const BeginReadU32Request* request, BeginReadU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadU32Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU32", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadU64(::grpc::ServerContext* context, const ReadU64Request* request, ReadU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    uint64_t value{};
-    auto status = library_->ReadU64(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadU64(::grpc::ServerContext* context, const BeginReadU64Request* request, BeginReadU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadU64Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU64", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReadU8(::grpc::ServerContext* context, const ReadU8Request* request, ReadU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-    uint8_t value{};
-    auto status = library_->ReadU8(session, indicator, &value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    response->set_value(value);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginReadU8(::grpc::ServerContext* context, const BeginReadU8Request* request, BeginReadU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t indicator = request->indicator();
-
-    auto data = std::make_unique<MonikerReadU8Data>();
-    data->session = session;
-    data->indicator = indicator;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU8", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::ReleaseFifoElements(::grpc::ServerContext* context, const ReleaseFifoElementsRequest* request, ReleaseFifoElementsResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    size_t elements = request->elements();
-    auto status = library_->ReleaseFifoElements(session, fifo, elements);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::Reset(::grpc::ServerContext* context, const ResetRequest* request, ResetResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    auto status = library_->Reset(session);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::Run(::grpc::ServerContext* context, const RunRequest* request, RunResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t attribute;
-    switch (request->attribute_enum_case()) {
-      case nifpga_grpc::RunRequest::AttributeEnumCase::kAttribute: {
-        attribute = static_cast<uint32_t>(request->attribute());
-        break;
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t depth = request->depth();
+      auto status = library_->ConfigureFifo(session, fifo, depth);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::RunRequest::AttributeEnumCase::kAttributeRaw: {
-        attribute = static_cast<uint32_t>(request->attribute_raw());
-        break;
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ConfigureFifo2(::grpc::ServerContext* context, const ConfigureFifo2Request* request, ConfigureFifo2Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t requested_depth = request->requested_depth();
+      size_t actual_depth {};
+      auto status = library_->ConfigureFifo2(session, fifo, requested_depth, &actual_depth);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::RunRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
-        break;
+      response->set_status(status);
+      response->set_actual_depth(actual_depth);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::Download(::grpc::ServerContext* context, const DownloadRequest* request, DownloadResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      auto status = library_->Download(session);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-
-    auto status = library_->Run(session, attribute);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::SetFifoPropertyI32(::grpc::ServerContext* context, const SetFifoPropertyI32Request* request, SetFifoPropertyI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    NiFpga_FifoProperty property;
-    switch (request->property_enum_case()) {
-      case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::kProperty: {
-        property = static_cast<NiFpga_FifoProperty>(request->property());
-        break;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::FindFifo(::grpc::ServerContext* context, const FindFifoRequest* request, FindFifoResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      auto fifo_name_mbcs = convert_from_grpc<std::string>(request->fifo_name());
+      char* fifo_name = (char*)fifo_name_mbcs.c_str();
+      uint32_t fifo_number {};
+      auto status = library_->FindFifo(session, fifo_name, &fifo_number);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::kPropertyRaw: {
-        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-        break;
+      response->set_status(status);
+      response->set_fifo_number(fifo_number);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::FindRegister(::grpc::ServerContext* context, const FindRegisterRequest* request, FindRegisterResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      auto register_name_mbcs = convert_from_grpc<std::string>(request->register_name());
+      char* register_name = (char*)register_name_mbcs.c_str();
+      uint32_t register_offset {};
+      auto status = library_->FindRegister(session, register_name, &register_offset);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-        break;
+      response->set_status(status);
+      response->set_register_offset(register_offset);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::GetBitfileSignature(::grpc::ServerContext* context, const GetBitfileSignatureRequest* request, GetBitfileSignatureResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t signature {};
+      size_t signature_size {};
+      auto status = library_->GetBitfileSignature(session, &signature, &signature_size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
+      response->set_status(status);
+      response->set_signature(signature);
+      response->set_signature_size(signature_size);
+      return ::grpc::Status::OK;
     }
-
-    int32_t value = request->value();
-    auto status = library_->SetFifoPropertyI32(session, fifo, property, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::SetFifoPropertyI64(::grpc::ServerContext* context, const SetFifoPropertyI64Request* request, SetFifoPropertyI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    NiFpga_FifoProperty property;
-    switch (request->property_enum_case()) {
-      case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::kProperty: {
-        property = static_cast<NiFpga_FifoProperty>(request->property());
-        break;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::GetFifoPropertyI32(::grpc::ServerContext* context, const GetFifoPropertyI32Request* request, GetFifoPropertyI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      NiFpga_FifoProperty property;
+      switch (request->property_enum_case()) {
+        case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::kProperty: {
+          property = static_cast<NiFpga_FifoProperty>(request->property());
+          break;
+        }
+        case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::kPropertyRaw: {
+          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+          break;
+        }
+        case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+          break;
+        }
       }
-      case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::kPropertyRaw: {
-        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-        break;
+
+      int32_t value {};
+      auto status = library_->GetFifoPropertyI32(session, fifo, property, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-        break;
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::GetFifoPropertyI64(::grpc::ServerContext* context, const GetFifoPropertyI64Request* request, GetFifoPropertyI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      NiFpga_FifoProperty property;
+      switch (request->property_enum_case()) {
+        case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::kProperty: {
+          property = static_cast<NiFpga_FifoProperty>(request->property());
+          break;
+        }
+        case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::kPropertyRaw: {
+          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+          break;
+        }
+        case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+          break;
+        }
       }
-    }
 
-    int64_t value = request->value();
-    auto status = library_->SetFifoPropertyI64(session, fifo, property, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-    }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::SetFifoPropertyU32(::grpc::ServerContext* context, const SetFifoPropertyU32Request* request, SetFifoPropertyU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    NiFpga_FifoProperty property;
-    switch (request->property_enum_case()) {
-      case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::kProperty: {
-        property = static_cast<NiFpga_FifoProperty>(request->property());
-        break;
+      int64_t value {};
+      auto status = library_->GetFifoPropertyI64(session, fifo, property, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::kPropertyRaw: {
-        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-        break;
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::GetFifoPropertyU32(::grpc::ServerContext* context, const GetFifoPropertyU32Request* request, GetFifoPropertyU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      NiFpga_FifoProperty property;
+      switch (request->property_enum_case()) {
+        case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::kProperty: {
+          property = static_cast<NiFpga_FifoProperty>(request->property());
+          break;
+        }
+        case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::kPropertyRaw: {
+          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+          break;
+        }
+        case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+          break;
+        }
       }
-      case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-        break;
+
+      uint32_t value {};
+      auto status = library_->GetFifoPropertyU32(session, fifo, property, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
     }
-
-    uint32_t value = request->value();
-    auto status = library_->SetFifoPropertyU32(session, fifo, property, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::SetFifoPropertyU64(::grpc::ServerContext* context, const SetFifoPropertyU64Request* request, SetFifoPropertyU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    NiFpga_FifoProperty property;
-    switch (request->property_enum_case()) {
-      case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::kProperty: {
-        property = static_cast<NiFpga_FifoProperty>(request->property());
-        break;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::GetFifoPropertyU64(::grpc::ServerContext* context, const GetFifoPropertyU64Request* request, GetFifoPropertyU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      NiFpga_FifoProperty property;
+      switch (request->property_enum_case()) {
+        case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::kProperty: {
+          property = static_cast<NiFpga_FifoProperty>(request->property());
+          break;
+        }
+        case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::kPropertyRaw: {
+          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+          break;
+        }
+        case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+          break;
+        }
       }
-      case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::kPropertyRaw: {
-        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-        break;
+
+      uint64_t value {};
+      auto status = library_->GetFifoPropertyU64(session, fifo, property, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
-      case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-        break;
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::GetFpgaViState(::grpc::ServerContext* context, const GetFpgaViStateRequest* request, GetFpgaViStateResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t state {};
+      auto status = library_->GetFpgaViState(session, &state);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
       }
+      response->set_status(status);
+      response->set_state(static_cast<nifpga_grpc::FpgaViState>(state));
+      response->set_state_raw(state);
+      return ::grpc::Status::OK;
     }
-
-    uint64_t value = request->value();
-    auto status = library_->SetFifoPropertyU64(session, fifo, property, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::StartFifo(::grpc::ServerContext* context, const StartFifoRequest* request, StartFifoResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto status = library_->StartFifo(session, fifo);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::Open(::grpc::ServerContext* context, const OpenRequest* request, OpenResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
+    try {
+      auto bitfile_mbcs = convert_from_grpc<std::string>(request->bitfile());
+      char* bitfile = (char*)bitfile_mbcs.c_str();
+      auto signature_mbcs = convert_from_grpc<std::string>(request->signature());
+      char* signature = (char*)signature_mbcs.c_str();
+      auto resource_mbcs = convert_from_grpc<std::string>(request->resource());
+      char* resource = (char*)resource_mbcs.c_str();
+      uint32_t attribute;
+      switch (request->attribute_enum_case()) {
+        case nifpga_grpc::OpenRequest::AttributeEnumCase::kAttributeMapped: {
+          auto attribute_imap_it = openattribute_input_map_.find(request->attribute_mapped());
+          if (attribute_imap_it == openattribute_input_map_.end()) {
+            return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute_mapped was not specified or out of range.");
+          }
+          attribute = static_cast<uint32_t>(attribute_imap_it->second);
+          break;
+        }
+        case nifpga_grpc::OpenRequest::AttributeEnumCase::kAttributeRaw: {
+          attribute = static_cast<uint32_t>(request->attribute_raw());
+          break;
+        }
+        case nifpga_grpc::OpenRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
+          break;
+        }
+      }
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::StopFifo(::grpc::ServerContext* context, const StopFifoRequest* request, StopFifoResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto status = library_->StopFifo(session, fifo);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      auto initialization_behavior = request->initialization_behavior();
+
+      bool new_session_initialized {};
+      auto init_lambda = [&] () {
+        NiFpga_Session session;
+        auto status = library_->Open(bitfile, signature, resource, attribute, &session);
+        return std::make_tuple(status, session);
+      };
+      std::string grpc_device_session_name = request->session_name();
+      // Capture the library shared_ptr by value. Do not capture `this` or any references.
+      LibrarySharedPtr library = library_;
+      auto cleanup_lambda = [library] (NiFpga_Session id) { library->Close(id, 0); };
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, 0);
+      }
+      response->set_status(status);
+      response->mutable_session()->set_name(grpc_device_session_name);
+      response->set_new_session_initialized(new_session_initialized);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::UnreserveFifo(::grpc::ServerContext* context, const UnreserveFifoRequest* request, UnreserveFifoResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto status = library_->UnreserveFifo(session, fifo);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WaitOnIrqs(::grpc::ServerContext* context, const WaitOnIrqsRequest* request, WaitOnIrqsResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t irqs = request->irqs();
-    uint32_t timeout = request->timeout();
-    NiFpga_IrqContext irq_context{};
-    uint32_t irqs_asserted{};
-    NiFpga_Bool timed_out{};
-    auto status = library_->WaitOnIrqs(session, &irq_context, irqs, timeout, &irqs_asserted, &timed_out);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayBool(::grpc::ServerContext* context, const ReadArrayBoolRequest* request, ReadArrayBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    response->set_irqs_asserted(irqs_asserted);
-    response->set_timed_out(timed_out);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayBool(::grpc::ServerContext* context, const WriteArrayBoolRequest* request, WriteArrayBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array = convert_from_grpc<NiFpga_Bool>(request->array());
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayBool(session, control, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
+      auto status = library_->ReadArrayBool(session, indicator, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      convert_to_grpc(array, response->mutable_array());
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayBool(::grpc::ServerContext* context, const BeginWriteArrayBoolRequest* request, BeginWriteArrayBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteArrayBoolData>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayBool", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayDbl(::grpc::ServerContext* context, const WriteArrayDblRequest* request, WriteArrayDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array = const_cast<double*>(request->array().data());
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayDbl(session, control, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayDbl(::grpc::ServerContext* context, const BeginWriteArrayDblRequest* request, BeginWriteArrayDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayBool(::grpc::ServerContext* context, const BeginReadArrayBoolRequest* request, BeginReadArrayBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
 
-    auto data = std::make_unique<MonikerWriteArrayDblData>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+      auto data = std::make_unique<MonikerReadArrayBoolData>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayDbl", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayBool", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayI16(::grpc::ServerContext* context, const WriteArrayI16Request* request, WriteArrayI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayDbl(::grpc::ServerContext* context, const ReadArrayDblRequest* request, ReadArrayDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      response->mutable_array()->Resize(size, 0);
+      double* array = response->mutable_array()->mutable_data();
+      auto status = library_->ReadArrayDbl(session, indicator, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array_raw = request->array();
-    auto array = std::vector<int16_t>();
-    array.reserve(array_raw.size());
-    std::transform(
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayDbl(::grpc::ServerContext* context, const BeginReadArrayDblRequest* request, BeginReadArrayDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayDblData>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayDbl", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayI16(::grpc::ServerContext* context, const ReadArrayI16Request* request, ReadArrayI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      std::vector<int16_t> array(size);
+      auto status = library_->ReadArrayI16(session, indicator, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayI16(::grpc::ServerContext* context, const BeginReadArrayI16Request* request, BeginReadArrayI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayI16Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI16", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayI32(::grpc::ServerContext* context, const ReadArrayI32Request* request, ReadArrayI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      response->mutable_array()->Resize(size, 0);
+      int32_t* array = response->mutable_array()->mutable_data();
+      auto status = library_->ReadArrayI32(session, indicator, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayI32(::grpc::ServerContext* context, const BeginReadArrayI32Request* request, BeginReadArrayI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayI32Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI32", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayI64(::grpc::ServerContext* context, const ReadArrayI64Request* request, ReadArrayI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      response->mutable_array()->Resize(size, 0);
+      int64_t* array = response->mutable_array()->mutable_data();
+      auto status = library_->ReadArrayI64(session, indicator, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayI64(::grpc::ServerContext* context, const BeginReadArrayI64Request* request, BeginReadArrayI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayI64Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI64", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayI8(::grpc::ServerContext* context, const ReadArrayI8Request* request, ReadArrayI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      std::vector<int8_t> array(size);
+      auto status = library_->ReadArrayI8(session, indicator, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayI8(::grpc::ServerContext* context, const BeginReadArrayI8Request* request, BeginReadArrayI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayI8Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI8", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArraySgl(::grpc::ServerContext* context, const ReadArraySglRequest* request, ReadArraySglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      response->mutable_array()->Resize(size, 0);
+      float* array = response->mutable_array()->mutable_data();
+      auto status = library_->ReadArraySgl(session, indicator, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArraySgl(::grpc::ServerContext* context, const BeginReadArraySglRequest* request, BeginReadArraySglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArraySglData>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArraySgl", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayU16(::grpc::ServerContext* context, const ReadArrayU16Request* request, ReadArrayU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      std::vector<uint16_t> array(size);
+      auto status = library_->ReadArrayU16(session, indicator, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayU16(::grpc::ServerContext* context, const BeginReadArrayU16Request* request, BeginReadArrayU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayU16Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU16", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayU32(::grpc::ServerContext* context, const ReadArrayU32Request* request, ReadArrayU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      response->mutable_array()->Resize(size, 0);
+      uint32_t* array = response->mutable_array()->mutable_data();
+      auto status = library_->ReadArrayU32(session, indicator, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayU32(::grpc::ServerContext* context, const BeginReadArrayU32Request* request, BeginReadArrayU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayU32Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU32", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayU64(::grpc::ServerContext* context, const ReadArrayU64Request* request, ReadArrayU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      response->mutable_array()->Resize(size, 0);
+      uint64_t* array = response->mutable_array()->mutable_data();
+      auto status = library_->ReadArrayU64(session, indicator, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayU64(::grpc::ServerContext* context, const BeginReadArrayU64Request* request, BeginReadArrayU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayU64Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU64", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadArrayU8(::grpc::ServerContext* context, const ReadArrayU8Request* request, ReadArrayU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+      std::vector<uint8_t> array(size);
+      auto status = library_->ReadArrayU8(session, indicator, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_array()->Clear();
+        response->mutable_array()->Reserve(size);
+        std::transform(
+          array.begin(),
+          array.begin() + size,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+          [&](auto x) {
+              return x;
+          });
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadArrayU8(::grpc::ServerContext* context, const BeginReadArrayU8Request* request, BeginReadArrayU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      size_t size = request->size();
+
+      auto data = std::make_unique<MonikerReadArrayU8Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->size = size;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      data->data.mutable_response()->mutable_array()->Reserve(request->size());
+      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU8", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadBool(::grpc::ServerContext* context, const ReadBoolRequest* request, ReadBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      NiFpga_Bool value {};
+      auto status = library_->ReadBool(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadBool(::grpc::ServerContext* context, const BeginReadBoolRequest* request, BeginReadBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadBoolData>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBool", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadDbl(::grpc::ServerContext* context, const ReadDblRequest* request, ReadDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      double value {};
+      auto status = library_->ReadDbl(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadDbl(::grpc::ServerContext* context, const BeginReadDblRequest* request, BeginReadDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadDblData>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDbl", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoBool(::grpc::ServerContext* context, const ReadFifoBoolRequest* request, ReadFifoBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      std::vector<NiFpga_Bool> data(number_of_elements, NiFpga_Bool());
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoBool(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      convert_to_grpc(data, response->mutable_data());
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoDbl(::grpc::ServerContext* context, const ReadFifoDblRequest* request, ReadFifoDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      response->mutable_data()->Resize(number_of_elements, 0);
+      double* data = response->mutable_data()->mutable_data();
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoDbl(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoI16(::grpc::ServerContext* context, const ReadFifoI16Request* request, ReadFifoI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      std::vector<int16_t> data(number_of_elements);
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoI16(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_data()->Clear();
+        response->mutable_data()->Reserve(number_of_elements);
+        std::transform(
+          data.begin(),
+          data.begin() + number_of_elements,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoI32(::grpc::ServerContext* context, const ReadFifoI32Request* request, ReadFifoI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      response->mutable_data()->Resize(number_of_elements, 0);
+      int32_t* data = response->mutable_data()->mutable_data();
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoI32(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoI64(::grpc::ServerContext* context, const ReadFifoI64Request* request, ReadFifoI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      response->mutable_data()->Resize(number_of_elements, 0);
+      int64_t* data = response->mutable_data()->mutable_data();
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoI64(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoI8(::grpc::ServerContext* context, const ReadFifoI8Request* request, ReadFifoI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      std::vector<int8_t> data(number_of_elements);
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoI8(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_data()->Clear();
+        response->mutable_data()->Reserve(number_of_elements);
+        std::transform(
+          data.begin(),
+          data.begin() + number_of_elements,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoSgl(::grpc::ServerContext* context, const ReadFifoSglRequest* request, ReadFifoSglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      response->mutable_data()->Resize(number_of_elements, 0);
+      float* data = response->mutable_data()->mutable_data();
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoSgl(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoU16(::grpc::ServerContext* context, const ReadFifoU16Request* request, ReadFifoU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      std::vector<uint16_t> data(number_of_elements);
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoU16(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_data()->Clear();
+        response->mutable_data()->Reserve(number_of_elements);
+        std::transform(
+          data.begin(),
+          data.begin() + number_of_elements,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoU32(::grpc::ServerContext* context, const ReadFifoU32Request* request, ReadFifoU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      response->mutable_data()->Resize(number_of_elements, 0);
+      uint32_t* data = response->mutable_data()->mutable_data();
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoU32(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoU64(::grpc::ServerContext* context, const ReadFifoU64Request* request, ReadFifoU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      response->mutable_data()->Resize(number_of_elements, 0);
+      uint64_t* data = response->mutable_data()->mutable_data();
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoU64(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadFifoU8(::grpc::ServerContext* context, const ReadFifoU8Request* request, ReadFifoU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t number_of_elements = request->number_of_elements();
+      uint32_t timeout = request->timeout();
+      std::vector<uint8_t> data(number_of_elements);
+      size_t elements_remaining {};
+      auto status = library_->ReadFifoU8(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+        response->mutable_data()->Clear();
+        response->mutable_data()->Reserve(number_of_elements);
+        std::transform(
+          data.begin(),
+          data.begin() + number_of_elements,
+          google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
+          [&](auto x) {
+              return x;
+          });
+      response->set_elements_remaining(elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadI16(::grpc::ServerContext* context, const ReadI16Request* request, ReadI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      int16_t value {};
+      auto status = library_->ReadI16(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadI16(::grpc::ServerContext* context, const BeginReadI16Request* request, BeginReadI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadI16Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI16", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadI32(::grpc::ServerContext* context, const ReadI32Request* request, ReadI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      int32_t value {};
+      auto status = library_->ReadI32(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadI32(::grpc::ServerContext* context, const BeginReadI32Request* request, BeginReadI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadI32Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI32", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadI64(::grpc::ServerContext* context, const ReadI64Request* request, ReadI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      int64_t value {};
+      auto status = library_->ReadI64(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadI64(::grpc::ServerContext* context, const BeginReadI64Request* request, BeginReadI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadI64Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI64", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadI8(::grpc::ServerContext* context, const ReadI8Request* request, ReadI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      int8_t value {};
+      auto status = library_->ReadI8(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadI8(::grpc::ServerContext* context, const BeginReadI8Request* request, BeginReadI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadI8Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI8", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadSgl(::grpc::ServerContext* context, const ReadSglRequest* request, ReadSglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      float value {};
+      auto status = library_->ReadSgl(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadSgl(::grpc::ServerContext* context, const BeginReadSglRequest* request, BeginReadSglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadSglData>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadSgl", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadU16(::grpc::ServerContext* context, const ReadU16Request* request, ReadU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      uint16_t value {};
+      auto status = library_->ReadU16(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadU16(::grpc::ServerContext* context, const BeginReadU16Request* request, BeginReadU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadU16Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU16", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadU32(::grpc::ServerContext* context, const ReadU32Request* request, ReadU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      uint32_t value {};
+      auto status = library_->ReadU32(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadU32(::grpc::ServerContext* context, const BeginReadU32Request* request, BeginReadU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadU32Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU32", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadU64(::grpc::ServerContext* context, const ReadU64Request* request, ReadU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      uint64_t value {};
+      auto status = library_->ReadU64(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadU64(::grpc::ServerContext* context, const BeginReadU64Request* request, BeginReadU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadU64Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU64", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReadU8(::grpc::ServerContext* context, const ReadU8Request* request, ReadU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+      uint8_t value {};
+      auto status = library_->ReadU8(session, indicator, &value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_value(value);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginReadU8(::grpc::ServerContext* context, const BeginReadU8Request* request, BeginReadU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t indicator = request->indicator();
+
+      auto data = std::make_unique<MonikerReadU8Data>();
+      data->session = session;
+      data->indicator = indicator;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU8", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::ReleaseFifoElements(::grpc::ServerContext* context, const ReleaseFifoElementsRequest* request, ReleaseFifoElementsResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      size_t elements = request->elements();
+      auto status = library_->ReleaseFifoElements(session, fifo, elements);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::Reset(::grpc::ServerContext* context, const ResetRequest* request, ResetResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      auto status = library_->Reset(session);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::Run(::grpc::ServerContext* context, const RunRequest* request, RunResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t attribute;
+      switch (request->attribute_enum_case()) {
+        case nifpga_grpc::RunRequest::AttributeEnumCase::kAttribute: {
+          attribute = static_cast<uint32_t>(request->attribute());
+          break;
+        }
+        case nifpga_grpc::RunRequest::AttributeEnumCase::kAttributeRaw: {
+          attribute = static_cast<uint32_t>(request->attribute_raw());
+          break;
+        }
+        case nifpga_grpc::RunRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->Run(session, attribute);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::SetFifoPropertyI32(::grpc::ServerContext* context, const SetFifoPropertyI32Request* request, SetFifoPropertyI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      NiFpga_FifoProperty property;
+      switch (request->property_enum_case()) {
+        case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::kProperty: {
+          property = static_cast<NiFpga_FifoProperty>(request->property());
+          break;
+        }
+        case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::kPropertyRaw: {
+          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+          break;
+        }
+        case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+          break;
+        }
+      }
+
+      int32_t value = request->value();
+      auto status = library_->SetFifoPropertyI32(session, fifo, property, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::SetFifoPropertyI64(::grpc::ServerContext* context, const SetFifoPropertyI64Request* request, SetFifoPropertyI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      NiFpga_FifoProperty property;
+      switch (request->property_enum_case()) {
+        case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::kProperty: {
+          property = static_cast<NiFpga_FifoProperty>(request->property());
+          break;
+        }
+        case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::kPropertyRaw: {
+          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+          break;
+        }
+        case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+          break;
+        }
+      }
+
+      int64_t value = request->value();
+      auto status = library_->SetFifoPropertyI64(session, fifo, property, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::SetFifoPropertyU32(::grpc::ServerContext* context, const SetFifoPropertyU32Request* request, SetFifoPropertyU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      NiFpga_FifoProperty property;
+      switch (request->property_enum_case()) {
+        case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::kProperty: {
+          property = static_cast<NiFpga_FifoProperty>(request->property());
+          break;
+        }
+        case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::kPropertyRaw: {
+          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+          break;
+        }
+        case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+          break;
+        }
+      }
+
+      uint32_t value = request->value();
+      auto status = library_->SetFifoPropertyU32(session, fifo, property, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::SetFifoPropertyU64(::grpc::ServerContext* context, const SetFifoPropertyU64Request* request, SetFifoPropertyU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      NiFpga_FifoProperty property;
+      switch (request->property_enum_case()) {
+        case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::kProperty: {
+          property = static_cast<NiFpga_FifoProperty>(request->property());
+          break;
+        }
+        case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::kPropertyRaw: {
+          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+          break;
+        }
+        case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+          break;
+        }
+      }
+
+      uint64_t value = request->value();
+      auto status = library_->SetFifoPropertyU64(session, fifo, property, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::StartFifo(::grpc::ServerContext* context, const StartFifoRequest* request, StartFifoResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto status = library_->StartFifo(session, fifo);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::StopFifo(::grpc::ServerContext* context, const StopFifoRequest* request, StopFifoResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto status = library_->StopFifo(session, fifo);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::UnreserveFifo(::grpc::ServerContext* context, const UnreserveFifoRequest* request, UnreserveFifoResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto status = library_->UnreserveFifo(session, fifo);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WaitOnIrqs(::grpc::ServerContext* context, const WaitOnIrqsRequest* request, WaitOnIrqsResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t irqs = request->irqs();
+      uint32_t timeout = request->timeout();
+      NiFpga_IrqContext irq_context {};
+      uint32_t irqs_asserted {};
+      NiFpga_Bool timed_out {};
+      auto status = library_->WaitOnIrqs(session, &irq_context, irqs, timeout, &irqs_asserted, &timed_out);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_irqs_asserted(irqs_asserted);
+      response->set_timed_out(timed_out);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayBool(::grpc::ServerContext* context, const WriteArrayBoolRequest* request, WriteArrayBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array = convert_from_grpc<NiFpga_Bool>(request->array());
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayBool(session, control, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayBool(::grpc::ServerContext* context, const BeginWriteArrayBoolRequest* request, BeginWriteArrayBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteArrayBoolData>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayBool", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayDbl(::grpc::ServerContext* context, const WriteArrayDblRequest* request, WriteArrayDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array = const_cast<double*>(request->array().data());
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayDbl(session, control, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayDbl(::grpc::ServerContext* context, const BeginWriteArrayDblRequest* request, BeginWriteArrayDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteArrayDblData>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayDbl", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayI16(::grpc::ServerContext* context, const WriteArrayI16Request* request, WriteArrayI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array_raw = request->array();
+      auto array = std::vector<int16_t>();
+      array.reserve(array_raw.size());
+      std::transform(
         array_raw.begin(),
         array_raw.end(),
         std::back_inserter(array),
         [](auto x) {
-          if (x < std::numeric_limits<int16_t>::min() || x > std::numeric_limits<int16_t>::max()) {
-            std::string message("value ");
-            message.append(std::to_string(x));
-            message.append(" doesn't fit in datatype ");
-            message.append("int16_t");
-            throw nidevice_grpc::ValueOutOfRangeException(message);
-          }
-          return static_cast<int16_t>(x);
+              if (x < std::numeric_limits<int16_t>::min() || x > std::numeric_limits<int16_t>::max()) {
+                  std::string message("value ");
+                  message.append(std::to_string(x));
+                  message.append(" doesn't fit in datatype ");
+                  message.append("int16_t");
+                  throw nidevice_grpc::ValueOutOfRangeException(message);
+              }
+              return static_cast<int16_t>(x);
         });
 
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayI16(session, control, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayI16(session, control, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayI16(::grpc::ServerContext* context, const BeginWriteArrayI16Request* request, BeginWriteArrayI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteArrayI16Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI16", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayI32(::grpc::ServerContext* context, const WriteArrayI32Request* request, WriteArrayI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array = const_cast<int32_t*>(request->array().data());
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayI32(session, control, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayI32(::grpc::ServerContext* context, const BeginWriteArrayI32Request* request, BeginWriteArrayI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteArrayI32Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI32", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayI64(::grpc::ServerContext* context, const WriteArrayI64Request* request, WriteArrayI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array = const_cast<int64_t*>(request->array().data());
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayI64(session, control, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayI16(::grpc::ServerContext* context, const BeginWriteArrayI16Request* request, BeginWriteArrayI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayI64(::grpc::ServerContext* context, const BeginWriteArrayI64Request* request, BeginWriteArrayI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
+      auto data = std::make_unique<MonikerWriteArrayI16Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-    auto data = std::make_unique<MonikerWriteArrayI64Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI16", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
 
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI64", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayI32(::grpc::ServerContext* context, const WriteArrayI32Request* request, WriteArrayI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array = const_cast<int32_t*>(request->array().data());
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayI32(session, control, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayI8(::grpc::ServerContext* context, const WriteArrayI8Request* request, WriteArrayI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayI32(::grpc::ServerContext* context, const BeginWriteArrayI32Request* request, BeginWriteArrayI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteArrayI32Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI32", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array_raw = request->array();
-    auto array = std::vector<int8_t>();
-    array.reserve(array_raw.size());
-    std::transform(
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayI64(::grpc::ServerContext* context, const WriteArrayI64Request* request, WriteArrayI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array = const_cast<int64_t*>(request->array().data());
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayI64(session, control, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayI64(::grpc::ServerContext* context, const BeginWriteArrayI64Request* request, BeginWriteArrayI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteArrayI64Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI64", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayI8(::grpc::ServerContext* context, const WriteArrayI8Request* request, WriteArrayI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array_raw = request->array();
+      auto array = std::vector<int8_t>();
+      array.reserve(array_raw.size());
+      std::transform(
         array_raw.begin(),
         array_raw.end(),
         std::back_inserter(array),
         [](auto x) {
-          if (x < std::numeric_limits<int8_t>::min() || x > std::numeric_limits<int8_t>::max()) {
-            std::string message("value ");
-            message.append(std::to_string(x));
-            message.append(" doesn't fit in datatype ");
-            message.append("int8_t");
-            throw nidevice_grpc::ValueOutOfRangeException(message);
-          }
-          return static_cast<int8_t>(x);
+              if (x < std::numeric_limits<int8_t>::min() || x > std::numeric_limits<int8_t>::max()) {
+                  std::string message("value ");
+                  message.append(std::to_string(x));
+                  message.append(" doesn't fit in datatype ");
+                  message.append("int8_t");
+                  throw nidevice_grpc::ValueOutOfRangeException(message);
+              }
+              return static_cast<int8_t>(x);
         });
 
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayI8(session, control, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayI8(session, control, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayI8(::grpc::ServerContext* context, const BeginWriteArrayI8Request* request, BeginWriteArrayI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteArrayI8Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI8", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArraySgl(::grpc::ServerContext* context, const WriteArraySglRequest* request, WriteArraySglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array = const_cast<float*>(request->array().data());
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArraySgl(session, control, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArraySgl(::grpc::ServerContext* context, const BeginWriteArraySglRequest* request, BeginWriteArraySglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayI8(::grpc::ServerContext* context, const BeginWriteArrayI8Request* request, BeginWriteArrayI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
 
-    auto data = std::make_unique<MonikerWriteArraySglData>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+      auto data = std::make_unique<MonikerWriteArrayI8Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArraySgl", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI8", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayU16(::grpc::ServerContext* context, const WriteArrayU16Request* request, WriteArrayU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArraySgl(::grpc::ServerContext* context, const WriteArraySglRequest* request, WriteArraySglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array = const_cast<float*>(request->array().data());
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArraySgl(session, control, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array_raw = request->array();
-    auto array = std::vector<uint16_t>();
-    array.reserve(array_raw.size());
-    std::transform(
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArraySgl(::grpc::ServerContext* context, const BeginWriteArraySglRequest* request, BeginWriteArraySglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteArraySglData>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArraySgl", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayU16(::grpc::ServerContext* context, const WriteArrayU16Request* request, WriteArrayU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array_raw = request->array();
+      auto array = std::vector<uint16_t>();
+      array.reserve(array_raw.size());
+      std::transform(
         array_raw.begin(),
         array_raw.end(),
         std::back_inserter(array),
         [](auto x) {
-          if (x < std::numeric_limits<uint16_t>::min() || x > std::numeric_limits<uint16_t>::max()) {
-            std::string message("value ");
-            message.append(std::to_string(x));
-            message.append(" doesn't fit in datatype ");
-            message.append("uint16_t");
-            throw nidevice_grpc::ValueOutOfRangeException(message);
-          }
-          return static_cast<uint16_t>(x);
+              if (x < std::numeric_limits<uint16_t>::min() || x > std::numeric_limits<uint16_t>::max()) {
+                  std::string message("value ");
+                  message.append(std::to_string(x));
+                  message.append(" doesn't fit in datatype ");
+                  message.append("uint16_t");
+                  throw nidevice_grpc::ValueOutOfRangeException(message);
+              }
+              return static_cast<uint16_t>(x);
         });
 
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayU16(session, control, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayU16(session, control, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayU16(::grpc::ServerContext* context, const BeginWriteArrayU16Request* request, BeginWriteArrayU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteArrayU16Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU16", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayU32(::grpc::ServerContext* context, const WriteArrayU32Request* request, WriteArrayU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array = const_cast<uint32_t*>(request->array().data());
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayU32(session, control, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayU32(::grpc::ServerContext* context, const BeginWriteArrayU32Request* request, BeginWriteArrayU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteArrayU32Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU32", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayU64(::grpc::ServerContext* context, const WriteArrayU64Request* request, WriteArrayU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array = const_cast<uint64_t*>(request->array().data());
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayU64(session, control, array, size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayU16(::grpc::ServerContext* context, const BeginWriteArrayU16Request* request, BeginWriteArrayU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayU64(::grpc::ServerContext* context, const BeginWriteArrayU64Request* request, BeginWriteArrayU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
+      auto data = std::make_unique<MonikerWriteArrayU16Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-    auto data = std::make_unique<MonikerWriteArrayU64Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU16", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
 
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU64", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayU32(::grpc::ServerContext* context, const WriteArrayU32Request* request, WriteArrayU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array = const_cast<uint32_t*>(request->array().data());
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayU32(session, control, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteArrayU8(::grpc::ServerContext* context, const WriteArrayU8Request* request, WriteArrayU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayU32(::grpc::ServerContext* context, const BeginWriteArrayU32Request* request, BeginWriteArrayU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteArrayU32Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU32", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto array_raw = request->array();
-    auto array = std::vector<uint8_t>();
-    array.reserve(array_raw.size());
-    std::transform(
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayU64(::grpc::ServerContext* context, const WriteArrayU64Request* request, WriteArrayU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array = const_cast<uint64_t*>(request->array().data());
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayU64(session, control, array, size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayU64(::grpc::ServerContext* context, const BeginWriteArrayU64Request* request, BeginWriteArrayU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteArrayU64Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU64", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteArrayU8(::grpc::ServerContext* context, const WriteArrayU8Request* request, WriteArrayU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto array_raw = request->array();
+      auto array = std::vector<uint8_t>();
+      array.reserve(array_raw.size());
+      std::transform(
         array_raw.begin(),
         array_raw.end(),
         std::back_inserter(array),
         [](auto x) {
-          if (x < std::numeric_limits<uint8_t>::min() || x > std::numeric_limits<uint8_t>::max()) {
-            std::string message("value ");
-            message.append(std::to_string(x));
-            message.append(" doesn't fit in datatype ");
-            message.append("uint8_t");
-            throw nidevice_grpc::ValueOutOfRangeException(message);
-          }
-          return static_cast<uint8_t>(x);
+              if (x < std::numeric_limits<uint8_t>::min() || x > std::numeric_limits<uint8_t>::max()) {
+                  std::string message("value ");
+                  message.append(std::to_string(x));
+                  message.append(" doesn't fit in datatype ");
+                  message.append("uint8_t");
+                  throw nidevice_grpc::ValueOutOfRangeException(message);
+              }
+              return static_cast<uint8_t>(x);
         });
 
-    size_t size = static_cast<size_t>(request->array().size());
-    auto status = library_->WriteArrayU8(session, control, array.data(), size);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      size_t size = static_cast<size_t>(request->array().size());
+      auto status = library_->WriteArrayU8(session, control, array.data(), size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteArrayU8(::grpc::ServerContext* context, const BeginWriteArrayU8Request* request, BeginWriteArrayU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteArrayU8Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU8", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteBool(::grpc::ServerContext* context, const WriteBoolRequest* request, WriteBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    NiFpga_Bool value = request->value();
-    auto status = library_->WriteBool(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteBool(::grpc::ServerContext* context, const BeginWriteBoolRequest* request, BeginWriteBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteBoolData>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBool", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteDbl(::grpc::ServerContext* context, const WriteDblRequest* request, WriteDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    double value = request->value();
-    auto status = library_->WriteDbl(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteArrayU8(::grpc::ServerContext* context, const BeginWriteArrayU8Request* request, BeginWriteArrayU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteDbl(::grpc::ServerContext* context, const BeginWriteDblRequest* request, BeginWriteDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
+      auto data = std::make_unique<MonikerWriteArrayU8Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-    auto data = std::make_unique<MonikerWriteDblData>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDbl", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoBool(::grpc::ServerContext* context, const WriteFifoBoolRequest* request, WriteFifoBoolResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data = convert_from_grpc<NiFpga_Bool>(request->data());
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoBool(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU8", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoDbl(::grpc::ServerContext* context, const WriteFifoDblRequest* request, WriteFifoDblResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data = const_cast<double*>(request->data().data());
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoDbl(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoI16(::grpc::ServerContext* context, const WriteFifoI16Request* request, WriteFifoI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteBool(::grpc::ServerContext* context, const WriteBoolRequest* request, WriteBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      NiFpga_Bool value = request->value();
+      auto status = library_->WriteBool(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data_raw = request->data();
-    auto data = std::vector<int16_t>();
-    data.reserve(data_raw.size());
-    std::transform(
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteBool(::grpc::ServerContext* context, const BeginWriteBoolRequest* request, BeginWriteBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteBoolData>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBool", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteDbl(::grpc::ServerContext* context, const WriteDblRequest* request, WriteDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      double value = request->value();
+      auto status = library_->WriteDbl(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteDbl(::grpc::ServerContext* context, const BeginWriteDblRequest* request, BeginWriteDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteDblData>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDbl", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoBool(::grpc::ServerContext* context, const WriteFifoBoolRequest* request, WriteFifoBoolResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data = convert_from_grpc<NiFpga_Bool>(request->data());
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoBool(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoDbl(::grpc::ServerContext* context, const WriteFifoDblRequest* request, WriteFifoDblResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data = const_cast<double*>(request->data().data());
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoDbl(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoI16(::grpc::ServerContext* context, const WriteFifoI16Request* request, WriteFifoI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data_raw = request->data();
+      auto data = std::vector<int16_t>();
+      data.reserve(data_raw.size());
+      std::transform(
         data_raw.begin(),
         data_raw.end(),
         std::back_inserter(data),
         [](auto x) {
-          if (x < std::numeric_limits<int16_t>::min() || x > std::numeric_limits<int16_t>::max()) {
-            std::string message("value ");
-            message.append(std::to_string(x));
-            message.append(" doesn't fit in datatype ");
-            message.append("int16_t");
-            throw nidevice_grpc::ValueOutOfRangeException(message);
-          }
-          return static_cast<int16_t>(x);
+              if (x < std::numeric_limits<int16_t>::min() || x > std::numeric_limits<int16_t>::max()) {
+                  std::string message("value ");
+                  message.append(std::to_string(x));
+                  message.append(" doesn't fit in datatype ");
+                  message.append("int16_t");
+                  throw nidevice_grpc::ValueOutOfRangeException(message);
+              }
+              return static_cast<int16_t>(x);
         });
 
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoI16(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoI16(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoI32(::grpc::ServerContext* context, const WriteFifoI32Request* request, WriteFifoI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data = const_cast<int32_t*>(request->data().data());
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoI32(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoI64(::grpc::ServerContext* context, const WriteFifoI64Request* request, WriteFifoI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data = const_cast<int64_t*>(request->data().data());
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoI64(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoI32(::grpc::ServerContext* context, const WriteFifoI32Request* request, WriteFifoI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data = const_cast<int32_t*>(request->data().data());
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoI32(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoI8(::grpc::ServerContext* context, const WriteFifoI8Request* request, WriteFifoI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoI64(::grpc::ServerContext* context, const WriteFifoI64Request* request, WriteFifoI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data = const_cast<int64_t*>(request->data().data());
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoI64(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data_raw = request->data();
-    auto data = std::vector<int8_t>();
-    data.reserve(data_raw.size());
-    std::transform(
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoI8(::grpc::ServerContext* context, const WriteFifoI8Request* request, WriteFifoI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data_raw = request->data();
+      auto data = std::vector<int8_t>();
+      data.reserve(data_raw.size());
+      std::transform(
         data_raw.begin(),
         data_raw.end(),
         std::back_inserter(data),
         [](auto x) {
-          if (x < std::numeric_limits<int8_t>::min() || x > std::numeric_limits<int8_t>::max()) {
-            std::string message("value ");
-            message.append(std::to_string(x));
-            message.append(" doesn't fit in datatype ");
-            message.append("int8_t");
-            throw nidevice_grpc::ValueOutOfRangeException(message);
-          }
-          return static_cast<int8_t>(x);
+              if (x < std::numeric_limits<int8_t>::min() || x > std::numeric_limits<int8_t>::max()) {
+                  std::string message("value ");
+                  message.append(std::to_string(x));
+                  message.append(" doesn't fit in datatype ");
+                  message.append("int8_t");
+                  throw nidevice_grpc::ValueOutOfRangeException(message);
+              }
+              return static_cast<int8_t>(x);
         });
 
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoI8(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoI8(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoSgl(::grpc::ServerContext* context, const WriteFifoSglRequest* request, WriteFifoSglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data = const_cast<float*>(request->data().data());
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoSgl(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoU16(::grpc::ServerContext* context, const WriteFifoU16Request* request, WriteFifoU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoSgl(::grpc::ServerContext* context, const WriteFifoSglRequest* request, WriteFifoSglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data = const_cast<float*>(request->data().data());
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoSgl(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data_raw = request->data();
-    auto data = std::vector<uint16_t>();
-    data.reserve(data_raw.size());
-    std::transform(
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoU16(::grpc::ServerContext* context, const WriteFifoU16Request* request, WriteFifoU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data_raw = request->data();
+      auto data = std::vector<uint16_t>();
+      data.reserve(data_raw.size());
+      std::transform(
         data_raw.begin(),
         data_raw.end(),
         std::back_inserter(data),
         [](auto x) {
-          if (x < std::numeric_limits<uint16_t>::min() || x > std::numeric_limits<uint16_t>::max()) {
-            std::string message("value ");
-            message.append(std::to_string(x));
-            message.append(" doesn't fit in datatype ");
-            message.append("uint16_t");
-            throw nidevice_grpc::ValueOutOfRangeException(message);
-          }
-          return static_cast<uint16_t>(x);
+              if (x < std::numeric_limits<uint16_t>::min() || x > std::numeric_limits<uint16_t>::max()) {
+                  std::string message("value ");
+                  message.append(std::to_string(x));
+                  message.append(" doesn't fit in datatype ");
+                  message.append("uint16_t");
+                  throw nidevice_grpc::ValueOutOfRangeException(message);
+              }
+              return static_cast<uint16_t>(x);
         });
 
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoU16(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoU16(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoU32(::grpc::ServerContext* context, const WriteFifoU32Request* request, WriteFifoU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data = const_cast<uint32_t*>(request->data().data());
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoU32(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoU64(::grpc::ServerContext* context, const WriteFifoU64Request* request, WriteFifoU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data = const_cast<uint64_t*>(request->data().data());
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoU64(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoU32(::grpc::ServerContext* context, const WriteFifoU32Request* request, WriteFifoU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data = const_cast<uint32_t*>(request->data().data());
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoU32(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteFifoU8(::grpc::ServerContext* context, const WriteFifoU8Request* request, WriteFifoU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoU64(::grpc::ServerContext* context, const WriteFifoU64Request* request, WriteFifoU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data = const_cast<uint64_t*>(request->data().data());
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoU64(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t fifo = request->fifo();
-    auto data_raw = request->data();
-    auto data = std::vector<uint8_t>();
-    data.reserve(data_raw.size());
-    std::transform(
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteFifoU8(::grpc::ServerContext* context, const WriteFifoU8Request* request, WriteFifoU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t fifo = request->fifo();
+      auto data_raw = request->data();
+      auto data = std::vector<uint8_t>();
+      data.reserve(data_raw.size());
+      std::transform(
         data_raw.begin(),
         data_raw.end(),
         std::back_inserter(data),
         [](auto x) {
-          if (x < std::numeric_limits<uint8_t>::min() || x > std::numeric_limits<uint8_t>::max()) {
-            std::string message("value ");
-            message.append(std::to_string(x));
-            message.append(" doesn't fit in datatype ");
-            message.append("uint8_t");
-            throw nidevice_grpc::ValueOutOfRangeException(message);
-          }
-          return static_cast<uint8_t>(x);
+              if (x < std::numeric_limits<uint8_t>::min() || x > std::numeric_limits<uint8_t>::max()) {
+                  std::string message("value ");
+                  message.append(std::to_string(x));
+                  message.append(" doesn't fit in datatype ");
+                  message.append("uint8_t");
+                  throw nidevice_grpc::ValueOutOfRangeException(message);
+              }
+              return static_cast<uint8_t>(x);
         });
 
-    size_t number_of_elements = static_cast<size_t>(request->data().size());
-    uint32_t timeout = request->timeout();
-    size_t empty_elements_remaining{};
-    auto status = library_->WriteFifoU8(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      size_t number_of_elements = static_cast<size_t>(request->data().size());
+      uint32_t timeout = request->timeout();
+      size_t empty_elements_remaining {};
+      auto status = library_->WriteFifoU8(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      response->set_empty_elements_remaining(empty_elements_remaining);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    response->set_empty_elements_remaining(empty_elements_remaining);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteI16(::grpc::ServerContext* context, const WriteI16Request* request, WriteI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto value_raw = request->value();
-    if (value_raw < std::numeric_limits<int16_t>::min() || value_raw > std::numeric_limits<int16_t>::max()) {
-      std::string message("value ");
-      message.append(std::to_string(value_raw));
-      message.append(" doesn't fit in datatype ");
-      message.append("int16_t");
-      throw nidevice_grpc::ValueOutOfRangeException(message);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    auto value = static_cast<int16_t>(value_raw);
+  }
 
-    auto status = library_->WriteI16(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteI16(::grpc::ServerContext* context, const WriteI16Request* request, WriteI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto value_raw = request->value();
+      if (value_raw < std::numeric_limits<int16_t>::min() || value_raw > std::numeric_limits<int16_t>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(value_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("int16_t");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+      auto value = static_cast<int16_t>(value_raw);
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteI16(::grpc::ServerContext* context, const BeginWriteI16Request* request, BeginWriteI16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteI16Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI16", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteI32(::grpc::ServerContext* context, const WriteI32Request* request, WriteI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    int32_t value = request->value();
-    auto status = library_->WriteI32(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      auto status = library_->WriteI16(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteI32(::grpc::ServerContext* context, const BeginWriteI32Request* request, BeginWriteI32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteI32Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI32", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteI64(::grpc::ServerContext* context, const WriteI64Request* request, WriteI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    int64_t value = request->value();
-    auto status = library_->WriteI64(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteI64(::grpc::ServerContext* context, const BeginWriteI64Request* request, BeginWriteI64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteI64Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI64", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteI8(::grpc::ServerContext* context, const WriteI8Request* request, WriteI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto value_raw = request->value();
-    if (value_raw < std::numeric_limits<int8_t>::min() || value_raw > std::numeric_limits<int8_t>::max()) {
-      std::string message("value ");
-      message.append(std::to_string(value_raw));
-      message.append(" doesn't fit in datatype ");
-      message.append("int8_t");
-      throw nidevice_grpc::ValueOutOfRangeException(message);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteI16(::grpc::ServerContext* context, const BeginWriteI16Request* request, BeginWriteI16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    auto value = static_cast<int8_t>(value_raw);
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
 
-    auto status = library_->WriteI8(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      auto data = std::make_unique<MonikerWriteI16Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI16", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteI8(::grpc::ServerContext* context, const BeginWriteI8Request* request, BeginWriteI8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteI8Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI8", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteSgl(::grpc::ServerContext* context, const WriteSglRequest* request, WriteSglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    float value = request->value();
-    auto status = library_->WriteSgl(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteSgl(::grpc::ServerContext* context, const BeginWriteSglRequest* request, BeginWriteSglResponse* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteSglData>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteSgl", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteU16(::grpc::ServerContext* context, const WriteU16Request* request, WriteU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto value_raw = request->value();
-    if (value_raw < std::numeric_limits<uint16_t>::min() || value_raw > std::numeric_limits<uint16_t>::max()) {
-      std::string message("value ");
-      message.append(std::to_string(value_raw));
-      message.append(" doesn't fit in datatype ");
-      message.append("uint16_t");
-      throw nidevice_grpc::ValueOutOfRangeException(message);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteI32(::grpc::ServerContext* context, const WriteI32Request* request, WriteI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    auto value = static_cast<uint16_t>(value_raw);
-
-    auto status = library_->WriteU16(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      int32_t value = request->value();
+      auto status = library_->WriteI32(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteU16(::grpc::ServerContext* context, const BeginWriteU16Request* request, BeginWriteU16Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteU16Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU16", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteU32(::grpc::ServerContext* context, const WriteU32Request* request, WriteU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    uint32_t value = request->value();
-    auto status = library_->WriteU32(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteU32(::grpc::ServerContext* context, const BeginWriteU32Request* request, BeginWriteU32Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-
-    auto data = std::make_unique<MonikerWriteU32Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU32", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteU64(::grpc::ServerContext* context, const WriteU64Request* request, WriteU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    uint64_t value = request->value();
-    auto status = library_->WriteU64(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteI32(::grpc::ServerContext* context, const BeginWriteI32Request* request, BeginWriteI32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteU64(::grpc::ServerContext* context, const BeginWriteU64Request* request, BeginWriteU64Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
+      auto data = std::make_unique<MonikerWriteI32Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-    auto data = std::make_unique<MonikerWriteU64Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU64", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
-
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::WriteU8(::grpc::ServerContext* context, const WriteU8Request* request, WriteU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
-    auto value_raw = request->value();
-    if (value_raw < std::numeric_limits<uint8_t>::min() || value_raw > std::numeric_limits<uint8_t>::max()) {
-      std::string message("value ");
-      message.append(std::to_string(value_raw));
-      message.append(" doesn't fit in datatype ");
-      message.append("uint8_t");
-      throw nidevice_grpc::ValueOutOfRangeException(message);
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI32", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
     }
-    auto value = static_cast<uint8_t>(value_raw);
-
-    auto status = library_->WriteU8(session, control, value);
-    if (!status_ok(status)) {
-      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
     }
-    response->set_status(status);
-    return ::grpc::Status::OK;
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-//---------------------------------------------------------------------
-//---------------------------------------------------------------------
-::grpc::Status NiFpgaService::BeginWriteU8(::grpc::ServerContext* context, const BeginWriteU8Request* request, BeginWriteU8Response* response)
-{
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteI64(::grpc::ServerContext* context, const WriteI64Request* request, WriteI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      int64_t value = request->value();
+      auto status = library_->WriteI64(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  try {
-    auto session_grpc_session = request->session();
-    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-    uint32_t control = request->control();
 
-    auto data = std::make_unique<MonikerWriteU8Data>();
-    data->session = session;
-    data->control = control;
-    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteI64(::grpc::ServerContext* context, const BeginWriteI64Request* request, BeginWriteI64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
 
-    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU8", data.release(), *moniker);
-    response->set_allocated_moniker(moniker.release());
-    response->set_status(0);
-    return ::grpc::Status::OK;
+      auto data = std::make_unique<MonikerWriteI64Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI64", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
   }
-  catch (nidevice_grpc::NonDriverException& ex) {
-    return ex.GetStatus();
-  }
-}
 
-NiFpgaFeatureToggles::NiFpgaFeatureToggles(
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteI8(::grpc::ServerContext* context, const WriteI8Request* request, WriteI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto value_raw = request->value();
+      if (value_raw < std::numeric_limits<int8_t>::min() || value_raw > std::numeric_limits<int8_t>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(value_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("int8_t");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+      auto value = static_cast<int8_t>(value_raw);
+
+      auto status = library_->WriteI8(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteI8(::grpc::ServerContext* context, const BeginWriteI8Request* request, BeginWriteI8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteI8Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI8", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteSgl(::grpc::ServerContext* context, const WriteSglRequest* request, WriteSglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      float value = request->value();
+      auto status = library_->WriteSgl(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteSgl(::grpc::ServerContext* context, const BeginWriteSglRequest* request, BeginWriteSglResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteSglData>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteSgl", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteU16(::grpc::ServerContext* context, const WriteU16Request* request, WriteU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto value_raw = request->value();
+      if (value_raw < std::numeric_limits<uint16_t>::min() || value_raw > std::numeric_limits<uint16_t>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(value_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("uint16_t");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+      auto value = static_cast<uint16_t>(value_raw);
+
+      auto status = library_->WriteU16(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteU16(::grpc::ServerContext* context, const BeginWriteU16Request* request, BeginWriteU16Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteU16Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU16", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteU32(::grpc::ServerContext* context, const WriteU32Request* request, WriteU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      uint32_t value = request->value();
+      auto status = library_->WriteU32(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteU32(::grpc::ServerContext* context, const BeginWriteU32Request* request, BeginWriteU32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteU32Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU32", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteU64(::grpc::ServerContext* context, const WriteU64Request* request, WriteU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      uint64_t value = request->value();
+      auto status = library_->WriteU64(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteU64(::grpc::ServerContext* context, const BeginWriteU64Request* request, BeginWriteU64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteU64Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU64", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::WriteU8(::grpc::ServerContext* context, const WriteU8Request* request, WriteU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+      auto value_raw = request->value();
+      if (value_raw < std::numeric_limits<uint8_t>::min() || value_raw > std::numeric_limits<uint8_t>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(value_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("uint8_t");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+      auto value = static_cast<uint8_t>(value_raw);
+
+      auto status = library_->WriteU8(session, control, value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFpgaService::BeginWriteU8(::grpc::ServerContext* context, const BeginWriteU8Request* request, BeginWriteU8Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+      uint32_t control = request->control();
+
+      auto data = std::make_unique<MonikerWriteU8Data>();
+      data->session = session;
+      data->control = control;
+      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU8", data.release(), *moniker);
+      response->set_allocated_moniker(moniker.release());
+      response->set_status(0);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+
+  NiFpgaFeatureToggles::NiFpgaFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-          feature_toggles.is_feature_enabled("nifpga", CodeReadiness::kRelease))
-{
-}
-}  // namespace nifpga_grpc
+        feature_toggles.is_feature_enabled("nifpga", CodeReadiness::kRelease))
+  {
+  }
+} // namespace nifpga_grpc
+

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -2292,8 +2292,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayBool", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2350,8 +2350,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayDbl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2416,8 +2416,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2474,8 +2474,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2532,8 +2532,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2598,8 +2598,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2656,8 +2656,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArraySgl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2722,8 +2722,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2780,8 +2780,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2838,8 +2838,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2904,8 +2904,8 @@ namespace nifpga_grpc {
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
 
-      data->mutable_response()->mutable_array()->Reserve(request->size());
-      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
+      data->response.mutable_array()->Reserve(request->size());
+      data->response.mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -1063,6 +1063,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayBool(session, control, array.data(), size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1083,6 +1087,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayDbl(session, control, array, size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1115,6 +1123,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayI16(session, control, array.data(), size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1135,6 +1147,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayI32(session, control, array, size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1155,6 +1171,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayI64(session, control, array, size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1187,6 +1207,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayI8(session, control, array.data(), size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1207,6 +1231,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArraySgl(session, control, array, size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1239,6 +1267,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayU16(session, control, array.data(), size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1259,6 +1291,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayU32(session, control, array, size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1279,6 +1315,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayU64(session, control, array, size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1311,6 +1351,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteArrayU8(session, control, array.data(), size);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1328,6 +1372,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteBool(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1345,6 +1393,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteDbl(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1366,6 +1418,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteI16(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1383,6 +1439,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteI32(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1400,6 +1460,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteI64(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1421,6 +1485,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteI8(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1438,6 +1506,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteSgl(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1459,6 +1531,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteU16(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1476,6 +1552,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteU32(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1493,6 +1573,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteU64(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1514,6 +1598,10 @@ namespace nifpga_grpc {
 
     auto status = library->WriteU8(session, control, value);
 
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
     return ::grpc::Status::OK;
 }
 

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -27,7 +27,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayBoolStreamingData data;
+     nifpga_grpc::ReadArrayBoolStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -36,7 +36,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayDblStreamingData data;
+     nifpga_grpc::ReadArrayDblStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -45,7 +45,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayI16StreamingData data;
+     nifpga_grpc::ReadArrayI16StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -54,7 +54,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayI32StreamingData data;
+     nifpga_grpc::ReadArrayI32StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -63,7 +63,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayI64StreamingData data;
+     nifpga_grpc::ReadArrayI64StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -72,7 +72,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayI8StreamingData data;
+     nifpga_grpc::ReadArrayI8StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -81,7 +81,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArraySglStreamingData data;
+     nifpga_grpc::ReadArraySglStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -90,7 +90,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayU16StreamingData data;
+     nifpga_grpc::ReadArrayU16StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -99,7 +99,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayU32StreamingData data;
+     nifpga_grpc::ReadArrayU32StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -108,7 +108,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayU64StreamingData data;
+     nifpga_grpc::ReadArrayU64StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -117,7 +117,7 @@ namespace nifpga_grpc {
      NiFpga_Session session;
      uint32_t indicator;
      size_t size;
-     nifpga_grpc::ReadArrayU8StreamingData data;
+     nifpga_grpc::ReadArrayU8StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -125,7 +125,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadBoolStreamingData data;
+     nifpga_grpc::ReadBoolStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -133,7 +133,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadDblStreamingData data;
+     nifpga_grpc::ReadDblStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -141,7 +141,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadI16StreamingData data;
+     nifpga_grpc::ReadI16StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -149,7 +149,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadI32StreamingData data;
+     nifpga_grpc::ReadI32StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -157,7 +157,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadI64StreamingData data;
+     nifpga_grpc::ReadI64StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -165,7 +165,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadI8StreamingData data;
+     nifpga_grpc::ReadI8StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -173,7 +173,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadSglStreamingData data;
+     nifpga_grpc::ReadSglStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -181,7 +181,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadU16StreamingData data;
+     nifpga_grpc::ReadU16StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -189,7 +189,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadU32StreamingData data;
+     nifpga_grpc::ReadU32StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -197,7 +197,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadU64StreamingData data;
+     nifpga_grpc::ReadU64StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -205,7 +205,7 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t indicator;
-     nifpga_grpc::ReadU8StreamingData data;
+     nifpga_grpc::ReadU8StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -213,7 +213,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayBoolStreamingData data;
+     nifpga_grpc::WriteArrayBoolStreamingRequest request;
+     nifpga_grpc::WriteArrayBoolStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -221,7 +222,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayDblStreamingData data;
+     nifpga_grpc::WriteArrayDblStreamingRequest request;
+     nifpga_grpc::WriteArrayDblStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -229,7 +231,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayI16StreamingData data;
+     nifpga_grpc::WriteArrayI16StreamingRequest request;
+     nifpga_grpc::WriteArrayI16StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -237,7 +240,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayI32StreamingData data;
+     nifpga_grpc::WriteArrayI32StreamingRequest request;
+     nifpga_grpc::WriteArrayI32StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -245,7 +249,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayI64StreamingData data;
+     nifpga_grpc::WriteArrayI64StreamingRequest request;
+     nifpga_grpc::WriteArrayI64StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -253,7 +258,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayI8StreamingData data;
+     nifpga_grpc::WriteArrayI8StreamingRequest request;
+     nifpga_grpc::WriteArrayI8StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -261,7 +267,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArraySglStreamingData data;
+     nifpga_grpc::WriteArraySglStreamingRequest request;
+     nifpga_grpc::WriteArraySglStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -269,7 +276,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayU16StreamingData data;
+     nifpga_grpc::WriteArrayU16StreamingRequest request;
+     nifpga_grpc::WriteArrayU16StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -277,7 +285,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayU32StreamingData data;
+     nifpga_grpc::WriteArrayU32StreamingRequest request;
+     nifpga_grpc::WriteArrayU32StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -285,7 +294,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayU64StreamingData data;
+     nifpga_grpc::WriteArrayU64StreamingRequest request;
+     nifpga_grpc::WriteArrayU64StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -293,7 +303,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteArrayU8StreamingData data;
+     nifpga_grpc::WriteArrayU8StreamingRequest request;
+     nifpga_grpc::WriteArrayU8StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -301,7 +312,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteBoolStreamingData data;
+     nifpga_grpc::WriteBoolStreamingRequest request;
+     nifpga_grpc::WriteBoolStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -309,7 +321,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteDblStreamingData data;
+     nifpga_grpc::WriteDblStreamingRequest request;
+     nifpga_grpc::WriteDblStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -317,7 +330,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteI16StreamingData data;
+     nifpga_grpc::WriteI16StreamingRequest request;
+     nifpga_grpc::WriteI16StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -325,7 +339,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteI32StreamingData data;
+     nifpga_grpc::WriteI32StreamingRequest request;
+     nifpga_grpc::WriteI32StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -333,7 +348,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteI64StreamingData data;
+     nifpga_grpc::WriteI64StreamingRequest request;
+     nifpga_grpc::WriteI64StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -341,7 +357,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteI8StreamingData data;
+     nifpga_grpc::WriteI8StreamingRequest request;
+     nifpga_grpc::WriteI8StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -349,7 +366,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteSglStreamingData data;
+     nifpga_grpc::WriteSglStreamingRequest request;
+     nifpga_grpc::WriteSglStreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -357,7 +375,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteU16StreamingData data;
+     nifpga_grpc::WriteU16StreamingRequest request;
+     nifpga_grpc::WriteU16StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -365,7 +384,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteU32StreamingData data;
+     nifpga_grpc::WriteU32StreamingRequest request;
+     nifpga_grpc::WriteU32StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -373,7 +393,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteU64StreamingData data;
+     nifpga_grpc::WriteU64StreamingRequest request;
+     nifpga_grpc::WriteU64StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 
@@ -381,7 +402,8 @@ namespace nifpga_grpc {
   {
      NiFpga_Session session;
      uint32_t control;
-     nifpga_grpc::WriteU8StreamingData data;
+     nifpga_grpc::WriteU8StreamingRequest request;
+     nifpga_grpc::WriteU8StreamingResponse response;
      std::shared_ptr<NiFpgaLibraryInterface> library;
   };
 

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -457,7 +457,7 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayBoolData* function_data = static_cast<MonikerReadArrayBoolData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
@@ -479,6 +479,11 @@ namespace nifpga_grpc {
       convert_to_grpc(array, response->mutable_array());
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -486,12 +491,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayDblData* function_data = static_cast<MonikerReadArrayDblData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    function_data->data.mutable_array()->Resize(size, 0);
+    response->mutable_array()->Resize(size, 0);
     auto array = response->mutable_array()->mutable_data();
     auto status = library->ReadArrayDbl(session, indicator, array, size);
 
@@ -507,6 +512,11 @@ namespace nifpga_grpc {
       response->set_status(status);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -514,7 +524,7 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayI16Data* function_data = static_cast<MonikerReadArrayI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
@@ -552,6 +562,11 @@ namespace nifpga_grpc {
           });
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -559,12 +574,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayI32Data* function_data = static_cast<MonikerReadArrayI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    function_data->data.mutable_array()->Resize(size, 0);
+    response->mutable_array()->Resize(size, 0);
     auto array = response->mutable_array()->mutable_data();
     auto status = library->ReadArrayI32(session, indicator, array, size);
 
@@ -580,6 +595,11 @@ namespace nifpga_grpc {
       response->set_status(status);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -587,12 +607,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayI64Data* function_data = static_cast<MonikerReadArrayI64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    function_data->data.mutable_array()->Resize(size, 0);
+    response->mutable_array()->Resize(size, 0);
     auto array = response->mutable_array()->mutable_data();
     auto status = library->ReadArrayI64(session, indicator, array, size);
 
@@ -608,6 +628,11 @@ namespace nifpga_grpc {
       response->set_status(status);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -615,7 +640,7 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayI8Data* function_data = static_cast<MonikerReadArrayI8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
@@ -653,6 +678,11 @@ namespace nifpga_grpc {
           });
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -660,12 +690,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArraySglData* function_data = static_cast<MonikerReadArraySglData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    function_data->data.mutable_array()->Resize(size, 0);
+    response->mutable_array()->Resize(size, 0);
     auto array = response->mutable_array()->mutable_data();
     auto status = library->ReadArraySgl(session, indicator, array, size);
 
@@ -681,6 +711,11 @@ namespace nifpga_grpc {
       response->set_status(status);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -688,7 +723,7 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayU16Data* function_data = static_cast<MonikerReadArrayU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
@@ -726,6 +761,11 @@ namespace nifpga_grpc {
           });
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -733,12 +773,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayU32Data* function_data = static_cast<MonikerReadArrayU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    function_data->data.mutable_array()->Resize(size, 0);
+    response->mutable_array()->Resize(size, 0);
     auto array = response->mutable_array()->mutable_data();
     auto status = library->ReadArrayU32(session, indicator, array, size);
 
@@ -754,6 +794,11 @@ namespace nifpga_grpc {
       response->set_status(status);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -761,12 +806,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayU64Data* function_data = static_cast<MonikerReadArrayU64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
         
-    function_data->data.mutable_array()->Resize(size, 0);
+    response->mutable_array()->Resize(size, 0);
     auto array = response->mutable_array()->mutable_data();
     auto status = library->ReadArrayU64(session, indicator, array, size);
 
@@ -782,6 +827,11 @@ namespace nifpga_grpc {
       response->set_status(status);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -789,7 +839,7 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayU8Data* function_data = static_cast<MonikerReadArrayU8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
@@ -827,6 +877,11 @@ namespace nifpga_grpc {
           });
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -834,7 +889,7 @@ namespace nifpga_grpc {
 {
     MonikerReadBoolData* function_data = static_cast<MonikerReadBoolData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -855,6 +910,11 @@ NiFpga_Bool value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -862,7 +922,7 @@ NiFpga_Bool value {};
 {
     MonikerReadDblData* function_data = static_cast<MonikerReadDblData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -883,6 +943,11 @@ double value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -890,7 +955,7 @@ double value {};
 {
     MonikerReadI16Data* function_data = static_cast<MonikerReadI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -911,6 +976,11 @@ int16_t value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -918,7 +988,7 @@ int16_t value {};
 {
     MonikerReadI32Data* function_data = static_cast<MonikerReadI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -939,6 +1009,11 @@ int32_t value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -946,7 +1021,7 @@ int32_t value {};
 {
     MonikerReadI64Data* function_data = static_cast<MonikerReadI64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -967,6 +1042,11 @@ int64_t value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -974,7 +1054,7 @@ int64_t value {};
 {
     MonikerReadI8Data* function_data = static_cast<MonikerReadI8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -995,6 +1075,11 @@ int8_t value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1002,7 +1087,7 @@ int8_t value {};
 {
     MonikerReadSglData* function_data = static_cast<MonikerReadSglData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -1023,6 +1108,11 @@ float value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1030,7 +1120,7 @@ float value {};
 {
     MonikerReadU16Data* function_data = static_cast<MonikerReadU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -1051,6 +1141,11 @@ uint16_t value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1058,7 +1153,7 @@ uint16_t value {};
 {
     MonikerReadU32Data* function_data = static_cast<MonikerReadU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -1079,6 +1174,11 @@ uint32_t value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1086,7 +1186,7 @@ uint32_t value {};
 {
     MonikerReadU64Data* function_data = static_cast<MonikerReadU64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -1107,6 +1207,11 @@ uint64_t value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1114,7 +1219,7 @@ uint64_t value {};
 {
     MonikerReadU8Data* function_data = static_cast<MonikerReadU8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto indicator = function_data->indicator;
         
@@ -1135,6 +1240,11 @@ uint8_t value {};
       response->set_value(value);
       packedData.PackFrom(function_data->data);
     }
+    else
+    {
+      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+    }
     return ::grpc::Status::OK;
 }
 
@@ -1142,7 +1252,7 @@ uint8_t value {};
 {
     MonikerWriteArrayBoolData* function_data = static_cast<MonikerWriteArrayBoolData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1168,7 +1278,7 @@ uint8_t value {};
 {
     MonikerWriteArrayDblData* function_data = static_cast<MonikerWriteArrayDblData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1194,7 +1304,7 @@ uint8_t value {};
 {
     MonikerWriteArrayI16Data* function_data = static_cast<MonikerWriteArrayI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1232,7 +1342,7 @@ uint8_t value {};
 {
     MonikerWriteArrayI32Data* function_data = static_cast<MonikerWriteArrayI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1258,7 +1368,7 @@ uint8_t value {};
 {
     MonikerWriteArrayI64Data* function_data = static_cast<MonikerWriteArrayI64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1284,7 +1394,7 @@ uint8_t value {};
 {
     MonikerWriteArrayI8Data* function_data = static_cast<MonikerWriteArrayI8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1322,7 +1432,7 @@ uint8_t value {};
 {
     MonikerWriteArraySglData* function_data = static_cast<MonikerWriteArraySglData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1348,7 +1458,7 @@ uint8_t value {};
 {
     MonikerWriteArrayU16Data* function_data = static_cast<MonikerWriteArrayU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1386,7 +1496,7 @@ uint8_t value {};
 {
     MonikerWriteArrayU32Data* function_data = static_cast<MonikerWriteArrayU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1412,7 +1522,7 @@ uint8_t value {};
 {
     MonikerWriteArrayU64Data* function_data = static_cast<MonikerWriteArrayU64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1438,7 +1548,7 @@ uint8_t value {};
 {
     MonikerWriteArrayU8Data* function_data = static_cast<MonikerWriteArrayU8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1476,7 +1586,7 @@ uint8_t value {};
 {
     MonikerWriteBoolData* function_data = static_cast<MonikerWriteBoolData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1499,7 +1609,7 @@ uint8_t value {};
 {
     MonikerWriteDblData* function_data = static_cast<MonikerWriteDblData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1522,7 +1632,7 @@ uint8_t value {};
 {
     MonikerWriteI16Data* function_data = static_cast<MonikerWriteI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1549,7 +1659,7 @@ uint8_t value {};
 {
     MonikerWriteI32Data* function_data = static_cast<MonikerWriteI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1572,7 +1682,7 @@ uint8_t value {};
 {
     MonikerWriteI64Data* function_data = static_cast<MonikerWriteI64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1595,7 +1705,7 @@ uint8_t value {};
 {
     MonikerWriteI8Data* function_data = static_cast<MonikerWriteI8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1622,7 +1732,7 @@ uint8_t value {};
 {
     MonikerWriteSglData* function_data = static_cast<MonikerWriteSglData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1645,7 +1755,7 @@ uint8_t value {};
 {
     MonikerWriteU16Data* function_data = static_cast<MonikerWriteU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1672,7 +1782,7 @@ uint8_t value {};
 {
     MonikerWriteU32Data* function_data = static_cast<MonikerWriteU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1695,7 +1805,7 @@ uint8_t value {};
 {
     MonikerWriteU64Data* function_data = static_cast<MonikerWriteU64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -1718,7 +1828,7 @@ uint8_t value {};
 {
     MonikerWriteU8Data* function_data = static_cast<MonikerWriteU8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();    
+    auto response = function_data->data.mutable_response();
     auto session = function_data->session;
     auto control = function_data->control;
         
@@ -2287,11 +2397,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayBoolData>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2345,11 +2455,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayDblData>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2411,11 +2521,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayI16Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2469,11 +2579,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayI32Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2527,11 +2637,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayI64Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2593,11 +2703,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayI8Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2651,11 +2761,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArraySglData>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2717,11 +2827,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayU16Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2775,11 +2885,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayU32Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2833,11 +2943,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayU64Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2899,11 +3009,11 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayU8Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       data->data.mutable_response()->mutable_array()->Reserve(request->size());
       data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
@@ -2955,10 +3065,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadBoolData>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBool", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3008,10 +3118,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadDblData>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDbl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3412,10 +3522,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadI16Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3465,10 +3575,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadI32Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3518,10 +3628,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadI64Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3571,10 +3681,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadI8Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3624,10 +3734,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadSglData>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadSgl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3677,10 +3787,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadU16Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3730,10 +3840,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadU32Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3783,10 +3893,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadU64Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3836,10 +3946,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadU8Data>();
-      data->session = session;
+            data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4231,10 +4341,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayBoolData>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayBool", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4284,10 +4394,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayDblData>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayDbl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4354,10 +4464,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayI16Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4407,10 +4517,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayI32Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4460,10 +4570,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayI64Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4530,10 +4640,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayI8Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4583,10 +4693,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArraySglData>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArraySgl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4653,10 +4763,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayU16Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4706,10 +4816,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayU32Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4759,10 +4869,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayU64Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4829,10 +4939,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayU8Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4881,10 +4991,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteBoolData>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBool", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4933,10 +5043,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteDblData>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDbl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5370,10 +5480,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteI16Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5422,10 +5532,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteI32Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5474,10 +5584,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteI64Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5535,10 +5645,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteI8Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5587,10 +5697,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteSglData>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteSgl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5648,10 +5758,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteU16Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5700,10 +5810,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteU32Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5752,10 +5862,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteU64Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5813,10 +5923,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteU8Data>();
-      data->session = session;
+            data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-
+      
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -487,14 +487,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayBool(session, indicator, array.data(), size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      convert_to_grpc(array, response->mutable_array());
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -503,7 +495,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -522,13 +514,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayDbl(session, indicator, array, size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -536,7 +521,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -554,22 +539,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayI16(session, indicator, array.data(), size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_array()->Clear();
-        response->mutable_array()->Reserve(size);
-        std::transform(
-          array.begin(),
-          array.begin() + size,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-          [&](auto x) {
-              return x;
-          });
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -586,7 +555,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -605,13 +574,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayI32(session, indicator, array, size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -619,7 +581,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -638,13 +600,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayI64(session, indicator, array, size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -652,7 +607,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -670,22 +625,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayI8(session, indicator, array.data(), size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_array()->Clear();
-        response->mutable_array()->Reserve(size);
-        std::transform(
-          array.begin(),
-          array.begin() + size,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-          [&](auto x) {
-              return x;
-          });
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -702,7 +641,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -721,13 +660,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArraySgl(session, indicator, array, size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -735,7 +667,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -753,22 +685,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayU16(session, indicator, array.data(), size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_array()->Clear();
-        response->mutable_array()->Reserve(size);
-        std::transform(
-          array.begin(),
-          array.begin() + size,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-          [&](auto x) {
-              return x;
-          });
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -785,7 +701,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -804,13 +720,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayU32(session, indicator, array, size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -818,7 +727,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -837,13 +746,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayU64(session, indicator, array, size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -851,7 +753,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -869,22 +771,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadArrayU8(session, indicator, array.data(), size);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_array()->Clear();
-        response->mutable_array()->Reserve(size);
-        std::transform(
-          array.begin(),
-          array.begin() + size,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-          [&](auto x) {
-              return x;
-          });
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -901,7 +787,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -918,14 +804,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadBool(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -934,7 +812,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -951,14 +829,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadDbl(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -967,7 +837,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -984,14 +854,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadI16(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1000,7 +862,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1017,14 +879,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadI32(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1033,7 +887,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1050,14 +904,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadI64(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1066,7 +912,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1083,14 +929,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadI8(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1099,7 +937,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1116,14 +954,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadSgl(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1132,7 +962,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1149,14 +979,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadU16(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1165,7 +987,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1182,14 +1004,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadU32(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1198,7 +1012,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1215,14 +1029,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadU64(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1231,7 +1037,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;
@@ -1248,14 +1054,6 @@ namespace nifpga_grpc {
 
     auto status = library->ReadU8(session, indicator, &value);
 
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-    */
     if (status >= 0)
     {
       response->set_status(status);
@@ -1264,7 +1062,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we make populate_response work which returns error through `AddTrailingMetadata`
+      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
     }
     return ::grpc::Status::OK;

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -479,12 +479,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayBoolData* function_data = static_cast<MonikerReadArrayBoolData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
+
     auto status = library->ReadArrayBool(session, indicator, array.data(), size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -499,7 +499,7 @@ namespace nifpga_grpc {
     {
       response->set_status(status);
       convert_to_grpc(array, response->mutable_array());
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -513,13 +513,13 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayDblData* function_data = static_cast<MonikerReadArrayDblData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     response->mutable_array()->Resize(size, 0);
-    auto array = response->mutable_array()->mutable_data();
+    double* array = response->mutable_array()->mutable_data();
+
     auto status = library->ReadArrayDbl(session, indicator, array, size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -532,7 +532,7 @@ namespace nifpga_grpc {
     if (status >= 0)
     {
       response->set_status(status);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -546,12 +546,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayI16Data* function_data = static_cast<MonikerReadArrayI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     std::vector<int16_t> array(size);
+
     auto status = library->ReadArrayI16(session, indicator, array.data(), size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -582,7 +582,7 @@ namespace nifpga_grpc {
           [&](auto x) {
               return x;
           });
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -596,13 +596,13 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayI32Data* function_data = static_cast<MonikerReadArrayI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     response->mutable_array()->Resize(size, 0);
-    auto array = response->mutable_array()->mutable_data();
+    int32_t* array = response->mutable_array()->mutable_data();
+
     auto status = library->ReadArrayI32(session, indicator, array, size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -615,7 +615,7 @@ namespace nifpga_grpc {
     if (status >= 0)
     {
       response->set_status(status);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -629,13 +629,13 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayI64Data* function_data = static_cast<MonikerReadArrayI64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     response->mutable_array()->Resize(size, 0);
-    auto array = response->mutable_array()->mutable_data();
+    int64_t* array = response->mutable_array()->mutable_data();
+
     auto status = library->ReadArrayI64(session, indicator, array, size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -648,7 +648,7 @@ namespace nifpga_grpc {
     if (status >= 0)
     {
       response->set_status(status);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -662,12 +662,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayI8Data* function_data = static_cast<MonikerReadArrayI8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     std::vector<int8_t> array(size);
+
     auto status = library->ReadArrayI8(session, indicator, array.data(), size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -698,7 +698,7 @@ namespace nifpga_grpc {
           [&](auto x) {
               return x;
           });
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -712,13 +712,13 @@ namespace nifpga_grpc {
 {
     MonikerReadArraySglData* function_data = static_cast<MonikerReadArraySglData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     response->mutable_array()->Resize(size, 0);
-    auto array = response->mutable_array()->mutable_data();
+    float* array = response->mutable_array()->mutable_data();
+
     auto status = library->ReadArraySgl(session, indicator, array, size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -731,7 +731,7 @@ namespace nifpga_grpc {
     if (status >= 0)
     {
       response->set_status(status);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -745,12 +745,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayU16Data* function_data = static_cast<MonikerReadArrayU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     std::vector<uint16_t> array(size);
+
     auto status = library->ReadArrayU16(session, indicator, array.data(), size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -781,7 +781,7 @@ namespace nifpga_grpc {
           [&](auto x) {
               return x;
           });
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -795,13 +795,13 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayU32Data* function_data = static_cast<MonikerReadArrayU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     response->mutable_array()->Resize(size, 0);
-    auto array = response->mutable_array()->mutable_data();
+    uint32_t* array = response->mutable_array()->mutable_data();
+
     auto status = library->ReadArrayU32(session, indicator, array, size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -814,7 +814,7 @@ namespace nifpga_grpc {
     if (status >= 0)
     {
       response->set_status(status);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -828,13 +828,13 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayU64Data* function_data = static_cast<MonikerReadArrayU64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     response->mutable_array()->Resize(size, 0);
-    auto array = response->mutable_array()->mutable_data();
+    uint64_t* array = response->mutable_array()->mutable_data();
+
     auto status = library->ReadArrayU64(session, indicator, array, size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -847,7 +847,7 @@ namespace nifpga_grpc {
     if (status >= 0)
     {
       response->set_status(status);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -861,12 +861,12 @@ namespace nifpga_grpc {
 {
     MonikerReadArrayU8Data* function_data = static_cast<MonikerReadArrayU8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
     auto size = function_data->size;
-        
     std::vector<uint8_t> array(size);
+
     auto status = library->ReadArrayU8(session, indicator, array.data(), size);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -897,7 +897,7 @@ namespace nifpga_grpc {
           [&](auto x) {
               return x;
           });
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -911,11 +911,11 @@ namespace nifpga_grpc {
 {
     MonikerReadBoolData* function_data = static_cast<MonikerReadBoolData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-NiFpga_Bool value {};
+    NiFpga_Bool value {};
+
     auto status = library->ReadBool(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -930,7 +930,7 @@ NiFpga_Bool value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -944,11 +944,11 @@ NiFpga_Bool value {};
 {
     MonikerReadDblData* function_data = static_cast<MonikerReadDblData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-double value {};
+    double value {};
+
     auto status = library->ReadDbl(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -963,7 +963,7 @@ double value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -977,11 +977,11 @@ double value {};
 {
     MonikerReadI16Data* function_data = static_cast<MonikerReadI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-int16_t value {};
+    int16_t value {};
+
     auto status = library->ReadI16(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -996,7 +996,7 @@ int16_t value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1010,11 +1010,11 @@ int16_t value {};
 {
     MonikerReadI32Data* function_data = static_cast<MonikerReadI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-int32_t value {};
+    int32_t value {};
+
     auto status = library->ReadI32(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1029,7 +1029,7 @@ int32_t value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1043,11 +1043,11 @@ int32_t value {};
 {
     MonikerReadI64Data* function_data = static_cast<MonikerReadI64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-int64_t value {};
+    int64_t value {};
+
     auto status = library->ReadI64(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1062,7 +1062,7 @@ int64_t value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1076,11 +1076,11 @@ int64_t value {};
 {
     MonikerReadI8Data* function_data = static_cast<MonikerReadI8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-int8_t value {};
+    int8_t value {};
+
     auto status = library->ReadI8(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1095,7 +1095,7 @@ int8_t value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1109,11 +1109,11 @@ int8_t value {};
 {
     MonikerReadSglData* function_data = static_cast<MonikerReadSglData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-float value {};
+    float value {};
+
     auto status = library->ReadSgl(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1128,7 +1128,7 @@ float value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1142,11 +1142,11 @@ float value {};
 {
     MonikerReadU16Data* function_data = static_cast<MonikerReadU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-uint16_t value {};
+    uint16_t value {};
+
     auto status = library->ReadU16(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1161,7 +1161,7 @@ uint16_t value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1175,11 +1175,11 @@ uint16_t value {};
 {
     MonikerReadU32Data* function_data = static_cast<MonikerReadU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-uint32_t value {};
+    uint32_t value {};
+
     auto status = library->ReadU32(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1194,7 +1194,7 @@ uint32_t value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1208,11 +1208,11 @@ uint32_t value {};
 {
     MonikerReadU64Data* function_data = static_cast<MonikerReadU64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-uint64_t value {};
+    uint64_t value {};
+
     auto status = library->ReadU64(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1227,7 +1227,7 @@ uint64_t value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1241,11 +1241,11 @@ uint64_t value {};
 {
     MonikerReadU8Data* function_data = static_cast<MonikerReadU8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto indicator = function_data->indicator;
-        
-uint8_t value {};
+    uint8_t value {};
+
     auto status = library->ReadU8(session, indicator, &value);
 
     /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
@@ -1260,7 +1260,7 @@ uint8_t value {};
     {
       response->set_status(status);
       response->set_value(value);
-      packedData.PackFrom(function_data->data);
+      packedData.PackFrom(*response);
     }
     else
     {
@@ -1274,25 +1274,19 @@ uint8_t value {};
 {
     MonikerWriteArrayBoolData* function_data = static_cast<MonikerWriteArrayBoolData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayBoolData arraybooldata_message;
-    packedData.UnpackTo(&arraybooldata_message);
+    packedData.UnpackTo(&arraybooldata_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arraybooldata_message.value();
     std::vector<NiFpga_Bool> array(data_array.begin(), data_array.end());
     auto size = data_array.size();
 
     auto status = library->WriteArrayBool(session, control, array.data(), size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1300,25 +1294,19 @@ uint8_t value {};
 {
     MonikerWriteArrayDblData* function_data = static_cast<MonikerWriteArrayDblData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayDoubleData arraydoubledata_message;
-    packedData.UnpackTo(&arraydoubledata_message);
+    packedData.UnpackTo(&arraydoubledata_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arraydoubledata_message.value();
     auto array = const_cast<double*>(arraydoubledata_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteArrayDbl(session, control, array, size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1326,12 +1314,12 @@ uint8_t value {};
 {
     MonikerWriteArrayI16Data* function_data = static_cast<MonikerWriteArrayI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message);
+    packedData.UnpackTo(&arrayi32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayi32data_message.value();
     auto array = std::vector<int16_t>();
@@ -1350,13 +1338,7 @@ uint8_t value {};
       });
 
     auto status = library->WriteArrayI16(session, control, array.data(), size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1364,25 +1346,19 @@ uint8_t value {};
 {
     MonikerWriteArrayI32Data* function_data = static_cast<MonikerWriteArrayI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message);
+    packedData.UnpackTo(&arrayi32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayi32data_message.value();
     auto array = const_cast<int32_t*>(arrayi32data_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteArrayI32(session, control, array, size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1390,25 +1366,19 @@ uint8_t value {};
 {
     MonikerWriteArrayI64Data* function_data = static_cast<MonikerWriteArrayI64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayI64Data arrayi64data_message;
-    packedData.UnpackTo(&arrayi64data_message);
+    packedData.UnpackTo(&arrayi64data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayi64data_message.value();
     auto array = const_cast<int64_t*>(arrayi64data_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteArrayI64(session, control, array, size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1416,12 +1386,12 @@ uint8_t value {};
 {
     MonikerWriteArrayI8Data* function_data = static_cast<MonikerWriteArrayI8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message);
+    packedData.UnpackTo(&arrayi32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayi32data_message.value();
     auto array = std::vector<int8_t>();
@@ -1440,13 +1410,7 @@ uint8_t value {};
       });
 
     auto status = library->WriteArrayI8(session, control, array.data(), size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1454,25 +1418,19 @@ uint8_t value {};
 {
     MonikerWriteArraySglData* function_data = static_cast<MonikerWriteArraySglData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayFloatData arrayfloatdata_message;
-    packedData.UnpackTo(&arrayfloatdata_message);
+    packedData.UnpackTo(&arrayfloatdata_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayfloatdata_message.value();
     auto array = const_cast<float*>(arrayfloatdata_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteArraySgl(session, control, array, size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1480,12 +1438,12 @@ uint8_t value {};
 {
     MonikerWriteArrayU16Data* function_data = static_cast<MonikerWriteArrayU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message);
+    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayu32data_message.value();
     auto array = std::vector<uint16_t>();
@@ -1504,13 +1462,7 @@ uint8_t value {};
       });
 
     auto status = library->WriteArrayU16(session, control, array.data(), size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1518,25 +1470,19 @@ uint8_t value {};
 {
     MonikerWriteArrayU32Data* function_data = static_cast<MonikerWriteArrayU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message);
+    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayu32data_message.value();
     auto array = const_cast<uint32_t*>(arrayu32data_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteArrayU32(session, control, array, size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1544,25 +1490,19 @@ uint8_t value {};
 {
     MonikerWriteArrayU64Data* function_data = static_cast<MonikerWriteArrayU64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayU64Data arrayu64data_message;
-    packedData.UnpackTo(&arrayu64data_message);
+    packedData.UnpackTo(&arrayu64data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayu64data_message.value();
     auto array = const_cast<uint64_t*>(arrayu64data_message.value().data());
     auto size = data_array.size();
 
     auto status = library->WriteArrayU64(session, control, array, size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1570,12 +1510,12 @@ uint8_t value {};
 {
     MonikerWriteArrayU8Data* function_data = static_cast<MonikerWriteArrayU8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message);
+    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
     
     auto data_array = arrayu32data_message.value();
     auto array = std::vector<uint8_t>();
@@ -1594,13 +1534,7 @@ uint8_t value {};
       });
 
     auto status = library->WriteArrayU8(session, control, array.data(), size);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1608,22 +1542,16 @@ uint8_t value {};
 {
     MonikerWriteBoolData* function_data = static_cast<MonikerWriteBoolData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     BoolData booldata_message;
-    packedData.UnpackTo(&booldata_message);
+    packedData.UnpackTo(&booldata_message); // TODO: should unpack to function_data->mutable_request()
     auto value = booldata_message.value();
 
     auto status = library->WriteBool(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1631,22 +1559,16 @@ uint8_t value {};
 {
     MonikerWriteDblData* function_data = static_cast<MonikerWriteDblData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     DoubleData doubledata_message;
-    packedData.UnpackTo(&doubledata_message);
+    packedData.UnpackTo(&doubledata_message); // TODO: should unpack to function_data->mutable_request()
     auto value = doubledata_message.value();
 
     auto status = library->WriteDbl(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1654,12 +1576,12 @@ uint8_t value {};
 {
     MonikerWriteI16Data* function_data = static_cast<MonikerWriteI16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message);
+    packedData.UnpackTo(&i32data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = i32data_message.value();
     if (value < std::numeric_limits<int16_t>::min() || value > std::numeric_limits<int16_t>::max()) {
       std::string message("value " + std::to_string(value) + " doesn't fit in datatype int16_t");
@@ -1667,13 +1589,7 @@ uint8_t value {};
     }
 
     auto status = library->WriteI16(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1681,22 +1597,16 @@ uint8_t value {};
 {
     MonikerWriteI32Data* function_data = static_cast<MonikerWriteI32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message);
+    packedData.UnpackTo(&i32data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = i32data_message.value();
 
     auto status = library->WriteI32(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1704,22 +1614,16 @@ uint8_t value {};
 {
     MonikerWriteI64Data* function_data = static_cast<MonikerWriteI64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     I64Data i64data_message;
-    packedData.UnpackTo(&i64data_message);
+    packedData.UnpackTo(&i64data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = i64data_message.value();
 
     auto status = library->WriteI64(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1727,12 +1631,12 @@ uint8_t value {};
 {
     MonikerWriteI8Data* function_data = static_cast<MonikerWriteI8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message);
+    packedData.UnpackTo(&i32data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = i32data_message.value();
     if (value < std::numeric_limits<int8_t>::min() || value > std::numeric_limits<int8_t>::max()) {
       std::string message("value " + std::to_string(value) + " doesn't fit in datatype int8_t");
@@ -1740,13 +1644,7 @@ uint8_t value {};
     }
 
     auto status = library->WriteI8(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1754,22 +1652,16 @@ uint8_t value {};
 {
     MonikerWriteSglData* function_data = static_cast<MonikerWriteSglData*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     FloatData floatdata_message;
-    packedData.UnpackTo(&floatdata_message);
+    packedData.UnpackTo(&floatdata_message); // TODO: should unpack to function_data->mutable_request()
     auto value = floatdata_message.value();
 
     auto status = library->WriteSgl(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1777,12 +1669,12 @@ uint8_t value {};
 {
     MonikerWriteU16Data* function_data = static_cast<MonikerWriteU16Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message);
+    packedData.UnpackTo(&u32data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = u32data_message.value();
     if (value < std::numeric_limits<uint16_t>::min() || value > std::numeric_limits<uint16_t>::max()) {
       std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint16_t");
@@ -1790,13 +1682,7 @@ uint8_t value {};
     }
 
     auto status = library->WriteU16(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1804,22 +1690,16 @@ uint8_t value {};
 {
     MonikerWriteU32Data* function_data = static_cast<MonikerWriteU32Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message);
+    packedData.UnpackTo(&u32data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = u32data_message.value();
 
     auto status = library->WriteU32(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1827,22 +1707,16 @@ uint8_t value {};
 {
     MonikerWriteU64Data* function_data = static_cast<MonikerWriteU64Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     U64Data u64data_message;
-    packedData.UnpackTo(&u64data_message);
+    packedData.UnpackTo(&u64data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = u64data_message.value();
 
     auto status = library->WriteU64(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -1850,12 +1724,12 @@ uint8_t value {};
 {
     MonikerWriteU8Data* function_data = static_cast<MonikerWriteU8Data*>(data);
     auto library = function_data->library;
-    auto response = function_data->data.mutable_response();
+    auto response = &function_data->response;
     auto session = function_data->session;
     auto control = function_data->control;
-        
+
     U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message);
+    packedData.UnpackTo(&u32data_message); // TODO: should unpack to function_data->mutable_request()
     auto value = u32data_message.value();
     if (value < std::numeric_limits<uint8_t>::min() || value > std::numeric_limits<uint8_t>::max()) {
       std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint8_t");
@@ -1863,13 +1737,7 @@ uint8_t value {};
     }
 
     auto status = library->WriteU8(session, control, value);
-    /* TODO context is unavailable to return error the proper way. Also error API is member of service class, this function is not.
-    ::grpc::ServerContext* context = NULL;
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-    */
+
     return ::grpc::Status::OK;
 }
 
@@ -2419,13 +2287,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayBoolData>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayBool", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2477,13 +2345,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayDblData>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayDbl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2543,13 +2411,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayI16Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2601,13 +2469,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayI32Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2659,13 +2527,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayI64Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2725,13 +2593,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayI8Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2783,13 +2651,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArraySglData>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArraySgl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2849,13 +2717,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayU16Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2907,13 +2775,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayU32Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -2965,13 +2833,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayU64Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3031,13 +2899,13 @@ uint8_t value {};
       size_t size = request->size();
 
       auto data = std::make_unique<MonikerReadArrayU8Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->size = size;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_response()->mutable_array()->Reserve(request->size());
-      data->data.mutable_response()->mutable_array()->Resize(request->size(), 0);
+
+      data->mutable_response()->mutable_array()->Reserve(request->size());
+      data->mutable_response()->mutable_array()->Resize(request->size(), 0);
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3087,10 +2955,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadBoolData>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBool", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3140,10 +3008,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadDblData>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDbl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3544,10 +3412,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadI16Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3597,10 +3465,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadI32Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3650,10 +3518,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadI64Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3703,10 +3571,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadI8Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3756,10 +3624,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadSglData>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadSgl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3809,10 +3677,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadU16Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3862,10 +3730,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadU32Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3915,10 +3783,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadU64Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -3968,10 +3836,10 @@ uint8_t value {};
       uint32_t indicator = request->indicator();
 
       auto data = std::make_unique<MonikerReadU8Data>();
-            data->session = session;
+      data->session = session;
       data->indicator = indicator;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4363,10 +4231,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayBoolData>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayBool", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4416,10 +4284,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayDblData>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayDbl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4486,10 +4354,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayI16Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4539,10 +4407,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayI32Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4592,10 +4460,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayI64Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4662,10 +4530,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayI8Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4715,10 +4583,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArraySglData>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArraySgl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4785,10 +4653,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayU16Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4838,10 +4706,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayU32Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4891,10 +4759,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayU64Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -4961,10 +4829,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteArrayU8Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5013,10 +4881,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteBoolData>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBool", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5065,10 +4933,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteDblData>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDbl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5502,10 +5370,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteI16Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5554,10 +5422,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteI32Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5606,10 +5474,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteI64Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5667,10 +5535,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteI8Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5719,10 +5587,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteSglData>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteSgl", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5780,10 +5648,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteU16Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU16", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5832,10 +5700,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteU32Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU32", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5884,10 +5752,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteU64Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU64", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());
@@ -5945,10 +5813,10 @@ uint8_t value {};
       uint32_t control = request->control();
 
       auto data = std::make_unique<MonikerWriteU8Data>();
-            data->session = session;
+      data->session = session;
       data->control = control;
       data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
+
       auto moniker = std::make_unique<ni::data_monikers::Moniker>();
       ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU8", data.release(), *moniker);
       response->set_allocated_moniker(moniker.release());

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -6,991 +6,948 @@
 //---------------------------------------------------------------------
 #include "nifpga_service.h"
 
-#include <sstream>
-#include <fstream>
-#include <iostream>
-#include <atomic>
-#include <vector>
 #include <server/converters.h>
 #include <server/data_moniker_service.h>
 
+#include <atomic>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
 namespace nifpga_grpc {
 
-  using nidevice_grpc::converters::allocate_output_storage;
-  using nidevice_grpc::converters::calculate_linked_array_size;
-  using nidevice_grpc::converters::convert_from_grpc;
-  using nidevice_grpc::converters::convert_to_grpc;
-  using nidevice_grpc::converters::MatchState;
+using nidevice_grpc::converters::allocate_output_storage;
+using nidevice_grpc::converters::calculate_linked_array_size;
+using nidevice_grpc::converters::convert_from_grpc;
+using nidevice_grpc::converters::convert_to_grpc;
+using nidevice_grpc::converters::MatchState;
 
-  struct MonikerReadArrayBoolData
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayBoolStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayBoolData {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayBoolStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayDblData
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayDblStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayDblData {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayDblStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayI16Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayI16StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayI16Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayI16StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayI32Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayI32StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayI32Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayI32StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayI64Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayI64StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayI64Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayI64StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayI8Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayI8StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayI8Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayI8StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArraySglData
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArraySglStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArraySglData {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArraySglStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayU16Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayU16StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayU16Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayU16StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayU32Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayU32StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayU32Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayU32StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayU64Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayU64StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayU64Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayU64StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadArrayU8Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     size_t size;
-     nifpga_grpc::ReadArrayU8StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadArrayU8Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  size_t size;
+  nifpga_grpc::ReadArrayU8StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadBoolData
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadBoolStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadBoolData {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadBoolStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadDblData
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadDblStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadDblData {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadDblStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadI16Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadI16StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadI16Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadI16StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadI32Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadI32StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadI32Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadI32StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadI64Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadI64StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadI64Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadI64StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadI8Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadI8StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadI8Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadI8StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadSglData
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadSglStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadSglData {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadSglStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadU16Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadU16StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadU16Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadU16StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadU32Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadU32StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadU32Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadU32StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadU64Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadU64StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadU64Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadU64StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerReadU8Data
-  {
-     NiFpga_Session session;
-     uint32_t indicator;
-     nifpga_grpc::ReadU8StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerReadU8Data {
+  NiFpga_Session session;
+  uint32_t indicator;
+  nifpga_grpc::ReadU8StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayBoolData
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayBoolStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayBoolData {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayBoolStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayDblData
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayDblStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayDblData {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayDblStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayI16Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayI16StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayI16Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayI16StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayI32Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayI32StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayI32Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayI32StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayI64Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayI64StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayI64Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayI64StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayI8Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayI8StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayI8Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayI8StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArraySglData
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArraySglStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArraySglData {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArraySglStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayU16Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayU16StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayU16Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayU16StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayU32Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayU32StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayU32Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayU32StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayU64Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayU64StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayU64Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayU64StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteArrayU8Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteArrayU8StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteArrayU8Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteArrayU8StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteBoolData
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteBoolStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteBoolData {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteBoolStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteDblData
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteDblStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteDblData {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteDblStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteI16Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteI16StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteI16Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteI16StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteI32Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteI32StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteI32Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteI32StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteI64Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteI64StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteI64Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteI64StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteI8Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteI8StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteI8Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteI8StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteSglData
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteSglStreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteSglData {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteSglStreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteU16Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteU16StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteU16Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteU16StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteU32Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteU32StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteU32Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteU32StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteU64Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteU64StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteU64Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteU64StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  struct MonikerWriteU8Data
-  {
-     NiFpga_Session session;
-     uint32_t control;
-     nifpga_grpc::WriteU8StreamingData data;
-     std::shared_ptr<NiFpgaLibraryInterface> library;
-  };
+struct MonikerWriteU8Data {
+  NiFpga_Session session;
+  uint32_t control;
+  nifpga_grpc::WriteU8StreamingData data;
+  std::shared_ptr<NiFpgaLibraryInterface> library;
+};
 
-  NiFpgaService::NiFpgaService(
-      LibrarySharedPtr library,
-      ResourceRepositorySharedPtr resource_repository,
-      const NiFpgaFeatureToggles& feature_toggles)
-      : library_(library),
+NiFpgaService::NiFpgaService(
+    LibrarySharedPtr library,
+    ResourceRepositorySharedPtr resource_repository,
+    const NiFpgaFeatureToggles& feature_toggles)
+    : library_(library),
       session_repository_(resource_repository),
       feature_toggles_(feature_toggles)
-  {
-  }
+{
+}
 
-  NiFpgaService::~NiFpgaService()
-  {
-  }
+NiFpgaService::~NiFpgaService()
+{
+}
 
-  // Returns true if it's safe to use outputs of a method with the given status.
-  inline bool status_ok(int32 status)
-  {
-    return status >= 0;
-  }
+// Returns true if it's safe to use outputs of a method with the given status.
+inline bool status_ok(int32 status)
+{
+  return status >= 0;
+}
 
-  void RegisterMonikerEndpoints()
-  {
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayBool", MonikerReadArrayBool);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayDbl", MonikerReadArrayDbl);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI16", MonikerReadArrayI16);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI32", MonikerReadArrayI32);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI64", MonikerReadArrayI64);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI8", MonikerReadArrayI8);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArraySgl", MonikerReadArraySgl);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU16", MonikerReadArrayU16);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU32", MonikerReadArrayU32);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU64", MonikerReadArrayU64);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU8", MonikerReadArrayU8);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadBool", MonikerReadBool);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadDbl", MonikerReadDbl);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI16", MonikerReadI16);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI32", MonikerReadI32);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI64", MonikerReadI64);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI8", MonikerReadI8);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadSgl", MonikerReadSgl);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU16", MonikerReadU16);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU32", MonikerReadU32);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU64", MonikerReadU64);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU8", MonikerReadU8);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayBool", MonikerWriteArrayBool);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayDbl", MonikerWriteArrayDbl);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI16", MonikerWriteArrayI16);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI32", MonikerWriteArrayI32);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI64", MonikerWriteArrayI64);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI8", MonikerWriteArrayI8);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArraySgl", MonikerWriteArraySgl);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU16", MonikerWriteArrayU16);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU32", MonikerWriteArrayU32);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU64", MonikerWriteArrayU64);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU8", MonikerWriteArrayU8);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteBool", MonikerWriteBool);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteDbl", MonikerWriteDbl);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI16", MonikerWriteI16);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI32", MonikerWriteI32);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI64", MonikerWriteI64);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI8", MonikerWriteI8);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteSgl", MonikerWriteSgl);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU16", MonikerWriteU16);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU32", MonikerWriteU32);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU64", MonikerWriteU64);
-      ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU8", MonikerWriteU8);
-  }
+void RegisterMonikerEndpoints()
+{
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayBool", MonikerReadArrayBool);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayDbl", MonikerReadArrayDbl);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI16", MonikerReadArrayI16);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI32", MonikerReadArrayI32);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI64", MonikerReadArrayI64);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayI8", MonikerReadArrayI8);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArraySgl", MonikerReadArraySgl);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU16", MonikerReadArrayU16);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU32", MonikerReadArrayU32);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU64", MonikerReadArrayU64);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadArrayU8", MonikerReadArrayU8);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadBool", MonikerReadBool);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadDbl", MonikerReadDbl);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI16", MonikerReadI16);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI32", MonikerReadI32);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI64", MonikerReadI64);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadI8", MonikerReadI8);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadSgl", MonikerReadSgl);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU16", MonikerReadU16);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU32", MonikerReadU32);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU64", MonikerReadU64);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerReadU8", MonikerReadU8);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayBool", MonikerWriteArrayBool);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayDbl", MonikerWriteArrayDbl);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI16", MonikerWriteArrayI16);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI32", MonikerWriteArrayI32);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI64", MonikerWriteArrayI64);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayI8", MonikerWriteArrayI8);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArraySgl", MonikerWriteArraySgl);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU16", MonikerWriteArrayU16);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU32", MonikerWriteArrayU32);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU64", MonikerWriteArrayU64);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteArrayU8", MonikerWriteArrayU8);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteBool", MonikerWriteBool);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteDbl", MonikerWriteDbl);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI16", MonikerWriteI16);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI32", MonikerWriteI32);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI64", MonikerWriteI64);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteI8", MonikerWriteI8);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteSgl", MonikerWriteSgl);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU16", MonikerWriteU16);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU32", MonikerWriteU32);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU64", MonikerWriteU64);
+  ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("MonikerWriteU8", MonikerWriteU8);
+}
 
 ::grpc::Status MonikerReadArrayBool(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayBoolData* function_data = static_cast<MonikerReadArrayBoolData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayBoolData* function_data = static_cast<MonikerReadArrayBoolData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
-    auto status = library->ReadArrayBool(session, indicator, array.data(), size);
-    if (status >= 0) {
-      std::transform(
+  std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
+  auto status = library->ReadArrayBool(session, indicator, array.data(), size);
+  if (status >= 0) {
+    std::transform(
         array.begin(),
         array.begin() + size,
         function_data->data.mutable_value()->begin(),
         [&](auto x) {
-           return x;
-      });
-      packedData.PackFrom(function_data->data);
-    }
+          return x;
+        });
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayBool error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayBool error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayDbl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayDblData* function_data = static_cast<MonikerReadArrayDblData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayDblData* function_data = static_cast<MonikerReadArrayDblData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    function_data->data.mutable_value()->Resize(size, 0);
-    auto array = function_data->data.mutable_value()->mutable_data();
-    auto status = library->ReadArrayDbl(session, indicator, array, size);
-    if (status >= 0) {
-      packedData.PackFrom(function_data->data);
-    }
+  function_data->data.mutable_value()->Resize(size, 0);
+  auto array = function_data->data.mutable_value()->mutable_data();
+  auto status = library->ReadArrayDbl(session, indicator, array, size);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayDbl error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayDbl error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayI16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayI16Data* function_data = static_cast<MonikerReadArrayI16Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayI16Data* function_data = static_cast<MonikerReadArrayI16Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    std::vector<int16_t> array(size);
-    auto status = library->ReadArrayI16(session, indicator, array.data(), size);
-    if (status >= 0) {
-      std::transform(
+  std::vector<int16_t> array(size);
+  auto status = library->ReadArrayI16(session, indicator, array.data(), size);
+  if (status >= 0) {
+    std::transform(
         array.begin(),
         array.begin() + size,
         function_data->data.mutable_value()->begin(),
         [&](auto x) {
-           return x;
-      });
-      packedData.PackFrom(function_data->data);
-    }
+          return x;
+        });
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayI16 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayI16 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayI32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayI32Data* function_data = static_cast<MonikerReadArrayI32Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayI32Data* function_data = static_cast<MonikerReadArrayI32Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    function_data->data.mutable_value()->Resize(size, 0);
-    auto array = function_data->data.mutable_value()->mutable_data();
-    auto status = library->ReadArrayI32(session, indicator, array, size);
-    if (status >= 0) {
-      packedData.PackFrom(function_data->data);
-    }
+  function_data->data.mutable_value()->Resize(size, 0);
+  auto array = function_data->data.mutable_value()->mutable_data();
+  auto status = library->ReadArrayI32(session, indicator, array, size);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayI32 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayI32 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayI64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayI64Data* function_data = static_cast<MonikerReadArrayI64Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayI64Data* function_data = static_cast<MonikerReadArrayI64Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    function_data->data.mutable_value()->Resize(size, 0);
-    auto array = function_data->data.mutable_value()->mutable_data();
-    auto status = library->ReadArrayI64(session, indicator, array, size);
-    if (status >= 0) {
-      packedData.PackFrom(function_data->data);
-    }
+  function_data->data.mutable_value()->Resize(size, 0);
+  auto array = function_data->data.mutable_value()->mutable_data();
+  auto status = library->ReadArrayI64(session, indicator, array, size);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayI64 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayI64 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayI8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayI8Data* function_data = static_cast<MonikerReadArrayI8Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayI8Data* function_data = static_cast<MonikerReadArrayI8Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    std::vector<int8_t> array(size);
-    auto status = library->ReadArrayI8(session, indicator, array.data(), size);
-    if (status >= 0) {
-      std::transform(
+  std::vector<int8_t> array(size);
+  auto status = library->ReadArrayI8(session, indicator, array.data(), size);
+  if (status >= 0) {
+    std::transform(
         array.begin(),
         array.begin() + size,
         function_data->data.mutable_value()->begin(),
         [&](auto x) {
-           return x;
-      });
-      packedData.PackFrom(function_data->data);
-    }
+          return x;
+        });
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayI8 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayI8 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArraySgl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArraySglData* function_data = static_cast<MonikerReadArraySglData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArraySglData* function_data = static_cast<MonikerReadArraySglData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    function_data->data.mutable_value()->Resize(size, 0);
-    auto array = function_data->data.mutable_value()->mutable_data();
-    auto status = library->ReadArraySgl(session, indicator, array, size);
-    if (status >= 0) {
-      packedData.PackFrom(function_data->data);
-    }
+  function_data->data.mutable_value()->Resize(size, 0);
+  auto array = function_data->data.mutable_value()->mutable_data();
+  auto status = library->ReadArraySgl(session, indicator, array, size);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArraySgl error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArraySgl error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayU16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayU16Data* function_data = static_cast<MonikerReadArrayU16Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayU16Data* function_data = static_cast<MonikerReadArrayU16Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    std::vector<uint16_t> array(size);
-    auto status = library->ReadArrayU16(session, indicator, array.data(), size);
-    if (status >= 0) {
-      std::transform(
+  std::vector<uint16_t> array(size);
+  auto status = library->ReadArrayU16(session, indicator, array.data(), size);
+  if (status >= 0) {
+    std::transform(
         array.begin(),
         array.begin() + size,
         function_data->data.mutable_value()->begin(),
         [&](auto x) {
-           return x;
-      });
-      packedData.PackFrom(function_data->data);
-    }
+          return x;
+        });
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayU16 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayU16 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayU32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayU32Data* function_data = static_cast<MonikerReadArrayU32Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayU32Data* function_data = static_cast<MonikerReadArrayU32Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    function_data->data.mutable_value()->Resize(size, 0);
-    auto array = function_data->data.mutable_value()->mutable_data();
-    auto status = library->ReadArrayU32(session, indicator, array, size);
-    if (status >= 0) {
-      packedData.PackFrom(function_data->data);
-    }
+  function_data->data.mutable_value()->Resize(size, 0);
+  auto array = function_data->data.mutable_value()->mutable_data();
+  auto status = library->ReadArrayU32(session, indicator, array, size);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayU32 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayU32 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayU64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayU64Data* function_data = static_cast<MonikerReadArrayU64Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayU64Data* function_data = static_cast<MonikerReadArrayU64Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    function_data->data.mutable_value()->Resize(size, 0);
-    auto array = function_data->data.mutable_value()->mutable_data();
-    auto status = library->ReadArrayU64(session, indicator, array, size);
-    if (status >= 0) {
-      packedData.PackFrom(function_data->data);
-    }
+  function_data->data.mutable_value()->Resize(size, 0);
+  auto array = function_data->data.mutable_value()->mutable_data();
+  auto status = library->ReadArrayU64(session, indicator, array, size);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayU64 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayU64 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadArrayU8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadArrayU8Data* function_data = static_cast<MonikerReadArrayU8Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
-    auto size = function_data->size;
+  MonikerReadArrayU8Data* function_data = static_cast<MonikerReadArrayU8Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
+  auto size = function_data->size;
 
-    std::vector<uint8_t> array(size);
-    auto status = library->ReadArrayU8(session, indicator, array.data(), size);
-    if (status >= 0) {
-      std::transform(
+  std::vector<uint8_t> array(size);
+  auto status = library->ReadArrayU8(session, indicator, array.data(), size);
+  if (status >= 0) {
+    std::transform(
         array.begin(),
         array.begin() + size,
         function_data->data.mutable_value()->begin(),
         [&](auto x) {
-           return x;
-      });
-      packedData.PackFrom(function_data->data);
-    }
+          return x;
+        });
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadArrayU8 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadArrayU8 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadBool(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadBoolData* function_data = static_cast<MonikerReadBoolData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadBoolData* function_data = static_cast<MonikerReadBoolData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    NiFpga_Bool value {};
-    auto status = library->ReadBool(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  NiFpga_Bool value{};
+  auto status = library->ReadBool(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadBool error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadBool error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadDbl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadDblData* function_data = static_cast<MonikerReadDblData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadDblData* function_data = static_cast<MonikerReadDblData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    double value {};
-    auto status = library->ReadDbl(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  double value{};
+  auto status = library->ReadDbl(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadDbl error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadDbl error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadI16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadI16Data* function_data = static_cast<MonikerReadI16Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadI16Data* function_data = static_cast<MonikerReadI16Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    int16_t value {};
-    auto status = library->ReadI16(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  int16_t value{};
+  auto status = library->ReadI16(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadI16 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadI16 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadI32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadI32Data* function_data = static_cast<MonikerReadI32Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadI32Data* function_data = static_cast<MonikerReadI32Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    int32_t value {};
-    auto status = library->ReadI32(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  int32_t value{};
+  auto status = library->ReadI32(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadI32 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadI32 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadI64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadI64Data* function_data = static_cast<MonikerReadI64Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadI64Data* function_data = static_cast<MonikerReadI64Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    int64_t value {};
-    auto status = library->ReadI64(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  int64_t value{};
+  auto status = library->ReadI64(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadI64 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadI64 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadI8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadI8Data* function_data = static_cast<MonikerReadI8Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadI8Data* function_data = static_cast<MonikerReadI8Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    int8_t value {};
-    auto status = library->ReadI8(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  int8_t value{};
+  auto status = library->ReadI8(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadI8 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadI8 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadSgl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadSglData* function_data = static_cast<MonikerReadSglData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadSglData* function_data = static_cast<MonikerReadSglData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    float value {};
-    auto status = library->ReadSgl(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  float value{};
+  auto status = library->ReadSgl(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadSgl error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadSgl error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadU16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadU16Data* function_data = static_cast<MonikerReadU16Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadU16Data* function_data = static_cast<MonikerReadU16Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    uint16_t value {};
-    auto status = library->ReadU16(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  uint16_t value{};
+  auto status = library->ReadU16(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadU16 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadU16 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadU32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadU32Data* function_data = static_cast<MonikerReadU32Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadU32Data* function_data = static_cast<MonikerReadU32Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    uint32_t value {};
-    auto status = library->ReadU32(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  uint32_t value{};
+  auto status = library->ReadU32(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadU32 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadU32 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadU64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadU64Data* function_data = static_cast<MonikerReadU64Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadU64Data* function_data = static_cast<MonikerReadU64Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    uint64_t value {};
-    auto status = library->ReadU64(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  uint64_t value{};
+  auto status = library->ReadU64(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadU64 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadU64 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerReadU8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerReadU8Data* function_data = static_cast<MonikerReadU8Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto indicator = function_data->indicator;
+  MonikerReadU8Data* function_data = static_cast<MonikerReadU8Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto indicator = function_data->indicator;
 
-    uint8_t value {};
-    auto status = library->ReadU8(session, indicator, &value);
-    function_data->data.set_value(value);
-    if (status >= 0) {
-        packedData.PackFrom(function_data->data);
-    }
+  uint8_t value{};
+  auto status = library->ReadU8(session, indicator, &value);
+  function_data->data.set_value(value);
+  if (status >= 0) {
+    packedData.PackFrom(function_data->data);
+  }
 
-    if (status < 0) {
-      std::cout << "MonikerReadU8 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  if (status < 0) {
+    std::cout << "MonikerReadU8 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayBool(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayBoolData* function_data = static_cast<MonikerWriteArrayBoolData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayBoolData* function_data = static_cast<MonikerWriteArrayBoolData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayBoolData arraybooldata_message;
-    packedData.UnpackTo(&arraybooldata_message);
-    
-    auto data_array = arraybooldata_message.value();
-    std::vector<NiFpga_Bool> array(data_array.begin(), data_array.end());
-    auto size = data_array.size();
+  ArrayBoolData arraybooldata_message;
+  packedData.UnpackTo(&arraybooldata_message);
 
-    auto status = library->WriteArrayBool(session, control, array.data(), size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayBool error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto data_array = arraybooldata_message.value();
+  std::vector<NiFpga_Bool> array(data_array.begin(), data_array.end());
+  auto size = data_array.size();
+
+  auto status = library->WriteArrayBool(session, control, array.data(), size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayBool error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayDbl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayDblData* function_data = static_cast<MonikerWriteArrayDblData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayDblData* function_data = static_cast<MonikerWriteArrayDblData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayDoubleData arraydoubledata_message;
-    packedData.UnpackTo(&arraydoubledata_message);
-    
-    auto data_array = arraydoubledata_message.value();
-    auto array = const_cast<double*>(arraydoubledata_message.value().data());
-    auto size = data_array.size();
+  ArrayDoubleData arraydoubledata_message;
+  packedData.UnpackTo(&arraydoubledata_message);
 
-    auto status = library->WriteArrayDbl(session, control, array, size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayDbl error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto data_array = arraydoubledata_message.value();
+  auto array = const_cast<double*>(arraydoubledata_message.value().data());
+  auto size = data_array.size();
+
+  auto status = library->WriteArrayDbl(session, control, array, size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayDbl error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayI16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayI16Data* function_data = static_cast<MonikerWriteArrayI16Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayI16Data* function_data = static_cast<MonikerWriteArrayI16Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message);
-    
-    auto data_array = arrayi32data_message.value();
-    auto array = std::vector<int16_t>();
-    auto size = data_array.size();
-    array.reserve(size);
-    std::transform(
+  ArrayI32Data arrayi32data_message;
+  packedData.UnpackTo(&arrayi32data_message);
+
+  auto data_array = arrayi32data_message.value();
+  auto array = std::vector<int16_t>();
+  auto size = data_array.size();
+  array.reserve(size);
+  std::transform(
       data_array.begin(),
       data_array.end(),
       std::back_inserter(array),
@@ -1002,70 +959,70 @@ namespace nifpga_grpc {
         return static_cast<int16_t>(x);
       });
 
-    auto status = library->WriteArrayI16(session, control, array.data(), size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayI16 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteArrayI16(session, control, array.data(), size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayI16 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayI32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayI32Data* function_data = static_cast<MonikerWriteArrayI32Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayI32Data* function_data = static_cast<MonikerWriteArrayI32Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message);
-    
-    auto data_array = arrayi32data_message.value();
-    auto array = const_cast<int32_t*>(arrayi32data_message.value().data());
-    auto size = data_array.size();
+  ArrayI32Data arrayi32data_message;
+  packedData.UnpackTo(&arrayi32data_message);
 
-    auto status = library->WriteArrayI32(session, control, array, size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayI32 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto data_array = arrayi32data_message.value();
+  auto array = const_cast<int32_t*>(arrayi32data_message.value().data());
+  auto size = data_array.size();
+
+  auto status = library->WriteArrayI32(session, control, array, size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayI32 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayI64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayI64Data* function_data = static_cast<MonikerWriteArrayI64Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayI64Data* function_data = static_cast<MonikerWriteArrayI64Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayI64Data arrayi64data_message;
-    packedData.UnpackTo(&arrayi64data_message);
-    
-    auto data_array = arrayi64data_message.value();
-    auto array = const_cast<int64_t*>(arrayi64data_message.value().data());
-    auto size = data_array.size();
+  ArrayI64Data arrayi64data_message;
+  packedData.UnpackTo(&arrayi64data_message);
 
-    auto status = library->WriteArrayI64(session, control, array, size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayI64 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto data_array = arrayi64data_message.value();
+  auto array = const_cast<int64_t*>(arrayi64data_message.value().data());
+  auto size = data_array.size();
+
+  auto status = library->WriteArrayI64(session, control, array, size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayI64 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayI8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayI8Data* function_data = static_cast<MonikerWriteArrayI8Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayI8Data* function_data = static_cast<MonikerWriteArrayI8Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message);
-    
-    auto data_array = arrayi32data_message.value();
-    auto array = std::vector<int8_t>();
-    auto size = data_array.size();
-    array.reserve(size);
-    std::transform(
+  ArrayI32Data arrayi32data_message;
+  packedData.UnpackTo(&arrayi32data_message);
+
+  auto data_array = arrayi32data_message.value();
+  auto array = std::vector<int8_t>();
+  auto size = data_array.size();
+  array.reserve(size);
+  std::transform(
       data_array.begin(),
       data_array.end(),
       std::back_inserter(array),
@@ -1077,49 +1034,49 @@ namespace nifpga_grpc {
         return static_cast<int8_t>(x);
       });
 
-    auto status = library->WriteArrayI8(session, control, array.data(), size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayI8 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteArrayI8(session, control, array.data(), size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayI8 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArraySgl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArraySglData* function_data = static_cast<MonikerWriteArraySglData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArraySglData* function_data = static_cast<MonikerWriteArraySglData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayFloatData arrayfloatdata_message;
-    packedData.UnpackTo(&arrayfloatdata_message);
-    
-    auto data_array = arrayfloatdata_message.value();
-    auto array = const_cast<float*>(arrayfloatdata_message.value().data());
-    auto size = data_array.size();
+  ArrayFloatData arrayfloatdata_message;
+  packedData.UnpackTo(&arrayfloatdata_message);
 
-    auto status = library->WriteArraySgl(session, control, array, size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArraySgl error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto data_array = arrayfloatdata_message.value();
+  auto array = const_cast<float*>(arrayfloatdata_message.value().data());
+  auto size = data_array.size();
+
+  auto status = library->WriteArraySgl(session, control, array, size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArraySgl error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayU16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayU16Data* function_data = static_cast<MonikerWriteArrayU16Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayU16Data* function_data = static_cast<MonikerWriteArrayU16Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message);
-    
-    auto data_array = arrayu32data_message.value();
-    auto array = std::vector<uint16_t>();
-    auto size = data_array.size();
-    array.reserve(size);
-    std::transform(
+  ArrayU32Data arrayu32data_message;
+  packedData.UnpackTo(&arrayu32data_message);
+
+  auto data_array = arrayu32data_message.value();
+  auto array = std::vector<uint16_t>();
+  auto size = data_array.size();
+  array.reserve(size);
+  std::transform(
       data_array.begin(),
       data_array.end(),
       std::back_inserter(array),
@@ -1131,70 +1088,70 @@ namespace nifpga_grpc {
         return static_cast<uint16_t>(x);
       });
 
-    auto status = library->WriteArrayU16(session, control, array.data(), size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayU16 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteArrayU16(session, control, array.data(), size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayU16 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayU32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayU32Data* function_data = static_cast<MonikerWriteArrayU32Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayU32Data* function_data = static_cast<MonikerWriteArrayU32Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message);
-    
-    auto data_array = arrayu32data_message.value();
-    auto array = const_cast<uint32_t*>(arrayu32data_message.value().data());
-    auto size = data_array.size();
+  ArrayU32Data arrayu32data_message;
+  packedData.UnpackTo(&arrayu32data_message);
 
-    auto status = library->WriteArrayU32(session, control, array, size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayU32 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto data_array = arrayu32data_message.value();
+  auto array = const_cast<uint32_t*>(arrayu32data_message.value().data());
+  auto size = data_array.size();
+
+  auto status = library->WriteArrayU32(session, control, array, size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayU32 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayU64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayU64Data* function_data = static_cast<MonikerWriteArrayU64Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayU64Data* function_data = static_cast<MonikerWriteArrayU64Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayU64Data arrayu64data_message;
-    packedData.UnpackTo(&arrayu64data_message);
-    
-    auto data_array = arrayu64data_message.value();
-    auto array = const_cast<uint64_t*>(arrayu64data_message.value().data());
-    auto size = data_array.size();
+  ArrayU64Data arrayu64data_message;
+  packedData.UnpackTo(&arrayu64data_message);
 
-    auto status = library->WriteArrayU64(session, control, array, size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayU64 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto data_array = arrayu64data_message.value();
+  auto array = const_cast<uint64_t*>(arrayu64data_message.value().data());
+  auto size = data_array.size();
+
+  auto status = library->WriteArrayU64(session, control, array, size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayU64 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteArrayU8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteArrayU8Data* function_data = static_cast<MonikerWriteArrayU8Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteArrayU8Data* function_data = static_cast<MonikerWriteArrayU8Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message);
-    
-    auto data_array = arrayu32data_message.value();
-    auto array = std::vector<uint8_t>();
-    auto size = data_array.size();
-    array.reserve(size);
-    std::transform(
+  ArrayU32Data arrayu32data_message;
+  packedData.UnpackTo(&arrayu32data_message);
+
+  auto data_array = arrayu32data_message.value();
+  auto array = std::vector<uint8_t>();
+  auto size = data_array.size();
+  array.reserve(size);
+  std::transform(
       data_array.begin(),
       data_array.end(),
       std::back_inserter(array),
@@ -1206,4319 +1163,4317 @@ namespace nifpga_grpc {
         return static_cast<uint8_t>(x);
       });
 
-    auto status = library->WriteArrayU8(session, control, array.data(), size);
-    if (status < 0) {
-      std::cout << "MonikerWriteArrayU8 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteArrayU8(session, control, array.data(), size);
+  if (status < 0) {
+    std::cout << "MonikerWriteArrayU8 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteBool(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteBoolData* function_data = static_cast<MonikerWriteBoolData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteBoolData* function_data = static_cast<MonikerWriteBoolData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    BoolData booldata_message;
-    packedData.UnpackTo(&booldata_message);
-    auto value = booldata_message.value();
+  BoolData booldata_message;
+  packedData.UnpackTo(&booldata_message);
+  auto value = booldata_message.value();
 
-    auto status = library->WriteBool(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteBool error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteBool(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteBool error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteDbl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteDblData* function_data = static_cast<MonikerWriteDblData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteDblData* function_data = static_cast<MonikerWriteDblData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    DoubleData doubledata_message;
-    packedData.UnpackTo(&doubledata_message);
-    auto value = doubledata_message.value();
+  DoubleData doubledata_message;
+  packedData.UnpackTo(&doubledata_message);
+  auto value = doubledata_message.value();
 
-    auto status = library->WriteDbl(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteDbl error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteDbl(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteDbl error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteI16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteI16Data* function_data = static_cast<MonikerWriteI16Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteI16Data* function_data = static_cast<MonikerWriteI16Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message);
-    auto value = i32data_message.value();
-    if (value < std::numeric_limits<int16_t>::min() || value > std::numeric_limits<int16_t>::max()) {
-      std::string message("value " + std::to_string(value) + " doesn't fit in datatype int16_t");
-      throw nidevice_grpc::ValueOutOfRangeException(message);
-    }
+  I32Data i32data_message;
+  packedData.UnpackTo(&i32data_message);
+  auto value = i32data_message.value();
+  if (value < std::numeric_limits<int16_t>::min() || value > std::numeric_limits<int16_t>::max()) {
+    std::string message("value " + std::to_string(value) + " doesn't fit in datatype int16_t");
+    throw nidevice_grpc::ValueOutOfRangeException(message);
+  }
 
-    auto status = library->WriteI16(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteI16 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteI16(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteI16 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteI32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteI32Data* function_data = static_cast<MonikerWriteI32Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteI32Data* function_data = static_cast<MonikerWriteI32Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message);
-    auto value = i32data_message.value();
+  I32Data i32data_message;
+  packedData.UnpackTo(&i32data_message);
+  auto value = i32data_message.value();
 
-    auto status = library->WriteI32(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteI32 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteI32(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteI32 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteI64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteI64Data* function_data = static_cast<MonikerWriteI64Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteI64Data* function_data = static_cast<MonikerWriteI64Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    I64Data i64data_message;
-    packedData.UnpackTo(&i64data_message);
-    auto value = i64data_message.value();
+  I64Data i64data_message;
+  packedData.UnpackTo(&i64data_message);
+  auto value = i64data_message.value();
 
-    auto status = library->WriteI64(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteI64 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteI64(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteI64 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteI8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteI8Data* function_data = static_cast<MonikerWriteI8Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteI8Data* function_data = static_cast<MonikerWriteI8Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message);
-    auto value = i32data_message.value();
-    if (value < std::numeric_limits<int8_t>::min() || value > std::numeric_limits<int8_t>::max()) {
-      std::string message("value " + std::to_string(value) + " doesn't fit in datatype int8_t");
-      throw nidevice_grpc::ValueOutOfRangeException(message);
-    }
+  I32Data i32data_message;
+  packedData.UnpackTo(&i32data_message);
+  auto value = i32data_message.value();
+  if (value < std::numeric_limits<int8_t>::min() || value > std::numeric_limits<int8_t>::max()) {
+    std::string message("value " + std::to_string(value) + " doesn't fit in datatype int8_t");
+    throw nidevice_grpc::ValueOutOfRangeException(message);
+  }
 
-    auto status = library->WriteI8(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteI8 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteI8(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteI8 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteSgl(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteSglData* function_data = static_cast<MonikerWriteSglData*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteSglData* function_data = static_cast<MonikerWriteSglData*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    FloatData floatdata_message;
-    packedData.UnpackTo(&floatdata_message);
-    auto value = floatdata_message.value();
+  FloatData floatdata_message;
+  packedData.UnpackTo(&floatdata_message);
+  auto value = floatdata_message.value();
 
-    auto status = library->WriteSgl(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteSgl error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteSgl(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteSgl error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteU16(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteU16Data* function_data = static_cast<MonikerWriteU16Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteU16Data* function_data = static_cast<MonikerWriteU16Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message);
-    auto value = u32data_message.value();
-    if (value < std::numeric_limits<uint16_t>::min() || value > std::numeric_limits<uint16_t>::max()) {
-      std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint16_t");
-      throw nidevice_grpc::ValueOutOfRangeException(message);
-    }
+  U32Data u32data_message;
+  packedData.UnpackTo(&u32data_message);
+  auto value = u32data_message.value();
+  if (value < std::numeric_limits<uint16_t>::min() || value > std::numeric_limits<uint16_t>::max()) {
+    std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint16_t");
+    throw nidevice_grpc::ValueOutOfRangeException(message);
+  }
 
-    auto status = library->WriteU16(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteU16 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteU16(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteU16 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteU32(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteU32Data* function_data = static_cast<MonikerWriteU32Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteU32Data* function_data = static_cast<MonikerWriteU32Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message);
-    auto value = u32data_message.value();
+  U32Data u32data_message;
+  packedData.UnpackTo(&u32data_message);
+  auto value = u32data_message.value();
 
-    auto status = library->WriteU32(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteU32 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteU32(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteU32 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteU64(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteU64Data* function_data = static_cast<MonikerWriteU64Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteU64Data* function_data = static_cast<MonikerWriteU64Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    U64Data u64data_message;
-    packedData.UnpackTo(&u64data_message);
-    auto value = u64data_message.value();
+  U64Data u64data_message;
+  packedData.UnpackTo(&u64data_message);
+  auto value = u64data_message.value();
 
-    auto status = library->WriteU64(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteU64 error: " << status << std::endl;
-    }
-    return ::grpc::Status::OK;
+  auto status = library->WriteU64(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteU64 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status MonikerWriteU8(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
 {
-    MonikerWriteU8Data* function_data = static_cast<MonikerWriteU8Data*>(data);
-    auto library = function_data->library;
-    auto session = function_data->session;
-    auto control = function_data->control;
+  MonikerWriteU8Data* function_data = static_cast<MonikerWriteU8Data*>(data);
+  auto library = function_data->library;
+  auto session = function_data->session;
+  auto control = function_data->control;
 
-    U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message);
-    auto value = u32data_message.value();
-    if (value < std::numeric_limits<uint8_t>::min() || value > std::numeric_limits<uint8_t>::max()) {
-      std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint8_t");
+  U32Data u32data_message;
+  packedData.UnpackTo(&u32data_message);
+  auto value = u32data_message.value();
+  if (value < std::numeric_limits<uint8_t>::min() || value > std::numeric_limits<uint8_t>::max()) {
+    std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint8_t");
+    throw nidevice_grpc::ValueOutOfRangeException(message);
+  }
+
+  auto status = library->WriteU8(session, control, value);
+  if (status < 0) {
+    std::cout << "MonikerWriteU8 error: " << status << std::endl;
+  }
+  return ::grpc::Status::OK;
+}
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    auto status = library_->Abort(session);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::AcknowledgeIrqs(::grpc::ServerContext* context, const AcknowledgeIrqsRequest* request, AcknowledgeIrqsResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t irqs = request->irqs();
+    auto status = library_->AcknowledgeIrqs(session, irqs);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t attribute;
+    switch (request->attribute_enum_case()) {
+      case nifpga_grpc::CloseRequest::AttributeEnumCase::kAttribute: {
+        attribute = static_cast<uint32_t>(request->attribute());
+        break;
+      }
+      case nifpga_grpc::CloseRequest::AttributeEnumCase::kAttributeRaw: {
+        attribute = static_cast<uint32_t>(request->attribute_raw());
+        break;
+      }
+      case nifpga_grpc::CloseRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
+        break;
+      }
+    }
+
+    session_repository_->remove_session(session_grpc_session.name());
+    auto status = library_->Close(session, attribute);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::CommitFifoConfiguration(::grpc::ServerContext* context, const CommitFifoConfigurationRequest* request, CommitFifoConfigurationResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto status = library_->CommitFifoConfiguration(session, fifo);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ConfigureFifo(::grpc::ServerContext* context, const ConfigureFifoRequest* request, ConfigureFifoResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t depth = request->depth();
+    auto status = library_->ConfigureFifo(session, fifo, depth);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ConfigureFifo2(::grpc::ServerContext* context, const ConfigureFifo2Request* request, ConfigureFifo2Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t requested_depth = request->requested_depth();
+    size_t actual_depth{};
+    auto status = library_->ConfigureFifo2(session, fifo, requested_depth, &actual_depth);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_actual_depth(actual_depth);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::Download(::grpc::ServerContext* context, const DownloadRequest* request, DownloadResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    auto status = library_->Download(session);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::FindFifo(::grpc::ServerContext* context, const FindFifoRequest* request, FindFifoResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    auto fifo_name_mbcs = convert_from_grpc<std::string>(request->fifo_name());
+    char* fifo_name = (char*)fifo_name_mbcs.c_str();
+    uint32_t fifo_number{};
+    auto status = library_->FindFifo(session, fifo_name, &fifo_number);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_fifo_number(fifo_number);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::FindRegister(::grpc::ServerContext* context, const FindRegisterRequest* request, FindRegisterResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    auto register_name_mbcs = convert_from_grpc<std::string>(request->register_name());
+    char* register_name = (char*)register_name_mbcs.c_str();
+    uint32_t register_offset{};
+    auto status = library_->FindRegister(session, register_name, &register_offset);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_register_offset(register_offset);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::GetBitfileSignature(::grpc::ServerContext* context, const GetBitfileSignatureRequest* request, GetBitfileSignatureResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t signature{};
+    size_t signature_size{};
+    auto status = library_->GetBitfileSignature(session, &signature, &signature_size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_signature(signature);
+    response->set_signature_size(signature_size);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::GetFifoPropertyI32(::grpc::ServerContext* context, const GetFifoPropertyI32Request* request, GetFifoPropertyI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    NiFpga_FifoProperty property;
+    switch (request->property_enum_case()) {
+      case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::kProperty: {
+        property = static_cast<NiFpga_FifoProperty>(request->property());
+        break;
+      }
+      case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::kPropertyRaw: {
+        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+        break;
+      }
+      case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+        break;
+      }
+    }
+
+    int32_t value{};
+    auto status = library_->GetFifoPropertyI32(session, fifo, property, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::GetFifoPropertyI64(::grpc::ServerContext* context, const GetFifoPropertyI64Request* request, GetFifoPropertyI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    NiFpga_FifoProperty property;
+    switch (request->property_enum_case()) {
+      case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::kProperty: {
+        property = static_cast<NiFpga_FifoProperty>(request->property());
+        break;
+      }
+      case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::kPropertyRaw: {
+        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+        break;
+      }
+      case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+        break;
+      }
+    }
+
+    int64_t value{};
+    auto status = library_->GetFifoPropertyI64(session, fifo, property, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::GetFifoPropertyU32(::grpc::ServerContext* context, const GetFifoPropertyU32Request* request, GetFifoPropertyU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    NiFpga_FifoProperty property;
+    switch (request->property_enum_case()) {
+      case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::kProperty: {
+        property = static_cast<NiFpga_FifoProperty>(request->property());
+        break;
+      }
+      case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::kPropertyRaw: {
+        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+        break;
+      }
+      case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+        break;
+      }
+    }
+
+    uint32_t value{};
+    auto status = library_->GetFifoPropertyU32(session, fifo, property, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::GetFifoPropertyU64(::grpc::ServerContext* context, const GetFifoPropertyU64Request* request, GetFifoPropertyU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    NiFpga_FifoProperty property;
+    switch (request->property_enum_case()) {
+      case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::kProperty: {
+        property = static_cast<NiFpga_FifoProperty>(request->property());
+        break;
+      }
+      case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::kPropertyRaw: {
+        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+        break;
+      }
+      case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+        break;
+      }
+    }
+
+    uint64_t value{};
+    auto status = library_->GetFifoPropertyU64(session, fifo, property, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::GetFpgaViState(::grpc::ServerContext* context, const GetFpgaViStateRequest* request, GetFpgaViStateResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t state{};
+    auto status = library_->GetFpgaViState(session, &state);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_state(static_cast<nifpga_grpc::FpgaViState>(state));
+    response->set_state_raw(state);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::Open(::grpc::ServerContext* context, const OpenRequest* request, OpenResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto bitfile_mbcs = convert_from_grpc<std::string>(request->bitfile());
+    char* bitfile = (char*)bitfile_mbcs.c_str();
+    auto signature_mbcs = convert_from_grpc<std::string>(request->signature());
+    char* signature = (char*)signature_mbcs.c_str();
+    auto resource_mbcs = convert_from_grpc<std::string>(request->resource());
+    char* resource = (char*)resource_mbcs.c_str();
+    uint32_t attribute;
+    switch (request->attribute_enum_case()) {
+      case nifpga_grpc::OpenRequest::AttributeEnumCase::kAttributeMapped: {
+        auto attribute_imap_it = openattribute_input_map_.find(request->attribute_mapped());
+        if (attribute_imap_it == openattribute_input_map_.end()) {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute_mapped was not specified or out of range.");
+        }
+        attribute = static_cast<uint32_t>(attribute_imap_it->second);
+        break;
+      }
+      case nifpga_grpc::OpenRequest::AttributeEnumCase::kAttributeRaw: {
+        attribute = static_cast<uint32_t>(request->attribute_raw());
+        break;
+      }
+      case nifpga_grpc::OpenRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
+        break;
+      }
+    }
+
+    auto initialization_behavior = request->initialization_behavior();
+
+    bool new_session_initialized{};
+    auto init_lambda = [&]() {
+      NiFpga_Session session;
+      auto status = library_->Open(bitfile, signature, resource, attribute, &session);
+      return std::make_tuple(status, session);
+    };
+    std::string grpc_device_session_name = request->session_name();
+    // Capture the library shared_ptr by value. Do not capture `this` or any references.
+    LibrarySharedPtr library = library_;
+    auto cleanup_lambda = [library](NiFpga_Session id) { library->Close(id, 0); };
+    int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, 0);
+    }
+    response->set_status(status);
+    response->mutable_session()->set_name(grpc_device_session_name);
+    response->set_new_session_initialized(new_session_initialized);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayBool(::grpc::ServerContext* context, const ReadArrayBoolRequest* request, ReadArrayBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
+    auto status = library_->ReadArrayBool(session, indicator, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    convert_to_grpc(array, response->mutable_array());
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayBool(::grpc::ServerContext* context, const BeginReadArrayBoolRequest* request, BeginReadArrayBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayBoolData>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayBool", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayDbl(::grpc::ServerContext* context, const ReadArrayDblRequest* request, ReadArrayDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    response->mutable_array()->Resize(size, 0);
+    double* array = response->mutable_array()->mutable_data();
+    auto status = library_->ReadArrayDbl(session, indicator, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayDbl(::grpc::ServerContext* context, const BeginReadArrayDblRequest* request, BeginReadArrayDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayDblData>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayDbl", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayI16(::grpc::ServerContext* context, const ReadArrayI16Request* request, ReadArrayI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    std::vector<int16_t> array(size);
+    auto status = library_->ReadArrayI16(session, indicator, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->mutable_array()->Clear();
+    response->mutable_array()->Reserve(size);
+    std::transform(
+        array.begin(),
+        array.begin() + size,
+        google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+        [&](auto x) {
+          return x;
+        });
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayI16(::grpc::ServerContext* context, const BeginReadArrayI16Request* request, BeginReadArrayI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayI16Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI16", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayI32(::grpc::ServerContext* context, const ReadArrayI32Request* request, ReadArrayI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    response->mutable_array()->Resize(size, 0);
+    int32_t* array = response->mutable_array()->mutable_data();
+    auto status = library_->ReadArrayI32(session, indicator, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayI32(::grpc::ServerContext* context, const BeginReadArrayI32Request* request, BeginReadArrayI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayI32Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI32", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayI64(::grpc::ServerContext* context, const ReadArrayI64Request* request, ReadArrayI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    response->mutable_array()->Resize(size, 0);
+    int64_t* array = response->mutable_array()->mutable_data();
+    auto status = library_->ReadArrayI64(session, indicator, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayI64(::grpc::ServerContext* context, const BeginReadArrayI64Request* request, BeginReadArrayI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayI64Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI64", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayI8(::grpc::ServerContext* context, const ReadArrayI8Request* request, ReadArrayI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    std::vector<int8_t> array(size);
+    auto status = library_->ReadArrayI8(session, indicator, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->mutable_array()->Clear();
+    response->mutable_array()->Reserve(size);
+    std::transform(
+        array.begin(),
+        array.begin() + size,
+        google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+        [&](auto x) {
+          return x;
+        });
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayI8(::grpc::ServerContext* context, const BeginReadArrayI8Request* request, BeginReadArrayI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayI8Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI8", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArraySgl(::grpc::ServerContext* context, const ReadArraySglRequest* request, ReadArraySglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    response->mutable_array()->Resize(size, 0);
+    float* array = response->mutable_array()->mutable_data();
+    auto status = library_->ReadArraySgl(session, indicator, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArraySgl(::grpc::ServerContext* context, const BeginReadArraySglRequest* request, BeginReadArraySglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArraySglData>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArraySgl", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayU16(::grpc::ServerContext* context, const ReadArrayU16Request* request, ReadArrayU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    std::vector<uint16_t> array(size);
+    auto status = library_->ReadArrayU16(session, indicator, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->mutable_array()->Clear();
+    response->mutable_array()->Reserve(size);
+    std::transform(
+        array.begin(),
+        array.begin() + size,
+        google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+        [&](auto x) {
+          return x;
+        });
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayU16(::grpc::ServerContext* context, const BeginReadArrayU16Request* request, BeginReadArrayU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayU16Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU16", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayU32(::grpc::ServerContext* context, const ReadArrayU32Request* request, ReadArrayU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    response->mutable_array()->Resize(size, 0);
+    uint32_t* array = response->mutable_array()->mutable_data();
+    auto status = library_->ReadArrayU32(session, indicator, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayU32(::grpc::ServerContext* context, const BeginReadArrayU32Request* request, BeginReadArrayU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayU32Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU32", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayU64(::grpc::ServerContext* context, const ReadArrayU64Request* request, ReadArrayU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    response->mutable_array()->Resize(size, 0);
+    uint64_t* array = response->mutable_array()->mutable_data();
+    auto status = library_->ReadArrayU64(session, indicator, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayU64(::grpc::ServerContext* context, const BeginReadArrayU64Request* request, BeginReadArrayU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayU64Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU64", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadArrayU8(::grpc::ServerContext* context, const ReadArrayU8Request* request, ReadArrayU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+    std::vector<uint8_t> array(size);
+    auto status = library_->ReadArrayU8(session, indicator, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->mutable_array()->Clear();
+    response->mutable_array()->Reserve(size);
+    std::transform(
+        array.begin(),
+        array.begin() + size,
+        google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
+        [&](auto x) {
+          return x;
+        });
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadArrayU8(::grpc::ServerContext* context, const BeginReadArrayU8Request* request, BeginReadArrayU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    size_t size = request->size();
+
+    auto data = std::make_unique<MonikerReadArrayU8Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->size = size;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    data->data.mutable_value()->Reserve(request->size());
+    data->data.mutable_value()->Resize(request->size(), 0);
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU8", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadBool(::grpc::ServerContext* context, const ReadBoolRequest* request, ReadBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    NiFpga_Bool value{};
+    auto status = library_->ReadBool(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadBool(::grpc::ServerContext* context, const BeginReadBoolRequest* request, BeginReadBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadBoolData>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBool", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadDbl(::grpc::ServerContext* context, const ReadDblRequest* request, ReadDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    double value{};
+    auto status = library_->ReadDbl(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadDbl(::grpc::ServerContext* context, const BeginReadDblRequest* request, BeginReadDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadDblData>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDbl", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoBool(::grpc::ServerContext* context, const ReadFifoBoolRequest* request, ReadFifoBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    std::vector<NiFpga_Bool> data(number_of_elements, NiFpga_Bool());
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoBool(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    convert_to_grpc(data, response->mutable_data());
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoDbl(::grpc::ServerContext* context, const ReadFifoDblRequest* request, ReadFifoDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    response->mutable_data()->Resize(number_of_elements, 0);
+    double* data = response->mutable_data()->mutable_data();
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoDbl(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoI16(::grpc::ServerContext* context, const ReadFifoI16Request* request, ReadFifoI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    std::vector<int16_t> data(number_of_elements);
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoI16(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->mutable_data()->Clear();
+    response->mutable_data()->Reserve(number_of_elements);
+    std::transform(
+        data.begin(),
+        data.begin() + number_of_elements,
+        google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
+        [&](auto x) {
+          return x;
+        });
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoI32(::grpc::ServerContext* context, const ReadFifoI32Request* request, ReadFifoI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    response->mutable_data()->Resize(number_of_elements, 0);
+    int32_t* data = response->mutable_data()->mutable_data();
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoI32(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoI64(::grpc::ServerContext* context, const ReadFifoI64Request* request, ReadFifoI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    response->mutable_data()->Resize(number_of_elements, 0);
+    int64_t* data = response->mutable_data()->mutable_data();
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoI64(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoI8(::grpc::ServerContext* context, const ReadFifoI8Request* request, ReadFifoI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    std::vector<int8_t> data(number_of_elements);
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoI8(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->mutable_data()->Clear();
+    response->mutable_data()->Reserve(number_of_elements);
+    std::transform(
+        data.begin(),
+        data.begin() + number_of_elements,
+        google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
+        [&](auto x) {
+          return x;
+        });
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoSgl(::grpc::ServerContext* context, const ReadFifoSglRequest* request, ReadFifoSglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    response->mutable_data()->Resize(number_of_elements, 0);
+    float* data = response->mutable_data()->mutable_data();
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoSgl(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoU16(::grpc::ServerContext* context, const ReadFifoU16Request* request, ReadFifoU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    std::vector<uint16_t> data(number_of_elements);
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoU16(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->mutable_data()->Clear();
+    response->mutable_data()->Reserve(number_of_elements);
+    std::transform(
+        data.begin(),
+        data.begin() + number_of_elements,
+        google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
+        [&](auto x) {
+          return x;
+        });
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoU32(::grpc::ServerContext* context, const ReadFifoU32Request* request, ReadFifoU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    response->mutable_data()->Resize(number_of_elements, 0);
+    uint32_t* data = response->mutable_data()->mutable_data();
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoU32(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoU64(::grpc::ServerContext* context, const ReadFifoU64Request* request, ReadFifoU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    response->mutable_data()->Resize(number_of_elements, 0);
+    uint64_t* data = response->mutable_data()->mutable_data();
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoU64(session, fifo, data, number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadFifoU8(::grpc::ServerContext* context, const ReadFifoU8Request* request, ReadFifoU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t number_of_elements = request->number_of_elements();
+    uint32_t timeout = request->timeout();
+    std::vector<uint8_t> data(number_of_elements);
+    size_t elements_remaining{};
+    auto status = library_->ReadFifoU8(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->mutable_data()->Clear();
+    response->mutable_data()->Reserve(number_of_elements);
+    std::transform(
+        data.begin(),
+        data.begin() + number_of_elements,
+        google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
+        [&](auto x) {
+          return x;
+        });
+    response->set_elements_remaining(elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadI16(::grpc::ServerContext* context, const ReadI16Request* request, ReadI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    int16_t value{};
+    auto status = library_->ReadI16(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadI16(::grpc::ServerContext* context, const BeginReadI16Request* request, BeginReadI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadI16Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI16", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadI32(::grpc::ServerContext* context, const ReadI32Request* request, ReadI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    int32_t value{};
+    auto status = library_->ReadI32(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadI32(::grpc::ServerContext* context, const BeginReadI32Request* request, BeginReadI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadI32Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI32", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadI64(::grpc::ServerContext* context, const ReadI64Request* request, ReadI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    int64_t value{};
+    auto status = library_->ReadI64(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadI64(::grpc::ServerContext* context, const BeginReadI64Request* request, BeginReadI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadI64Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI64", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadI8(::grpc::ServerContext* context, const ReadI8Request* request, ReadI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    int8_t value{};
+    auto status = library_->ReadI8(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadI8(::grpc::ServerContext* context, const BeginReadI8Request* request, BeginReadI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadI8Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI8", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadSgl(::grpc::ServerContext* context, const ReadSglRequest* request, ReadSglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    float value{};
+    auto status = library_->ReadSgl(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadSgl(::grpc::ServerContext* context, const BeginReadSglRequest* request, BeginReadSglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadSglData>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadSgl", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadU16(::grpc::ServerContext* context, const ReadU16Request* request, ReadU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    uint16_t value{};
+    auto status = library_->ReadU16(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadU16(::grpc::ServerContext* context, const BeginReadU16Request* request, BeginReadU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadU16Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU16", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadU32(::grpc::ServerContext* context, const ReadU32Request* request, ReadU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    uint32_t value{};
+    auto status = library_->ReadU32(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadU32(::grpc::ServerContext* context, const BeginReadU32Request* request, BeginReadU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadU32Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU32", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadU64(::grpc::ServerContext* context, const ReadU64Request* request, ReadU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    uint64_t value{};
+    auto status = library_->ReadU64(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadU64(::grpc::ServerContext* context, const BeginReadU64Request* request, BeginReadU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadU64Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU64", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReadU8(::grpc::ServerContext* context, const ReadU8Request* request, ReadU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+    uint8_t value{};
+    auto status = library_->ReadU8(session, indicator, &value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_value(value);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginReadU8(::grpc::ServerContext* context, const BeginReadU8Request* request, BeginReadU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t indicator = request->indicator();
+
+    auto data = std::make_unique<MonikerReadU8Data>();
+    data->session = session;
+    data->indicator = indicator;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU8", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::ReleaseFifoElements(::grpc::ServerContext* context, const ReleaseFifoElementsRequest* request, ReleaseFifoElementsResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    size_t elements = request->elements();
+    auto status = library_->ReleaseFifoElements(session, fifo, elements);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::Reset(::grpc::ServerContext* context, const ResetRequest* request, ResetResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    auto status = library_->Reset(session);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::Run(::grpc::ServerContext* context, const RunRequest* request, RunResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t attribute;
+    switch (request->attribute_enum_case()) {
+      case nifpga_grpc::RunRequest::AttributeEnumCase::kAttribute: {
+        attribute = static_cast<uint32_t>(request->attribute());
+        break;
+      }
+      case nifpga_grpc::RunRequest::AttributeEnumCase::kAttributeRaw: {
+        attribute = static_cast<uint32_t>(request->attribute_raw());
+        break;
+      }
+      case nifpga_grpc::RunRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
+        break;
+      }
+    }
+
+    auto status = library_->Run(session, attribute);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::SetFifoPropertyI32(::grpc::ServerContext* context, const SetFifoPropertyI32Request* request, SetFifoPropertyI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    NiFpga_FifoProperty property;
+    switch (request->property_enum_case()) {
+      case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::kProperty: {
+        property = static_cast<NiFpga_FifoProperty>(request->property());
+        break;
+      }
+      case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::kPropertyRaw: {
+        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+        break;
+      }
+      case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+        break;
+      }
+    }
+
+    int32_t value = request->value();
+    auto status = library_->SetFifoPropertyI32(session, fifo, property, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::SetFifoPropertyI64(::grpc::ServerContext* context, const SetFifoPropertyI64Request* request, SetFifoPropertyI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    NiFpga_FifoProperty property;
+    switch (request->property_enum_case()) {
+      case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::kProperty: {
+        property = static_cast<NiFpga_FifoProperty>(request->property());
+        break;
+      }
+      case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::kPropertyRaw: {
+        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+        break;
+      }
+      case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+        break;
+      }
+    }
+
+    int64_t value = request->value();
+    auto status = library_->SetFifoPropertyI64(session, fifo, property, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::SetFifoPropertyU32(::grpc::ServerContext* context, const SetFifoPropertyU32Request* request, SetFifoPropertyU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    NiFpga_FifoProperty property;
+    switch (request->property_enum_case()) {
+      case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::kProperty: {
+        property = static_cast<NiFpga_FifoProperty>(request->property());
+        break;
+      }
+      case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::kPropertyRaw: {
+        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+        break;
+      }
+      case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+        break;
+      }
+    }
+
+    uint32_t value = request->value();
+    auto status = library_->SetFifoPropertyU32(session, fifo, property, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::SetFifoPropertyU64(::grpc::ServerContext* context, const SetFifoPropertyU64Request* request, SetFifoPropertyU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    NiFpga_FifoProperty property;
+    switch (request->property_enum_case()) {
+      case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::kProperty: {
+        property = static_cast<NiFpga_FifoProperty>(request->property());
+        break;
+      }
+      case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::kPropertyRaw: {
+        property = static_cast<NiFpga_FifoProperty>(request->property_raw());
+        break;
+      }
+      case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
+        break;
+      }
+    }
+
+    uint64_t value = request->value();
+    auto status = library_->SetFifoPropertyU64(session, fifo, property, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::StartFifo(::grpc::ServerContext* context, const StartFifoRequest* request, StartFifoResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto status = library_->StartFifo(session, fifo);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::StopFifo(::grpc::ServerContext* context, const StopFifoRequest* request, StopFifoResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto status = library_->StopFifo(session, fifo);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::UnreserveFifo(::grpc::ServerContext* context, const UnreserveFifoRequest* request, UnreserveFifoResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto status = library_->UnreserveFifo(session, fifo);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WaitOnIrqs(::grpc::ServerContext* context, const WaitOnIrqsRequest* request, WaitOnIrqsResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t irqs = request->irqs();
+    uint32_t timeout = request->timeout();
+    NiFpga_IrqContext irq_context{};
+    uint32_t irqs_asserted{};
+    NiFpga_Bool timed_out{};
+    auto status = library_->WaitOnIrqs(session, &irq_context, irqs, timeout, &irqs_asserted, &timed_out);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_irqs_asserted(irqs_asserted);
+    response->set_timed_out(timed_out);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayBool(::grpc::ServerContext* context, const WriteArrayBoolRequest* request, WriteArrayBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array = convert_from_grpc<NiFpga_Bool>(request->array());
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayBool(session, control, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayBool(::grpc::ServerContext* context, const BeginWriteArrayBoolRequest* request, BeginWriteArrayBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayBoolData>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayBool", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayDbl(::grpc::ServerContext* context, const WriteArrayDblRequest* request, WriteArrayDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array = const_cast<double*>(request->array().data());
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayDbl(session, control, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayDbl(::grpc::ServerContext* context, const BeginWriteArrayDblRequest* request, BeginWriteArrayDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayDblData>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayDbl", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayI16(::grpc::ServerContext* context, const WriteArrayI16Request* request, WriteArrayI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array_raw = request->array();
+    auto array = std::vector<int16_t>();
+    array.reserve(array_raw.size());
+    std::transform(
+        array_raw.begin(),
+        array_raw.end(),
+        std::back_inserter(array),
+        [](auto x) {
+          if (x < std::numeric_limits<int16_t>::min() || x > std::numeric_limits<int16_t>::max()) {
+            std::string message("value ");
+            message.append(std::to_string(x));
+            message.append(" doesn't fit in datatype ");
+            message.append("int16_t");
+            throw nidevice_grpc::ValueOutOfRangeException(message);
+          }
+          return static_cast<int16_t>(x);
+        });
+
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayI16(session, control, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayI16(::grpc::ServerContext* context, const BeginWriteArrayI16Request* request, BeginWriteArrayI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayI16Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI16", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayI32(::grpc::ServerContext* context, const WriteArrayI32Request* request, WriteArrayI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array = const_cast<int32_t*>(request->array().data());
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayI32(session, control, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayI32(::grpc::ServerContext* context, const BeginWriteArrayI32Request* request, BeginWriteArrayI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayI32Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI32", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayI64(::grpc::ServerContext* context, const WriteArrayI64Request* request, WriteArrayI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array = const_cast<int64_t*>(request->array().data());
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayI64(session, control, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayI64(::grpc::ServerContext* context, const BeginWriteArrayI64Request* request, BeginWriteArrayI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayI64Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI64", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayI8(::grpc::ServerContext* context, const WriteArrayI8Request* request, WriteArrayI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array_raw = request->array();
+    auto array = std::vector<int8_t>();
+    array.reserve(array_raw.size());
+    std::transform(
+        array_raw.begin(),
+        array_raw.end(),
+        std::back_inserter(array),
+        [](auto x) {
+          if (x < std::numeric_limits<int8_t>::min() || x > std::numeric_limits<int8_t>::max()) {
+            std::string message("value ");
+            message.append(std::to_string(x));
+            message.append(" doesn't fit in datatype ");
+            message.append("int8_t");
+            throw nidevice_grpc::ValueOutOfRangeException(message);
+          }
+          return static_cast<int8_t>(x);
+        });
+
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayI8(session, control, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayI8(::grpc::ServerContext* context, const BeginWriteArrayI8Request* request, BeginWriteArrayI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayI8Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI8", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArraySgl(::grpc::ServerContext* context, const WriteArraySglRequest* request, WriteArraySglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array = const_cast<float*>(request->array().data());
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArraySgl(session, control, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArraySgl(::grpc::ServerContext* context, const BeginWriteArraySglRequest* request, BeginWriteArraySglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArraySglData>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArraySgl", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayU16(::grpc::ServerContext* context, const WriteArrayU16Request* request, WriteArrayU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array_raw = request->array();
+    auto array = std::vector<uint16_t>();
+    array.reserve(array_raw.size());
+    std::transform(
+        array_raw.begin(),
+        array_raw.end(),
+        std::back_inserter(array),
+        [](auto x) {
+          if (x < std::numeric_limits<uint16_t>::min() || x > std::numeric_limits<uint16_t>::max()) {
+            std::string message("value ");
+            message.append(std::to_string(x));
+            message.append(" doesn't fit in datatype ");
+            message.append("uint16_t");
+            throw nidevice_grpc::ValueOutOfRangeException(message);
+          }
+          return static_cast<uint16_t>(x);
+        });
+
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayU16(session, control, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayU16(::grpc::ServerContext* context, const BeginWriteArrayU16Request* request, BeginWriteArrayU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayU16Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU16", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayU32(::grpc::ServerContext* context, const WriteArrayU32Request* request, WriteArrayU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array = const_cast<uint32_t*>(request->array().data());
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayU32(session, control, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayU32(::grpc::ServerContext* context, const BeginWriteArrayU32Request* request, BeginWriteArrayU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayU32Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU32", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayU64(::grpc::ServerContext* context, const WriteArrayU64Request* request, WriteArrayU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array = const_cast<uint64_t*>(request->array().data());
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayU64(session, control, array, size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayU64(::grpc::ServerContext* context, const BeginWriteArrayU64Request* request, BeginWriteArrayU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayU64Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU64", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteArrayU8(::grpc::ServerContext* context, const WriteArrayU8Request* request, WriteArrayU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto array_raw = request->array();
+    auto array = std::vector<uint8_t>();
+    array.reserve(array_raw.size());
+    std::transform(
+        array_raw.begin(),
+        array_raw.end(),
+        std::back_inserter(array),
+        [](auto x) {
+          if (x < std::numeric_limits<uint8_t>::min() || x > std::numeric_limits<uint8_t>::max()) {
+            std::string message("value ");
+            message.append(std::to_string(x));
+            message.append(" doesn't fit in datatype ");
+            message.append("uint8_t");
+            throw nidevice_grpc::ValueOutOfRangeException(message);
+          }
+          return static_cast<uint8_t>(x);
+        });
+
+    size_t size = static_cast<size_t>(request->array().size());
+    auto status = library_->WriteArrayU8(session, control, array.data(), size);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteArrayU8(::grpc::ServerContext* context, const BeginWriteArrayU8Request* request, BeginWriteArrayU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteArrayU8Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU8", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteBool(::grpc::ServerContext* context, const WriteBoolRequest* request, WriteBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    NiFpga_Bool value = request->value();
+    auto status = library_->WriteBool(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteBool(::grpc::ServerContext* context, const BeginWriteBoolRequest* request, BeginWriteBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteBoolData>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBool", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteDbl(::grpc::ServerContext* context, const WriteDblRequest* request, WriteDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    double value = request->value();
+    auto status = library_->WriteDbl(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteDbl(::grpc::ServerContext* context, const BeginWriteDblRequest* request, BeginWriteDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteDblData>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDbl", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoBool(::grpc::ServerContext* context, const WriteFifoBoolRequest* request, WriteFifoBoolResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data = convert_from_grpc<NiFpga_Bool>(request->data());
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoBool(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoDbl(::grpc::ServerContext* context, const WriteFifoDblRequest* request, WriteFifoDblResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data = const_cast<double*>(request->data().data());
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoDbl(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoI16(::grpc::ServerContext* context, const WriteFifoI16Request* request, WriteFifoI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data_raw = request->data();
+    auto data = std::vector<int16_t>();
+    data.reserve(data_raw.size());
+    std::transform(
+        data_raw.begin(),
+        data_raw.end(),
+        std::back_inserter(data),
+        [](auto x) {
+          if (x < std::numeric_limits<int16_t>::min() || x > std::numeric_limits<int16_t>::max()) {
+            std::string message("value ");
+            message.append(std::to_string(x));
+            message.append(" doesn't fit in datatype ");
+            message.append("int16_t");
+            throw nidevice_grpc::ValueOutOfRangeException(message);
+          }
+          return static_cast<int16_t>(x);
+        });
+
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoI16(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoI32(::grpc::ServerContext* context, const WriteFifoI32Request* request, WriteFifoI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data = const_cast<int32_t*>(request->data().data());
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoI32(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoI64(::grpc::ServerContext* context, const WriteFifoI64Request* request, WriteFifoI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data = const_cast<int64_t*>(request->data().data());
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoI64(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoI8(::grpc::ServerContext* context, const WriteFifoI8Request* request, WriteFifoI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data_raw = request->data();
+    auto data = std::vector<int8_t>();
+    data.reserve(data_raw.size());
+    std::transform(
+        data_raw.begin(),
+        data_raw.end(),
+        std::back_inserter(data),
+        [](auto x) {
+          if (x < std::numeric_limits<int8_t>::min() || x > std::numeric_limits<int8_t>::max()) {
+            std::string message("value ");
+            message.append(std::to_string(x));
+            message.append(" doesn't fit in datatype ");
+            message.append("int8_t");
+            throw nidevice_grpc::ValueOutOfRangeException(message);
+          }
+          return static_cast<int8_t>(x);
+        });
+
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoI8(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoSgl(::grpc::ServerContext* context, const WriteFifoSglRequest* request, WriteFifoSglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data = const_cast<float*>(request->data().data());
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoSgl(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoU16(::grpc::ServerContext* context, const WriteFifoU16Request* request, WriteFifoU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data_raw = request->data();
+    auto data = std::vector<uint16_t>();
+    data.reserve(data_raw.size());
+    std::transform(
+        data_raw.begin(),
+        data_raw.end(),
+        std::back_inserter(data),
+        [](auto x) {
+          if (x < std::numeric_limits<uint16_t>::min() || x > std::numeric_limits<uint16_t>::max()) {
+            std::string message("value ");
+            message.append(std::to_string(x));
+            message.append(" doesn't fit in datatype ");
+            message.append("uint16_t");
+            throw nidevice_grpc::ValueOutOfRangeException(message);
+          }
+          return static_cast<uint16_t>(x);
+        });
+
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoU16(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoU32(::grpc::ServerContext* context, const WriteFifoU32Request* request, WriteFifoU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data = const_cast<uint32_t*>(request->data().data());
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoU32(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoU64(::grpc::ServerContext* context, const WriteFifoU64Request* request, WriteFifoU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data = const_cast<uint64_t*>(request->data().data());
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoU64(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteFifoU8(::grpc::ServerContext* context, const WriteFifoU8Request* request, WriteFifoU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t fifo = request->fifo();
+    auto data_raw = request->data();
+    auto data = std::vector<uint8_t>();
+    data.reserve(data_raw.size());
+    std::transform(
+        data_raw.begin(),
+        data_raw.end(),
+        std::back_inserter(data),
+        [](auto x) {
+          if (x < std::numeric_limits<uint8_t>::min() || x > std::numeric_limits<uint8_t>::max()) {
+            std::string message("value ");
+            message.append(std::to_string(x));
+            message.append(" doesn't fit in datatype ");
+            message.append("uint8_t");
+            throw nidevice_grpc::ValueOutOfRangeException(message);
+          }
+          return static_cast<uint8_t>(x);
+        });
+
+    size_t number_of_elements = static_cast<size_t>(request->data().size());
+    uint32_t timeout = request->timeout();
+    size_t empty_elements_remaining{};
+    auto status = library_->WriteFifoU8(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    response->set_empty_elements_remaining(empty_elements_remaining);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteI16(::grpc::ServerContext* context, const WriteI16Request* request, WriteI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto value_raw = request->value();
+    if (value_raw < std::numeric_limits<int16_t>::min() || value_raw > std::numeric_limits<int16_t>::max()) {
+      std::string message("value ");
+      message.append(std::to_string(value_raw));
+      message.append(" doesn't fit in datatype ");
+      message.append("int16_t");
       throw nidevice_grpc::ValueOutOfRangeException(message);
     }
+    auto value = static_cast<int16_t>(value_raw);
 
-    auto status = library->WriteU8(session, control, value);
-    if (status < 0) {
-      std::cout << "MonikerWriteU8 error: " << status << std::endl;
+    auto status = library_->WriteI16(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
     }
+    response->set_status(status);
     return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
 }
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      auto status = library_->Abort(session);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::AcknowledgeIrqs(::grpc::ServerContext* context, const AcknowledgeIrqsRequest* request, AcknowledgeIrqsResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t irqs = request->irqs();
-      auto status = library_->AcknowledgeIrqs(session, irqs);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t attribute;
-      switch (request->attribute_enum_case()) {
-        case nifpga_grpc::CloseRequest::AttributeEnumCase::kAttribute: {
-          attribute = static_cast<uint32_t>(request->attribute());
-          break;
-        }
-        case nifpga_grpc::CloseRequest::AttributeEnumCase::kAttributeRaw: {
-          attribute = static_cast<uint32_t>(request->attribute_raw());
-          break;
-        }
-        case nifpga_grpc::CloseRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
-          break;
-        }
-      }
-
-      session_repository_->remove_session(session_grpc_session.name());
-      auto status = library_->Close(session, attribute);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::CommitFifoConfiguration(::grpc::ServerContext* context, const CommitFifoConfigurationRequest* request, CommitFifoConfigurationResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto status = library_->CommitFifoConfiguration(session, fifo);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ConfigureFifo(::grpc::ServerContext* context, const ConfigureFifoRequest* request, ConfigureFifoResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t depth = request->depth();
-      auto status = library_->ConfigureFifo(session, fifo, depth);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ConfigureFifo2(::grpc::ServerContext* context, const ConfigureFifo2Request* request, ConfigureFifo2Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t requested_depth = request->requested_depth();
-      size_t actual_depth {};
-      auto status = library_->ConfigureFifo2(session, fifo, requested_depth, &actual_depth);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_actual_depth(actual_depth);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::Download(::grpc::ServerContext* context, const DownloadRequest* request, DownloadResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      auto status = library_->Download(session);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::FindFifo(::grpc::ServerContext* context, const FindFifoRequest* request, FindFifoResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      auto fifo_name_mbcs = convert_from_grpc<std::string>(request->fifo_name());
-      char* fifo_name = (char*)fifo_name_mbcs.c_str();
-      uint32_t fifo_number {};
-      auto status = library_->FindFifo(session, fifo_name, &fifo_number);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_fifo_number(fifo_number);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::FindRegister(::grpc::ServerContext* context, const FindRegisterRequest* request, FindRegisterResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      auto register_name_mbcs = convert_from_grpc<std::string>(request->register_name());
-      char* register_name = (char*)register_name_mbcs.c_str();
-      uint32_t register_offset {};
-      auto status = library_->FindRegister(session, register_name, &register_offset);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_register_offset(register_offset);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::GetBitfileSignature(::grpc::ServerContext* context, const GetBitfileSignatureRequest* request, GetBitfileSignatureResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t signature {};
-      size_t signature_size {};
-      auto status = library_->GetBitfileSignature(session, &signature, &signature_size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_signature(signature);
-      response->set_signature_size(signature_size);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::GetFifoPropertyI32(::grpc::ServerContext* context, const GetFifoPropertyI32Request* request, GetFifoPropertyI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      NiFpga_FifoProperty property;
-      switch (request->property_enum_case()) {
-        case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::kProperty: {
-          property = static_cast<NiFpga_FifoProperty>(request->property());
-          break;
-        }
-        case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::kPropertyRaw: {
-          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-          break;
-        }
-        case nifpga_grpc::GetFifoPropertyI32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-          break;
-        }
-      }
-
-      int32_t value {};
-      auto status = library_->GetFifoPropertyI32(session, fifo, property, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::GetFifoPropertyI64(::grpc::ServerContext* context, const GetFifoPropertyI64Request* request, GetFifoPropertyI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      NiFpga_FifoProperty property;
-      switch (request->property_enum_case()) {
-        case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::kProperty: {
-          property = static_cast<NiFpga_FifoProperty>(request->property());
-          break;
-        }
-        case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::kPropertyRaw: {
-          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-          break;
-        }
-        case nifpga_grpc::GetFifoPropertyI64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-          break;
-        }
-      }
-
-      int64_t value {};
-      auto status = library_->GetFifoPropertyI64(session, fifo, property, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::GetFifoPropertyU32(::grpc::ServerContext* context, const GetFifoPropertyU32Request* request, GetFifoPropertyU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      NiFpga_FifoProperty property;
-      switch (request->property_enum_case()) {
-        case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::kProperty: {
-          property = static_cast<NiFpga_FifoProperty>(request->property());
-          break;
-        }
-        case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::kPropertyRaw: {
-          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-          break;
-        }
-        case nifpga_grpc::GetFifoPropertyU32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-          break;
-        }
-      }
-
-      uint32_t value {};
-      auto status = library_->GetFifoPropertyU32(session, fifo, property, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::GetFifoPropertyU64(::grpc::ServerContext* context, const GetFifoPropertyU64Request* request, GetFifoPropertyU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      NiFpga_FifoProperty property;
-      switch (request->property_enum_case()) {
-        case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::kProperty: {
-          property = static_cast<NiFpga_FifoProperty>(request->property());
-          break;
-        }
-        case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::kPropertyRaw: {
-          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-          break;
-        }
-        case nifpga_grpc::GetFifoPropertyU64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-          break;
-        }
-      }
-
-      uint64_t value {};
-      auto status = library_->GetFifoPropertyU64(session, fifo, property, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::GetFpgaViState(::grpc::ServerContext* context, const GetFpgaViStateRequest* request, GetFpgaViStateResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t state {};
-      auto status = library_->GetFpgaViState(session, &state);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_state(static_cast<nifpga_grpc::FpgaViState>(state));
-      response->set_state_raw(state);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::Open(::grpc::ServerContext* context, const OpenRequest* request, OpenResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto bitfile_mbcs = convert_from_grpc<std::string>(request->bitfile());
-      char* bitfile = (char*)bitfile_mbcs.c_str();
-      auto signature_mbcs = convert_from_grpc<std::string>(request->signature());
-      char* signature = (char*)signature_mbcs.c_str();
-      auto resource_mbcs = convert_from_grpc<std::string>(request->resource());
-      char* resource = (char*)resource_mbcs.c_str();
-      uint32_t attribute;
-      switch (request->attribute_enum_case()) {
-        case nifpga_grpc::OpenRequest::AttributeEnumCase::kAttributeMapped: {
-          auto attribute_imap_it = openattribute_input_map_.find(request->attribute_mapped());
-          if (attribute_imap_it == openattribute_input_map_.end()) {
-            return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute_mapped was not specified or out of range.");
-          }
-          attribute = static_cast<uint32_t>(attribute_imap_it->second);
-          break;
-        }
-        case nifpga_grpc::OpenRequest::AttributeEnumCase::kAttributeRaw: {
-          attribute = static_cast<uint32_t>(request->attribute_raw());
-          break;
-        }
-        case nifpga_grpc::OpenRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
-          break;
-        }
-      }
-
-      auto initialization_behavior = request->initialization_behavior();
-
-      bool new_session_initialized {};
-      auto init_lambda = [&] () {
-        NiFpga_Session session;
-        auto status = library_->Open(bitfile, signature, resource, attribute, &session);
-        return std::make_tuple(status, session);
-      };
-      std::string grpc_device_session_name = request->session_name();
-      // Capture the library shared_ptr by value. Do not capture `this` or any references.
-      LibrarySharedPtr library = library_;
-      auto cleanup_lambda = [library] (NiFpga_Session id) { library->Close(id, 0); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, 0);
-      }
-      response->set_status(status);
-      response->mutable_session()->set_name(grpc_device_session_name);
-      response->set_new_session_initialized(new_session_initialized);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayBool(::grpc::ServerContext* context, const ReadArrayBoolRequest* request, ReadArrayBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      std::vector<NiFpga_Bool> array(size, NiFpga_Bool());
-      auto status = library_->ReadArrayBool(session, indicator, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      convert_to_grpc(array, response->mutable_array());
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayBool(::grpc::ServerContext* context, const BeginReadArrayBoolRequest* request, BeginReadArrayBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayBoolData>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayBool", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayDbl(::grpc::ServerContext* context, const ReadArrayDblRequest* request, ReadArrayDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      response->mutable_array()->Resize(size, 0);
-      double* array = response->mutable_array()->mutable_data();
-      auto status = library_->ReadArrayDbl(session, indicator, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayDbl(::grpc::ServerContext* context, const BeginReadArrayDblRequest* request, BeginReadArrayDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayDblData>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayDbl", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayI16(::grpc::ServerContext* context, const ReadArrayI16Request* request, ReadArrayI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      std::vector<int16_t> array(size);
-      auto status = library_->ReadArrayI16(session, indicator, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_array()->Clear();
-        response->mutable_array()->Reserve(size);
-        std::transform(
-          array.begin(),
-          array.begin() + size,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-          [&](auto x) {
-              return x;
-          });
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayI16(::grpc::ServerContext* context, const BeginReadArrayI16Request* request, BeginReadArrayI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayI16Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI16", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayI32(::grpc::ServerContext* context, const ReadArrayI32Request* request, ReadArrayI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      response->mutable_array()->Resize(size, 0);
-      int32_t* array = response->mutable_array()->mutable_data();
-      auto status = library_->ReadArrayI32(session, indicator, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayI32(::grpc::ServerContext* context, const BeginReadArrayI32Request* request, BeginReadArrayI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayI32Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI32", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayI64(::grpc::ServerContext* context, const ReadArrayI64Request* request, ReadArrayI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      response->mutable_array()->Resize(size, 0);
-      int64_t* array = response->mutable_array()->mutable_data();
-      auto status = library_->ReadArrayI64(session, indicator, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayI64(::grpc::ServerContext* context, const BeginReadArrayI64Request* request, BeginReadArrayI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayI64Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI64", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayI8(::grpc::ServerContext* context, const ReadArrayI8Request* request, ReadArrayI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      std::vector<int8_t> array(size);
-      auto status = library_->ReadArrayI8(session, indicator, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_array()->Clear();
-        response->mutable_array()->Reserve(size);
-        std::transform(
-          array.begin(),
-          array.begin() + size,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-          [&](auto x) {
-              return x;
-          });
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayI8(::grpc::ServerContext* context, const BeginReadArrayI8Request* request, BeginReadArrayI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayI8Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayI8", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArraySgl(::grpc::ServerContext* context, const ReadArraySglRequest* request, ReadArraySglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      response->mutable_array()->Resize(size, 0);
-      float* array = response->mutable_array()->mutable_data();
-      auto status = library_->ReadArraySgl(session, indicator, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArraySgl(::grpc::ServerContext* context, const BeginReadArraySglRequest* request, BeginReadArraySglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArraySglData>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArraySgl", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayU16(::grpc::ServerContext* context, const ReadArrayU16Request* request, ReadArrayU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      std::vector<uint16_t> array(size);
-      auto status = library_->ReadArrayU16(session, indicator, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_array()->Clear();
-        response->mutable_array()->Reserve(size);
-        std::transform(
-          array.begin(),
-          array.begin() + size,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-          [&](auto x) {
-              return x;
-          });
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayU16(::grpc::ServerContext* context, const BeginReadArrayU16Request* request, BeginReadArrayU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayU16Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU16", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayU32(::grpc::ServerContext* context, const ReadArrayU32Request* request, ReadArrayU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      response->mutable_array()->Resize(size, 0);
-      uint32_t* array = response->mutable_array()->mutable_data();
-      auto status = library_->ReadArrayU32(session, indicator, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayU32(::grpc::ServerContext* context, const BeginReadArrayU32Request* request, BeginReadArrayU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayU32Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU32", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayU64(::grpc::ServerContext* context, const ReadArrayU64Request* request, ReadArrayU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      response->mutable_array()->Resize(size, 0);
-      uint64_t* array = response->mutable_array()->mutable_data();
-      auto status = library_->ReadArrayU64(session, indicator, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayU64(::grpc::ServerContext* context, const BeginReadArrayU64Request* request, BeginReadArrayU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayU64Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU64", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadArrayU8(::grpc::ServerContext* context, const ReadArrayU8Request* request, ReadArrayU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-      std::vector<uint8_t> array(size);
-      auto status = library_->ReadArrayU8(session, indicator, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_array()->Clear();
-        response->mutable_array()->Reserve(size);
-        std::transform(
-          array.begin(),
-          array.begin() + size,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_array()),
-          [&](auto x) {
-              return x;
-          });
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadArrayU8(::grpc::ServerContext* context, const BeginReadArrayU8Request* request, BeginReadArrayU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      size_t size = request->size();
-
-      auto data = std::make_unique<MonikerReadArrayU8Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->size = size;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      data->data.mutable_value()->Reserve(request->size());
-      data->data.mutable_value()->Resize(request->size(), 0);
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadArrayU8", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadBool(::grpc::ServerContext* context, const ReadBoolRequest* request, ReadBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      NiFpga_Bool value {};
-      auto status = library_->ReadBool(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadBool(::grpc::ServerContext* context, const BeginReadBoolRequest* request, BeginReadBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadBoolData>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadBool", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadDbl(::grpc::ServerContext* context, const ReadDblRequest* request, ReadDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      double value {};
-      auto status = library_->ReadDbl(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadDbl(::grpc::ServerContext* context, const BeginReadDblRequest* request, BeginReadDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadDblData>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadDbl", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoBool(::grpc::ServerContext* context, const ReadFifoBoolRequest* request, ReadFifoBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      std::vector<NiFpga_Bool> data(number_of_elements, NiFpga_Bool());
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoBool(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      convert_to_grpc(data, response->mutable_data());
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoDbl(::grpc::ServerContext* context, const ReadFifoDblRequest* request, ReadFifoDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      response->mutable_data()->Resize(number_of_elements, 0);
-      double* data = response->mutable_data()->mutable_data();
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoDbl(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoI16(::grpc::ServerContext* context, const ReadFifoI16Request* request, ReadFifoI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      std::vector<int16_t> data(number_of_elements);
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoI16(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_data()->Clear();
-        response->mutable_data()->Reserve(number_of_elements);
-        std::transform(
-          data.begin(),
-          data.begin() + number_of_elements,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
-          [&](auto x) {
-              return x;
-          });
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoI32(::grpc::ServerContext* context, const ReadFifoI32Request* request, ReadFifoI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      response->mutable_data()->Resize(number_of_elements, 0);
-      int32_t* data = response->mutable_data()->mutable_data();
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoI32(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoI64(::grpc::ServerContext* context, const ReadFifoI64Request* request, ReadFifoI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      response->mutable_data()->Resize(number_of_elements, 0);
-      int64_t* data = response->mutable_data()->mutable_data();
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoI64(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoI8(::grpc::ServerContext* context, const ReadFifoI8Request* request, ReadFifoI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      std::vector<int8_t> data(number_of_elements);
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoI8(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_data()->Clear();
-        response->mutable_data()->Reserve(number_of_elements);
-        std::transform(
-          data.begin(),
-          data.begin() + number_of_elements,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
-          [&](auto x) {
-              return x;
-          });
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoSgl(::grpc::ServerContext* context, const ReadFifoSglRequest* request, ReadFifoSglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      response->mutable_data()->Resize(number_of_elements, 0);
-      float* data = response->mutable_data()->mutable_data();
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoSgl(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoU16(::grpc::ServerContext* context, const ReadFifoU16Request* request, ReadFifoU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      std::vector<uint16_t> data(number_of_elements);
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoU16(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_data()->Clear();
-        response->mutable_data()->Reserve(number_of_elements);
-        std::transform(
-          data.begin(),
-          data.begin() + number_of_elements,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
-          [&](auto x) {
-              return x;
-          });
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoU32(::grpc::ServerContext* context, const ReadFifoU32Request* request, ReadFifoU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      response->mutable_data()->Resize(number_of_elements, 0);
-      uint32_t* data = response->mutable_data()->mutable_data();
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoU32(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoU64(::grpc::ServerContext* context, const ReadFifoU64Request* request, ReadFifoU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      response->mutable_data()->Resize(number_of_elements, 0);
-      uint64_t* data = response->mutable_data()->mutable_data();
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoU64(session, fifo, data, number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadFifoU8(::grpc::ServerContext* context, const ReadFifoU8Request* request, ReadFifoU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t number_of_elements = request->number_of_elements();
-      uint32_t timeout = request->timeout();
-      std::vector<uint8_t> data(number_of_elements);
-      size_t elements_remaining {};
-      auto status = library_->ReadFifoU8(session, fifo, data.data(), number_of_elements, timeout, &elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-        response->mutable_data()->Clear();
-        response->mutable_data()->Reserve(number_of_elements);
-        std::transform(
-          data.begin(),
-          data.begin() + number_of_elements,
-          google::protobuf::RepeatedFieldBackInserter(response->mutable_data()),
-          [&](auto x) {
-              return x;
-          });
-      response->set_elements_remaining(elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadI16(::grpc::ServerContext* context, const ReadI16Request* request, ReadI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      int16_t value {};
-      auto status = library_->ReadI16(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadI16(::grpc::ServerContext* context, const BeginReadI16Request* request, BeginReadI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadI16Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI16", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadI32(::grpc::ServerContext* context, const ReadI32Request* request, ReadI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      int32_t value {};
-      auto status = library_->ReadI32(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadI32(::grpc::ServerContext* context, const BeginReadI32Request* request, BeginReadI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadI32Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI32", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadI64(::grpc::ServerContext* context, const ReadI64Request* request, ReadI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      int64_t value {};
-      auto status = library_->ReadI64(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadI64(::grpc::ServerContext* context, const BeginReadI64Request* request, BeginReadI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadI64Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI64", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadI8(::grpc::ServerContext* context, const ReadI8Request* request, ReadI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      int8_t value {};
-      auto status = library_->ReadI8(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadI8(::grpc::ServerContext* context, const BeginReadI8Request* request, BeginReadI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadI8Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadI8", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadSgl(::grpc::ServerContext* context, const ReadSglRequest* request, ReadSglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      float value {};
-      auto status = library_->ReadSgl(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadSgl(::grpc::ServerContext* context, const BeginReadSglRequest* request, BeginReadSglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadSglData>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadSgl", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadU16(::grpc::ServerContext* context, const ReadU16Request* request, ReadU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      uint16_t value {};
-      auto status = library_->ReadU16(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadU16(::grpc::ServerContext* context, const BeginReadU16Request* request, BeginReadU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadU16Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU16", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadU32(::grpc::ServerContext* context, const ReadU32Request* request, ReadU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      uint32_t value {};
-      auto status = library_->ReadU32(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadU32(::grpc::ServerContext* context, const BeginReadU32Request* request, BeginReadU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadU32Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU32", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadU64(::grpc::ServerContext* context, const ReadU64Request* request, ReadU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      uint64_t value {};
-      auto status = library_->ReadU64(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadU64(::grpc::ServerContext* context, const BeginReadU64Request* request, BeginReadU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadU64Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU64", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReadU8(::grpc::ServerContext* context, const ReadU8Request* request, ReadU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-      uint8_t value {};
-      auto status = library_->ReadU8(session, indicator, &value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_value(value);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginReadU8(::grpc::ServerContext* context, const BeginReadU8Request* request, BeginReadU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t indicator = request->indicator();
-
-      auto data = std::make_unique<MonikerReadU8Data>();      
-      data->session = session;
-      data->indicator = indicator;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerReadU8", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::ReleaseFifoElements(::grpc::ServerContext* context, const ReleaseFifoElementsRequest* request, ReleaseFifoElementsResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      size_t elements = request->elements();
-      auto status = library_->ReleaseFifoElements(session, fifo, elements);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::Reset(::grpc::ServerContext* context, const ResetRequest* request, ResetResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      auto status = library_->Reset(session);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::Run(::grpc::ServerContext* context, const RunRequest* request, RunResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t attribute;
-      switch (request->attribute_enum_case()) {
-        case nifpga_grpc::RunRequest::AttributeEnumCase::kAttribute: {
-          attribute = static_cast<uint32_t>(request->attribute());
-          break;
-        }
-        case nifpga_grpc::RunRequest::AttributeEnumCase::kAttributeRaw: {
-          attribute = static_cast<uint32_t>(request->attribute_raw());
-          break;
-        }
-        case nifpga_grpc::RunRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute was not specified or out of range");
-          break;
-        }
-      }
-
-      auto status = library_->Run(session, attribute);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::SetFifoPropertyI32(::grpc::ServerContext* context, const SetFifoPropertyI32Request* request, SetFifoPropertyI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      NiFpga_FifoProperty property;
-      switch (request->property_enum_case()) {
-        case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::kProperty: {
-          property = static_cast<NiFpga_FifoProperty>(request->property());
-          break;
-        }
-        case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::kPropertyRaw: {
-          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-          break;
-        }
-        case nifpga_grpc::SetFifoPropertyI32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-          break;
-        }
-      }
-
-      int32_t value = request->value();
-      auto status = library_->SetFifoPropertyI32(session, fifo, property, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::SetFifoPropertyI64(::grpc::ServerContext* context, const SetFifoPropertyI64Request* request, SetFifoPropertyI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      NiFpga_FifoProperty property;
-      switch (request->property_enum_case()) {
-        case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::kProperty: {
-          property = static_cast<NiFpga_FifoProperty>(request->property());
-          break;
-        }
-        case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::kPropertyRaw: {
-          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-          break;
-        }
-        case nifpga_grpc::SetFifoPropertyI64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-          break;
-        }
-      }
-
-      int64_t value = request->value();
-      auto status = library_->SetFifoPropertyI64(session, fifo, property, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::SetFifoPropertyU32(::grpc::ServerContext* context, const SetFifoPropertyU32Request* request, SetFifoPropertyU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      NiFpga_FifoProperty property;
-      switch (request->property_enum_case()) {
-        case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::kProperty: {
-          property = static_cast<NiFpga_FifoProperty>(request->property());
-          break;
-        }
-        case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::kPropertyRaw: {
-          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-          break;
-        }
-        case nifpga_grpc::SetFifoPropertyU32Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-          break;
-        }
-      }
-
-      uint32_t value = request->value();
-      auto status = library_->SetFifoPropertyU32(session, fifo, property, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::SetFifoPropertyU64(::grpc::ServerContext* context, const SetFifoPropertyU64Request* request, SetFifoPropertyU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      NiFpga_FifoProperty property;
-      switch (request->property_enum_case()) {
-        case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::kProperty: {
-          property = static_cast<NiFpga_FifoProperty>(request->property());
-          break;
-        }
-        case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::kPropertyRaw: {
-          property = static_cast<NiFpga_FifoProperty>(request->property_raw());
-          break;
-        }
-        case nifpga_grpc::SetFifoPropertyU64Request::PropertyEnumCase::PROPERTY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for property was not specified or out of range");
-          break;
-        }
-      }
-
-      uint64_t value = request->value();
-      auto status = library_->SetFifoPropertyU64(session, fifo, property, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::StartFifo(::grpc::ServerContext* context, const StartFifoRequest* request, StartFifoResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto status = library_->StartFifo(session, fifo);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::StopFifo(::grpc::ServerContext* context, const StopFifoRequest* request, StopFifoResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto status = library_->StopFifo(session, fifo);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::UnreserveFifo(::grpc::ServerContext* context, const UnreserveFifoRequest* request, UnreserveFifoResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto status = library_->UnreserveFifo(session, fifo);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WaitOnIrqs(::grpc::ServerContext* context, const WaitOnIrqsRequest* request, WaitOnIrqsResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t irqs = request->irqs();
-      uint32_t timeout = request->timeout();
-      NiFpga_IrqContext irq_context {};
-      uint32_t irqs_asserted {};
-      NiFpga_Bool timed_out {};
-      auto status = library_->WaitOnIrqs(session, &irq_context, irqs, timeout, &irqs_asserted, &timed_out);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_irqs_asserted(irqs_asserted);
-      response->set_timed_out(timed_out);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayBool(::grpc::ServerContext* context, const WriteArrayBoolRequest* request, WriteArrayBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array = convert_from_grpc<NiFpga_Bool>(request->array());
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayBool(session, control, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayBool(::grpc::ServerContext* context, const BeginWriteArrayBoolRequest* request, BeginWriteArrayBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayBoolData>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayBool", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayDbl(::grpc::ServerContext* context, const WriteArrayDblRequest* request, WriteArrayDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array = const_cast<double*>(request->array().data());
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayDbl(session, control, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayDbl(::grpc::ServerContext* context, const BeginWriteArrayDblRequest* request, BeginWriteArrayDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayDblData>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayDbl", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayI16(::grpc::ServerContext* context, const WriteArrayI16Request* request, WriteArrayI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array_raw = request->array();
-      auto array = std::vector<int16_t>();
-      array.reserve(array_raw.size());
-      std::transform(
-        array_raw.begin(),
-        array_raw.end(),
-        std::back_inserter(array),
-        [](auto x) {
-              if (x < std::numeric_limits<int16_t>::min() || x > std::numeric_limits<int16_t>::max()) {
-                  std::string message("value ");
-                  message.append(std::to_string(x));
-                  message.append(" doesn't fit in datatype ");
-                  message.append("int16_t");
-                  throw nidevice_grpc::ValueOutOfRangeException(message);
-              }
-              return static_cast<int16_t>(x);
-        });
-
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayI16(session, control, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayI16(::grpc::ServerContext* context, const BeginWriteArrayI16Request* request, BeginWriteArrayI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayI16Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI16", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayI32(::grpc::ServerContext* context, const WriteArrayI32Request* request, WriteArrayI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array = const_cast<int32_t*>(request->array().data());
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayI32(session, control, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayI32(::grpc::ServerContext* context, const BeginWriteArrayI32Request* request, BeginWriteArrayI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayI32Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI32", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayI64(::grpc::ServerContext* context, const WriteArrayI64Request* request, WriteArrayI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array = const_cast<int64_t*>(request->array().data());
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayI64(session, control, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayI64(::grpc::ServerContext* context, const BeginWriteArrayI64Request* request, BeginWriteArrayI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayI64Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI64", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayI8(::grpc::ServerContext* context, const WriteArrayI8Request* request, WriteArrayI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array_raw = request->array();
-      auto array = std::vector<int8_t>();
-      array.reserve(array_raw.size());
-      std::transform(
-        array_raw.begin(),
-        array_raw.end(),
-        std::back_inserter(array),
-        [](auto x) {
-              if (x < std::numeric_limits<int8_t>::min() || x > std::numeric_limits<int8_t>::max()) {
-                  std::string message("value ");
-                  message.append(std::to_string(x));
-                  message.append(" doesn't fit in datatype ");
-                  message.append("int8_t");
-                  throw nidevice_grpc::ValueOutOfRangeException(message);
-              }
-              return static_cast<int8_t>(x);
-        });
-
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayI8(session, control, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayI8(::grpc::ServerContext* context, const BeginWriteArrayI8Request* request, BeginWriteArrayI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayI8Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayI8", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArraySgl(::grpc::ServerContext* context, const WriteArraySglRequest* request, WriteArraySglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array = const_cast<float*>(request->array().data());
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArraySgl(session, control, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArraySgl(::grpc::ServerContext* context, const BeginWriteArraySglRequest* request, BeginWriteArraySglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArraySglData>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArraySgl", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayU16(::grpc::ServerContext* context, const WriteArrayU16Request* request, WriteArrayU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array_raw = request->array();
-      auto array = std::vector<uint16_t>();
-      array.reserve(array_raw.size());
-      std::transform(
-        array_raw.begin(),
-        array_raw.end(),
-        std::back_inserter(array),
-        [](auto x) {
-              if (x < std::numeric_limits<uint16_t>::min() || x > std::numeric_limits<uint16_t>::max()) {
-                  std::string message("value ");
-                  message.append(std::to_string(x));
-                  message.append(" doesn't fit in datatype ");
-                  message.append("uint16_t");
-                  throw nidevice_grpc::ValueOutOfRangeException(message);
-              }
-              return static_cast<uint16_t>(x);
-        });
-
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayU16(session, control, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayU16(::grpc::ServerContext* context, const BeginWriteArrayU16Request* request, BeginWriteArrayU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayU16Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU16", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayU32(::grpc::ServerContext* context, const WriteArrayU32Request* request, WriteArrayU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array = const_cast<uint32_t*>(request->array().data());
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayU32(session, control, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayU32(::grpc::ServerContext* context, const BeginWriteArrayU32Request* request, BeginWriteArrayU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayU32Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU32", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayU64(::grpc::ServerContext* context, const WriteArrayU64Request* request, WriteArrayU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array = const_cast<uint64_t*>(request->array().data());
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayU64(session, control, array, size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayU64(::grpc::ServerContext* context, const BeginWriteArrayU64Request* request, BeginWriteArrayU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayU64Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU64", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteArrayU8(::grpc::ServerContext* context, const WriteArrayU8Request* request, WriteArrayU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto array_raw = request->array();
-      auto array = std::vector<uint8_t>();
-      array.reserve(array_raw.size());
-      std::transform(
-        array_raw.begin(),
-        array_raw.end(),
-        std::back_inserter(array),
-        [](auto x) {
-              if (x < std::numeric_limits<uint8_t>::min() || x > std::numeric_limits<uint8_t>::max()) {
-                  std::string message("value ");
-                  message.append(std::to_string(x));
-                  message.append(" doesn't fit in datatype ");
-                  message.append("uint8_t");
-                  throw nidevice_grpc::ValueOutOfRangeException(message);
-              }
-              return static_cast<uint8_t>(x);
-        });
-
-      size_t size = static_cast<size_t>(request->array().size());
-      auto status = library_->WriteArrayU8(session, control, array.data(), size);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteArrayU8(::grpc::ServerContext* context, const BeginWriteArrayU8Request* request, BeginWriteArrayU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteArrayU8Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteArrayU8", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteBool(::grpc::ServerContext* context, const WriteBoolRequest* request, WriteBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      NiFpga_Bool value = request->value();
-      auto status = library_->WriteBool(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteBool(::grpc::ServerContext* context, const BeginWriteBoolRequest* request, BeginWriteBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteBoolData>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteBool", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteDbl(::grpc::ServerContext* context, const WriteDblRequest* request, WriteDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      double value = request->value();
-      auto status = library_->WriteDbl(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteDbl(::grpc::ServerContext* context, const BeginWriteDblRequest* request, BeginWriteDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteDblData>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteDbl", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoBool(::grpc::ServerContext* context, const WriteFifoBoolRequest* request, WriteFifoBoolResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data = convert_from_grpc<NiFpga_Bool>(request->data());
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoBool(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoDbl(::grpc::ServerContext* context, const WriteFifoDblRequest* request, WriteFifoDblResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data = const_cast<double*>(request->data().data());
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoDbl(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoI16(::grpc::ServerContext* context, const WriteFifoI16Request* request, WriteFifoI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data_raw = request->data();
-      auto data = std::vector<int16_t>();
-      data.reserve(data_raw.size());
-      std::transform(
-        data_raw.begin(),
-        data_raw.end(),
-        std::back_inserter(data),
-        [](auto x) {
-              if (x < std::numeric_limits<int16_t>::min() || x > std::numeric_limits<int16_t>::max()) {
-                  std::string message("value ");
-                  message.append(std::to_string(x));
-                  message.append(" doesn't fit in datatype ");
-                  message.append("int16_t");
-                  throw nidevice_grpc::ValueOutOfRangeException(message);
-              }
-              return static_cast<int16_t>(x);
-        });
-
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoI16(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoI32(::grpc::ServerContext* context, const WriteFifoI32Request* request, WriteFifoI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data = const_cast<int32_t*>(request->data().data());
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoI32(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoI64(::grpc::ServerContext* context, const WriteFifoI64Request* request, WriteFifoI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data = const_cast<int64_t*>(request->data().data());
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoI64(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoI8(::grpc::ServerContext* context, const WriteFifoI8Request* request, WriteFifoI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data_raw = request->data();
-      auto data = std::vector<int8_t>();
-      data.reserve(data_raw.size());
-      std::transform(
-        data_raw.begin(),
-        data_raw.end(),
-        std::back_inserter(data),
-        [](auto x) {
-              if (x < std::numeric_limits<int8_t>::min() || x > std::numeric_limits<int8_t>::max()) {
-                  std::string message("value ");
-                  message.append(std::to_string(x));
-                  message.append(" doesn't fit in datatype ");
-                  message.append("int8_t");
-                  throw nidevice_grpc::ValueOutOfRangeException(message);
-              }
-              return static_cast<int8_t>(x);
-        });
-
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoI8(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoSgl(::grpc::ServerContext* context, const WriteFifoSglRequest* request, WriteFifoSglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data = const_cast<float*>(request->data().data());
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoSgl(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoU16(::grpc::ServerContext* context, const WriteFifoU16Request* request, WriteFifoU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data_raw = request->data();
-      auto data = std::vector<uint16_t>();
-      data.reserve(data_raw.size());
-      std::transform(
-        data_raw.begin(),
-        data_raw.end(),
-        std::back_inserter(data),
-        [](auto x) {
-              if (x < std::numeric_limits<uint16_t>::min() || x > std::numeric_limits<uint16_t>::max()) {
-                  std::string message("value ");
-                  message.append(std::to_string(x));
-                  message.append(" doesn't fit in datatype ");
-                  message.append("uint16_t");
-                  throw nidevice_grpc::ValueOutOfRangeException(message);
-              }
-              return static_cast<uint16_t>(x);
-        });
-
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoU16(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoU32(::grpc::ServerContext* context, const WriteFifoU32Request* request, WriteFifoU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data = const_cast<uint32_t*>(request->data().data());
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoU32(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoU64(::grpc::ServerContext* context, const WriteFifoU64Request* request, WriteFifoU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data = const_cast<uint64_t*>(request->data().data());
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoU64(session, fifo, data, number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteFifoU8(::grpc::ServerContext* context, const WriteFifoU8Request* request, WriteFifoU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t fifo = request->fifo();
-      auto data_raw = request->data();
-      auto data = std::vector<uint8_t>();
-      data.reserve(data_raw.size());
-      std::transform(
-        data_raw.begin(),
-        data_raw.end(),
-        std::back_inserter(data),
-        [](auto x) {
-              if (x < std::numeric_limits<uint8_t>::min() || x > std::numeric_limits<uint8_t>::max()) {
-                  std::string message("value ");
-                  message.append(std::to_string(x));
-                  message.append(" doesn't fit in datatype ");
-                  message.append("uint8_t");
-                  throw nidevice_grpc::ValueOutOfRangeException(message);
-              }
-              return static_cast<uint8_t>(x);
-        });
-
-      size_t number_of_elements = static_cast<size_t>(request->data().size());
-      uint32_t timeout = request->timeout();
-      size_t empty_elements_remaining {};
-      auto status = library_->WriteFifoU8(session, fifo, data.data(), number_of_elements, timeout, &empty_elements_remaining);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      response->set_empty_elements_remaining(empty_elements_remaining);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteI16(::grpc::ServerContext* context, const WriteI16Request* request, WriteI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto value_raw = request->value();
-      if (value_raw < std::numeric_limits<int16_t>::min() || value_raw > std::numeric_limits<int16_t>::max()) {
-          std::string message("value ");
-          message.append(std::to_string(value_raw));
-          message.append(" doesn't fit in datatype ");
-          message.append("int16_t");
-          throw nidevice_grpc::ValueOutOfRangeException(message);
-      }
-      auto value = static_cast<int16_t>(value_raw);
-
-      auto status = library_->WriteI16(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteI16(::grpc::ServerContext* context, const BeginWriteI16Request* request, BeginWriteI16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteI16Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI16", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteI32(::grpc::ServerContext* context, const WriteI32Request* request, WriteI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      int32_t value = request->value();
-      auto status = library_->WriteI32(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteI32(::grpc::ServerContext* context, const BeginWriteI32Request* request, BeginWriteI32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteI32Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI32", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteI64(::grpc::ServerContext* context, const WriteI64Request* request, WriteI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      int64_t value = request->value();
-      auto status = library_->WriteI64(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteI64(::grpc::ServerContext* context, const BeginWriteI64Request* request, BeginWriteI64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteI64Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI64", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteI8(::grpc::ServerContext* context, const WriteI8Request* request, WriteI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto value_raw = request->value();
-      if (value_raw < std::numeric_limits<int8_t>::min() || value_raw > std::numeric_limits<int8_t>::max()) {
-          std::string message("value ");
-          message.append(std::to_string(value_raw));
-          message.append(" doesn't fit in datatype ");
-          message.append("int8_t");
-          throw nidevice_grpc::ValueOutOfRangeException(message);
-      }
-      auto value = static_cast<int8_t>(value_raw);
-
-      auto status = library_->WriteI8(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteI8(::grpc::ServerContext* context, const BeginWriteI8Request* request, BeginWriteI8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteI8Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI8", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteSgl(::grpc::ServerContext* context, const WriteSglRequest* request, WriteSglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      float value = request->value();
-      auto status = library_->WriteSgl(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteSgl(::grpc::ServerContext* context, const BeginWriteSglRequest* request, BeginWriteSglResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteSglData>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteSgl", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteU16(::grpc::ServerContext* context, const WriteU16Request* request, WriteU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto value_raw = request->value();
-      if (value_raw < std::numeric_limits<uint16_t>::min() || value_raw > std::numeric_limits<uint16_t>::max()) {
-          std::string message("value ");
-          message.append(std::to_string(value_raw));
-          message.append(" doesn't fit in datatype ");
-          message.append("uint16_t");
-          throw nidevice_grpc::ValueOutOfRangeException(message);
-      }
-      auto value = static_cast<uint16_t>(value_raw);
-
-      auto status = library_->WriteU16(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteU16(::grpc::ServerContext* context, const BeginWriteU16Request* request, BeginWriteU16Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteU16Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU16", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteU32(::grpc::ServerContext* context, const WriteU32Request* request, WriteU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      uint32_t value = request->value();
-      auto status = library_->WriteU32(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteU32(::grpc::ServerContext* context, const BeginWriteU32Request* request, BeginWriteU32Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteU32Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU32", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteU64(::grpc::ServerContext* context, const WriteU64Request* request, WriteU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      uint64_t value = request->value();
-      auto status = library_->WriteU64(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteU64(::grpc::ServerContext* context, const BeginWriteU64Request* request, BeginWriteU64Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteU64Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU64", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::WriteU8(::grpc::ServerContext* context, const WriteU8Request* request, WriteU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-      auto value_raw = request->value();
-      if (value_raw < std::numeric_limits<uint8_t>::min() || value_raw > std::numeric_limits<uint8_t>::max()) {
-          std::string message("value ");
-          message.append(std::to_string(value_raw));
-          message.append(" doesn't fit in datatype ");
-          message.append("uint8_t");
-          throw nidevice_grpc::ValueOutOfRangeException(message);
-      }
-      auto value = static_cast<uint8_t>(value_raw);
-
-      auto status = library_->WriteU8(session, control, value);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFpgaService::BeginWriteU8(::grpc::ServerContext* context, const BeginWriteU8Request* request, BeginWriteU8Response* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
-      uint32_t control = request->control();
-
-      auto data = std::make_unique<MonikerWriteU8Data>();      
-      data->session = session;
-      data->control = control;
-      data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
-      
-      auto moniker = std::make_unique<ni::data_monikers::Moniker>();
-      ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU8", data.release(), *moniker);
-      response->set_allocated_moniker(moniker.release());
-      response->set_status(0);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
 
-  NiFpgaFeatureToggles::NiFpgaFeatureToggles(
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteI16(::grpc::ServerContext* context, const BeginWriteI16Request* request, BeginWriteI16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteI16Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI16", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteI32(::grpc::ServerContext* context, const WriteI32Request* request, WriteI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    int32_t value = request->value();
+    auto status = library_->WriteI32(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteI32(::grpc::ServerContext* context, const BeginWriteI32Request* request, BeginWriteI32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteI32Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI32", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteI64(::grpc::ServerContext* context, const WriteI64Request* request, WriteI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    int64_t value = request->value();
+    auto status = library_->WriteI64(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteI64(::grpc::ServerContext* context, const BeginWriteI64Request* request, BeginWriteI64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteI64Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI64", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteI8(::grpc::ServerContext* context, const WriteI8Request* request, WriteI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto value_raw = request->value();
+    if (value_raw < std::numeric_limits<int8_t>::min() || value_raw > std::numeric_limits<int8_t>::max()) {
+      std::string message("value ");
+      message.append(std::to_string(value_raw));
+      message.append(" doesn't fit in datatype ");
+      message.append("int8_t");
+      throw nidevice_grpc::ValueOutOfRangeException(message);
+    }
+    auto value = static_cast<int8_t>(value_raw);
+
+    auto status = library_->WriteI8(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteI8(::grpc::ServerContext* context, const BeginWriteI8Request* request, BeginWriteI8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteI8Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteI8", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteSgl(::grpc::ServerContext* context, const WriteSglRequest* request, WriteSglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    float value = request->value();
+    auto status = library_->WriteSgl(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteSgl(::grpc::ServerContext* context, const BeginWriteSglRequest* request, BeginWriteSglResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteSglData>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteSgl", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteU16(::grpc::ServerContext* context, const WriteU16Request* request, WriteU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto value_raw = request->value();
+    if (value_raw < std::numeric_limits<uint16_t>::min() || value_raw > std::numeric_limits<uint16_t>::max()) {
+      std::string message("value ");
+      message.append(std::to_string(value_raw));
+      message.append(" doesn't fit in datatype ");
+      message.append("uint16_t");
+      throw nidevice_grpc::ValueOutOfRangeException(message);
+    }
+    auto value = static_cast<uint16_t>(value_raw);
+
+    auto status = library_->WriteU16(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteU16(::grpc::ServerContext* context, const BeginWriteU16Request* request, BeginWriteU16Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteU16Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU16", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteU32(::grpc::ServerContext* context, const WriteU32Request* request, WriteU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    uint32_t value = request->value();
+    auto status = library_->WriteU32(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteU32(::grpc::ServerContext* context, const BeginWriteU32Request* request, BeginWriteU32Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteU32Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU32", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteU64(::grpc::ServerContext* context, const WriteU64Request* request, WriteU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    uint64_t value = request->value();
+    auto status = library_->WriteU64(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteU64(::grpc::ServerContext* context, const BeginWriteU64Request* request, BeginWriteU64Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteU64Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU64", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::WriteU8(::grpc::ServerContext* context, const WriteU8Request* request, WriteU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+    auto value_raw = request->value();
+    if (value_raw < std::numeric_limits<uint8_t>::min() || value_raw > std::numeric_limits<uint8_t>::max()) {
+      std::string message("value ");
+      message.append(std::to_string(value_raw));
+      message.append(" doesn't fit in datatype ");
+      message.append("uint8_t");
+      throw nidevice_grpc::ValueOutOfRangeException(message);
+    }
+    auto value = static_cast<uint8_t>(value_raw);
+
+    auto status = library_->WriteU8(session, control, value);
+    if (!status_ok(status)) {
+      return ConvertApiErrorStatusForNiFpga_Session(context, status, session);
+    }
+    response->set_status(status);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiFpgaService::BeginWriteU8(::grpc::ServerContext* context, const BeginWriteU8Request* request, BeginWriteU8Response* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto session_grpc_session = request->session();
+    NiFpga_Session session = session_repository_->access_session(session_grpc_session.name());
+    uint32_t control = request->control();
+
+    auto data = std::make_unique<MonikerWriteU8Data>();
+    data->session = session;
+    data->control = control;
+    data->library = std::shared_ptr<NiFpgaLibraryInterface>(library_);
+
+    auto moniker = std::make_unique<ni::data_monikers::Moniker>();
+    ni::data_monikers::DataMonikerService::RegisterMonikerInstance("MonikerWriteU8", data.release(), *moniker);
+    response->set_allocated_moniker(moniker.release());
+    response->set_status(0);
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::NonDriverException& ex) {
+    return ex.GetStatus();
+  }
+}
+
+NiFpgaFeatureToggles::NiFpgaFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nifpga", CodeReadiness::kRelease))
-  {
-  }
-} // namespace nifpga_grpc
-
+          feature_toggles.is_feature_enabled("nifpga", CodeReadiness::kRelease))
+{
+}
+}  // namespace nifpga_grpc

--- a/generated/nifpga/nifpga_service.cpp
+++ b/generated/nifpga/nifpga_service.cpp
@@ -495,8 +495,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -521,8 +520,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -555,8 +553,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -581,8 +578,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -607,8 +603,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -641,8 +636,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -667,8 +661,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -701,8 +694,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -727,8 +719,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -753,8 +744,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -787,8 +777,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -812,8 +801,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -837,8 +825,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -862,8 +849,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -887,8 +873,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -912,8 +897,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -937,8 +921,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -962,8 +945,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -987,8 +969,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -1012,8 +993,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -1037,8 +1017,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -1062,8 +1041,7 @@ namespace nifpga_grpc {
     }
     else
     {
-      // TODO this is not needed if we can make populate_response work which returns error through `AddTrailingMetadata`
-      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "Error code: " + status);
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
     return ::grpc::Status::OK;
 }
@@ -1077,7 +1055,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayBoolData arraybooldata_message;
-    packedData.UnpackTo(&arraybooldata_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arraybooldata_message);
     
     auto data_array = arraybooldata_message.value();
     std::vector<NiFpga_Bool> array(data_array.begin(), data_array.end());
@@ -1097,7 +1075,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayDoubleData arraydoubledata_message;
-    packedData.UnpackTo(&arraydoubledata_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arraydoubledata_message);
     
     auto data_array = arraydoubledata_message.value();
     auto array = const_cast<double*>(arraydoubledata_message.value().data());
@@ -1117,7 +1095,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayi32data_message);
     
     auto data_array = arrayi32data_message.value();
     auto array = std::vector<int16_t>();
@@ -1149,7 +1127,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayi32data_message);
     
     auto data_array = arrayi32data_message.value();
     auto array = const_cast<int32_t*>(arrayi32data_message.value().data());
@@ -1169,7 +1147,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayI64Data arrayi64data_message;
-    packedData.UnpackTo(&arrayi64data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayi64data_message);
     
     auto data_array = arrayi64data_message.value();
     auto array = const_cast<int64_t*>(arrayi64data_message.value().data());
@@ -1189,7 +1167,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayI32Data arrayi32data_message;
-    packedData.UnpackTo(&arrayi32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayi32data_message);
     
     auto data_array = arrayi32data_message.value();
     auto array = std::vector<int8_t>();
@@ -1221,7 +1199,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayFloatData arrayfloatdata_message;
-    packedData.UnpackTo(&arrayfloatdata_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayfloatdata_message);
     
     auto data_array = arrayfloatdata_message.value();
     auto array = const_cast<float*>(arrayfloatdata_message.value().data());
@@ -1241,7 +1219,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayu32data_message);
     
     auto data_array = arrayu32data_message.value();
     auto array = std::vector<uint16_t>();
@@ -1273,7 +1251,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayu32data_message);
     
     auto data_array = arrayu32data_message.value();
     auto array = const_cast<uint32_t*>(arrayu32data_message.value().data());
@@ -1293,7 +1271,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayU64Data arrayu64data_message;
-    packedData.UnpackTo(&arrayu64data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayu64data_message);
     
     auto data_array = arrayu64data_message.value();
     auto array = const_cast<uint64_t*>(arrayu64data_message.value().data());
@@ -1313,7 +1291,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     ArrayU32Data arrayu32data_message;
-    packedData.UnpackTo(&arrayu32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&arrayu32data_message);
     
     auto data_array = arrayu32data_message.value();
     auto array = std::vector<uint8_t>();
@@ -1345,7 +1323,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     BoolData booldata_message;
-    packedData.UnpackTo(&booldata_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&booldata_message);
     auto value = booldata_message.value();
 
     auto status = library->WriteBool(session, control, value);
@@ -1362,7 +1340,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     DoubleData doubledata_message;
-    packedData.UnpackTo(&doubledata_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&doubledata_message);
     auto value = doubledata_message.value();
 
     auto status = library->WriteDbl(session, control, value);
@@ -1379,7 +1357,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&i32data_message);
     auto value = i32data_message.value();
     if (value < std::numeric_limits<int16_t>::min() || value > std::numeric_limits<int16_t>::max()) {
       std::string message("value " + std::to_string(value) + " doesn't fit in datatype int16_t");
@@ -1400,7 +1378,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&i32data_message);
     auto value = i32data_message.value();
 
     auto status = library->WriteI32(session, control, value);
@@ -1417,7 +1395,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     I64Data i64data_message;
-    packedData.UnpackTo(&i64data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&i64data_message);
     auto value = i64data_message.value();
 
     auto status = library->WriteI64(session, control, value);
@@ -1434,7 +1412,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     I32Data i32data_message;
-    packedData.UnpackTo(&i32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&i32data_message);
     auto value = i32data_message.value();
     if (value < std::numeric_limits<int8_t>::min() || value > std::numeric_limits<int8_t>::max()) {
       std::string message("value " + std::to_string(value) + " doesn't fit in datatype int8_t");
@@ -1455,7 +1433,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     FloatData floatdata_message;
-    packedData.UnpackTo(&floatdata_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&floatdata_message);
     auto value = floatdata_message.value();
 
     auto status = library->WriteSgl(session, control, value);
@@ -1472,7 +1450,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&u32data_message);
     auto value = u32data_message.value();
     if (value < std::numeric_limits<uint16_t>::min() || value > std::numeric_limits<uint16_t>::max()) {
       std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint16_t");
@@ -1493,7 +1471,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&u32data_message);
     auto value = u32data_message.value();
 
     auto status = library->WriteU32(session, control, value);
@@ -1510,7 +1488,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     U64Data u64data_message;
-    packedData.UnpackTo(&u64data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&u64data_message);
     auto value = u64data_message.value();
 
     auto status = library->WriteU64(session, control, value);
@@ -1527,7 +1505,7 @@ namespace nifpga_grpc {
     auto control = function_data->control;
 
     U32Data u32data_message;
-    packedData.UnpackTo(&u32data_message); // TODO: should unpack to function_data->mutable_request()
+    packedData.UnpackTo(&u32data_message);
     auto value = u32data_message.value();
     if (value < std::numeric_limits<uint8_t>::min() || value > std::numeric_limits<uint8_t>::max()) {
       std::string message("value " + std::to_string(value) + " doesn't fit in datatype uint8_t");

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1204,24 +1204,24 @@ def get_params_needing_initialization(parameters: List[dict]) -> List[dict]:
     return [p for p in parameters if not (is_return_value(p) or is_get_last_error_output_param(p))]
 
 
-def filter_moniker_streaming_functions(functions, functions_to_generate):
+def filter_moniker_streaming_functions(functions: dict, functions_to_generate: List[str]) -> List[str]:
     """Return streaming functions that need to be generated."""
     return [
         name for name in functions_to_generate if is_moniker_streaming_function(functions[name])
     ]
 
 
-def is_moniker_streaming_function(function):
+def is_moniker_streaming_function(function: dict) -> bool:
     """Whether this function is for streaming data through moniker."""
     return function.get("is_streaming_api", False)
 
 
-def get_data_moniker_function_name(function_name):
+def get_data_moniker_function_name(function_name: str) -> str:
     """Return the corresponding moniker function name for the given C API function."""
     return function_name.replace("Begin", "Moniker")
 
 
-def get_data_moniker_struct_name(begin_function_name):
+def get_data_moniker_struct_name(begin_function_name: str) -> str:
     """Return the Moniker function name.
 
     Input expected is Begin* streaming API name.
@@ -1229,7 +1229,7 @@ def get_data_moniker_struct_name(begin_function_name):
     return f"{begin_function_name.replace('Begin', 'Moniker')}Data"
 
 
-def get_data_moniker_request_message_type(begin_function_name):
+def get_data_moniker_request_message_type(begin_function_name: str) -> str:
     """Return the request message type for Moniker functions.
 
     Input expected is Begin* streaming API name.
@@ -1237,7 +1237,7 @@ def get_data_moniker_request_message_type(begin_function_name):
     return f"{begin_function_name.replace('Begin', '')}StreamingRequest"
 
 
-def get_data_moniker_response_message_type(begin_function_name):
+def get_data_moniker_response_message_type(begin_function_name: str) -> str:
     """Return the response message type for Moniker functions.
 
     Input expected is Begin* streaming API name.
@@ -1245,7 +1245,7 @@ def get_data_moniker_response_message_type(begin_function_name):
     return f"{begin_function_name.replace('Begin', '')}StreamingResponse"
 
 
-def get_data_moniker_function_parameters(function):
+def get_data_moniker_function_parameters(function: dict) -> tuple[List[dict], List[dict]]:
     """Return moniker function parameters split into input/output.
 
     Input expected is equivalent non-streaming function.
@@ -1261,12 +1261,12 @@ def get_data_moniker_function_parameters(function):
     return (input_parameters, output_parameters)
 
 
-def is_function_in_streaming_functions(function_name, streaming_functions_to_generate):
+def is_function_in_streaming_functions(function_name: str, streaming_functions_to_generate: List[str]):
     """Check if a function name is in the streaming functions to generate."""
     return function_name in streaming_functions_to_generate
 
 
-def _is_streaming_param_input_array(streaming_param):
+def _is_streaming_param_input_array(streaming_param: dict) -> bool:
     """Check if the streaming parameter is an input array."""
     return (
         streaming_param
@@ -1275,7 +1275,7 @@ def _is_streaming_param_input_array(streaming_param):
     )
 
 
-def get_non_streaming_input_parameters(parameters):
+def get_non_streaming_input_parameters(parameters: List[dict]) -> List[dict]:
     """Determine if a parameter should be passed from Begin streaming API to Moniker function."""
     streaming_param = get_first_streaming_parameter(parameters)
     params = []

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1207,9 +1207,12 @@ def get_params_needing_initialization(parameters: List[dict]) -> List[dict]:
 def filter_moniker_streaming_functions(functions, functions_to_generate):
     """Return streaming functions that need to be generated."""
     return [
-        name for name in functions_to_generate if functions[name].get("is_streaming_api", False)
+        name for name in functions_to_generate if is_moniker_streaming_function(functions[name])
     ]
 
+def is_moniker_streaming_function(function):
+    """Whether this function is for streaming data through moniker."""
+    return function.get("is_streaming_api", False)
 
 def get_data_moniker_function_name(function_name):
     """Return the corresponding moniker function name for the given C API function."""
@@ -1219,6 +1222,10 @@ def get_data_moniker_function_name(function_name):
 def get_data_moniker_struct_name(function_name):
     """Return the corresponding moniker function name for the given C API function."""
     return f"{function_name.replace('Begin', 'Moniker')}Data"
+
+def get_data_moniker_request_response_data_type(function_name):
+    """Return the corresponding moniker function name for the given C API function."""
+    return f"{function_name.replace('Begin', '')}StreamingData"
 
 
 def is_function_in_streaming_functions(function_name, streaming_functions_to_generate):

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1204,7 +1204,9 @@ def get_params_needing_initialization(parameters: List[dict]) -> List[dict]:
     return [p for p in parameters if not (is_return_value(p) or is_get_last_error_output_param(p))]
 
 
-def filter_moniker_streaming_functions(functions: dict, functions_to_generate: List[str]) -> List[str]:
+def filter_moniker_streaming_functions(
+    functions: dict, functions_to_generate: List[str]
+) -> List[str]:
     """Return streaming functions that need to be generated."""
     return [
         name for name in functions_to_generate if is_moniker_streaming_function(functions[name])
@@ -1261,7 +1263,9 @@ def get_data_moniker_function_parameters(function: dict) -> tuple[List[dict], Li
     return (input_parameters, output_parameters)
 
 
-def is_function_in_streaming_functions(function_name: str, streaming_functions_to_generate: List[str]):
+def is_function_in_streaming_functions(
+    function_name: str, streaming_functions_to_generate: List[str]
+):
     """Check if a function name is in the streaming functions to generate."""
     return function_name in streaming_functions_to_generate
 

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1222,7 +1222,7 @@ def get_data_moniker_function_name(function_name):
 
 
 def get_data_moniker_struct_name(begin_function_name):
-    """Return the Moniker function name..
+    """Return the Moniker function name.
 
     Input expected is Begin* streaming API name.
     """
@@ -1277,12 +1277,7 @@ def _is_streaming_param_input_array(streaming_param):
 
 def get_input_streaming_params(parameters):
     """Determine if a parameter should be included based on streaming conditions."""
-    streaming_param = None
-    for param in parameters:
-        if param.get("is_streaming_type", False):
-            streaming_param = param
-            break
-
+    streaming_param = get_first_streaming_parameter(parameters)
     params = []
     for param in parameters:
         if is_input_parameter(param) and not param.get("is_streaming_type", False):

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1222,24 +1222,33 @@ def get_data_moniker_function_name(function_name):
 
 
 def get_data_moniker_struct_name(begin_function_name):
-    """Return the corresponding moniker function name for the given Begin* C API function."""
+    """Return the Moniker function name..
+
+    Input expected is Begin* streaming API name.
+    """
     return f"{begin_function_name.replace('Begin', 'Moniker')}Data"
 
 
 def get_data_moniker_request_message_type(begin_function_name):
-    """Return the request message type for corresponding moniker function name given Begin* C API function."""
+    """Return the request message type for Moniker functions.
+
+    Input expected is Begin* streaming API name.
+    """
     return f"{begin_function_name.replace('Begin', '')}StreamingRequest"
 
 
 def get_data_moniker_response_message_type(begin_function_name):
-    """Return the response message type for corresponding moniker function name given Begin* C API function."""
+    """Return the response message type for Moniker functions.
+
+    Input expected is Begin* streaming API name.
+    """
     return f"{begin_function_name.replace('Begin', '')}StreamingResponse"
 
 
 def get_data_moniker_function_parameters(function):
-    """Given non-streaming function equivalent filter the parameters needed for Moniker APIs for streaming APIs,
-    and split into input/output parameters.
+    """Return moniker function parameters split into input/output.
 
+    Input expected is equivalent non-streaming function.
     Add a default "status" output parameter if there isn't one already.
     """
     parameter_array = filter_parameters_for_grpc_fields(function["parameters"])

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -3,7 +3,7 @@
 import os
 import re
 from collections import defaultdict, namedtuple
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 _NIDEVICE_COMMON_MESSAGE_TYPES = (
     "nidevice_grpc.NIComplexNumber",
@@ -1247,7 +1247,7 @@ def get_data_moniker_response_message_type(begin_function_name: str) -> str:
     return f"{begin_function_name.replace('Begin', '')}StreamingResponse"
 
 
-def get_data_moniker_function_parameters(function: dict) -> tuple[List[dict], List[dict]]:
+def get_data_moniker_function_parameters(function: dict) -> Tuple[List[dict], List[dict]]:
     """Return moniker function parameters split into input/output.
 
     Input expected is equivalent non-streaming function.

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1275,8 +1275,8 @@ def _is_streaming_param_input_array(streaming_param):
     )
 
 
-def get_input_streaming_params(parameters):
-    """Determine if a parameter should be included based on streaming conditions."""
+def get_non_streaming_input_parameters(parameters):
+    """Determine if a parameter should be passed from Begin streaming API to Moniker function."""
     streaming_param = get_first_streaming_parameter(parameters)
     params = []
     for param in parameters:

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -253,6 +253,18 @@ def get_parameters(function):
 
     return (input_parameters, output_parameters)
 
+def get_streaming_moniker_function_parameters(function):
+    """TODO
+    """
+    parameter_array = common_helpers.filter_parameters_for_grpc_fields(function["parameters"])
+    input_parameters = [p for p in parameter_array if common_helpers.is_input_parameter(p) and p.get("is_streaming_type", False)]
+    default_status_param = {"name": "status", "type": "int32", "grpc_type": "int32"}
+    output_parameters = [default_status_param]
+    output_parameters.extend(
+        [p for p in parameter_array if common_helpers.is_output_parameter(p)]
+    )
+    return (input_parameters, output_parameters)
+
 
 def _get_callback_output_params(function):
     """Look for a parameter that specifies callback_params and return those params.

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -253,18 +253,6 @@ def get_parameters(function):
 
     return (input_parameters, output_parameters)
 
-def get_streaming_moniker_function_parameters(function):
-    """TODO
-    """
-    parameter_array = common_helpers.filter_parameters_for_grpc_fields(function["parameters"])
-    input_parameters = [p for p in parameter_array if common_helpers.is_input_parameter(p) and p.get("is_streaming_type", False)]
-    default_status_param = {"name": "status", "type": "int32", "grpc_type": "int32"}
-    output_parameters = [default_status_param]
-    output_parameters.extend(
-        [p for p in parameter_array if common_helpers.is_output_parameter(p)]
-    )
-    return (input_parameters, output_parameters)
-
 
 def _get_callback_output_params(function):
     """Look for a parameter that specifies callback_params and return those params.

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -709,15 +709,7 @@ def get_protobuf_cpplib_type(grpc_type: str) -> str:
     return grpc_type
 
 
-def get_streaming_type(parameters) -> str:
-    """Get the streaming type from the function data."""
-    for param in parameters:
-        if param.get("is_streaming_type", False):
-            return param["type"]
-    return None
-
-
-def get_size_param_name(streaming_param) -> str:
+def get_size_param_name(streaming_param: dict) -> str:
     """Get the size parameter name for the given streaming parameter.
 
     The size is only present for read arrays, which have an "out" direction.
@@ -726,11 +718,3 @@ def get_size_param_name(streaming_param) -> str:
         return common_helpers.camel_to_snake(streaming_param["size"]["value"])
     else:
         return None
-
-
-def get_c_api_name(function_name) -> str:
-    """Get the C API name for the given function name."""
-    if function_name.startswith("Begin"):
-        base_name = function_name[len("Begin") :]
-        return f"{base_name}"
-    return f"{function_name}"

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -734,14 +734,3 @@ def get_c_api_name(function_name) -> str:
         base_name = function_name[len("Begin") :]
         return f"{base_name}"
     return f"{function_name}"
-
-
-def is_secondary_streaming_param(param, first_streaming_param) -> bool:
-    """Check if a parameter is a secondry streaming type parameter."""
-    return param.get("is_streaming_type", False) and param["name"] != first_streaming_param["name"]
-
-
-def get_output_streaming_params_to_define(parameters, first_streaming_param) -> List[dict]:
-    """Get the list of output streaming parameters that need to be defined."""
-    output_params = [p for p in parameters if common_helpers.is_output_parameter(p)]
-    return [p for p in output_params if is_secondary_streaming_param(p, first_streaming_param)]

--- a/source/codegen/templates/proto.mako
+++ b/source/codegen/templates/proto.mako
@@ -68,4 +68,8 @@ ${mako_helper.define_request_message(function, input_parameters)}\
 
 ${mako_helper.define_response_message(function, output_parameters)}\
 
+% if common_helpers.is_moniker_streaming_function(functions[function]):
+${mako_helper.define_moniker_request_response_message(function, functions)}\
+
+% endif
 % endfor

--- a/source/codegen/templates/proto.mako
+++ b/source/codegen/templates/proto.mako
@@ -69,7 +69,7 @@ ${mako_helper.define_request_message(function, input_parameters)}\
 ${mako_helper.define_response_message(function, output_parameters)}\
 
 % if common_helpers.is_moniker_streaming_function(functions[function]):
-${mako_helper.define_moniker_request_response_message(function, functions)}\
+${mako_helper.define_moniker_request_response_messages(function, functions)}\
 
 % endif
 % endfor

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -116,29 +116,23 @@ message ${common_helpers.snake_to_pascal(function)}Response {
 ## Define a proto message moniker streaming function.
 <%def name="define_moniker_request_response_message(begin_function_name, functions)">\
 <%
-  request_response_data_type = common_helpers.get_data_moniker_request_response_data_type(begin_function_name)
   non_streaming_function_name = begin_function_name.replace("Begin", "")
-  input_parameters, output_parameters = proto_helpers.get_streaming_moniker_function_parameters(functions[non_streaming_function_name])
+  input_parameters, output_parameters = common_helpers.get_data_moniker_function_parameters(functions[non_streaming_function_name])
 
   request_parameters = proto_helpers.get_message_parameter_definitions(input_parameters)
   response_parameters = proto_helpers.get_message_parameter_definitions(output_parameters)
+  request_message_type = common_helpers.get_data_moniker_request_message_type(begin_function_name)
+  response_message_type = common_helpers.get_data_moniker_response_message_type(begin_function_name)
 %>\
-message ${request_response_data_type} {
 % if request_parameters:
-  ${request_response_data_type}Request request = 1;
-% endif
-  ${request_response_data_type}Response response = 2;
-}
-
-% if request_parameters:
-message ${request_response_data_type}Request {
+message ${request_message_type} {
 % for parameter in request_parameters:
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
 % endfor
 }
 
 % endif
-message ${request_response_data_type}Response {
+message ${response_message_type} {
 % for parameter in response_parameters:
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
 % endfor

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -113,6 +113,38 @@ message ${common_helpers.snake_to_pascal(function)}Response {
 }
 </%def>
 
+## Define a proto message moniker streaming function.
+<%def name="define_moniker_request_response_message(begin_function_name, functions)">\
+<%
+  request_response_data_type = common_helpers.get_data_moniker_request_response_data_type(begin_function_name)
+  non_streaming_function_name = begin_function_name.replace("Begin", "")
+  input_parameters, output_parameters = proto_helpers.get_streaming_moniker_function_parameters(functions[non_streaming_function_name])
+
+  request_parameters = proto_helpers.get_message_parameter_definitions(input_parameters)
+  response_parameters = proto_helpers.get_message_parameter_definitions(output_parameters)
+%>\
+message ${request_response_data_type} {
+% if request_parameters:
+  ${request_response_data_type}Request request = 1;
+% endif
+  ${request_response_data_type}Response response = 2;
+}
+
+% if request_parameters:
+message ${request_response_data_type}Request {
+% for parameter in request_parameters:
+  ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
+% endfor
+}
+
+% endif
+message ${request_response_data_type}Response {
+% for parameter in response_parameters:
+  ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
+% endfor
+}
+</%def>
+
 ## Define a proto message for a given custom type.
 <%def name="define_custom_type(custom_type)">\
 <%

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -113,12 +113,11 @@ message ${common_helpers.snake_to_pascal(function)}Response {
 }
 </%def>
 
-## Define a proto message moniker streaming function.
-<%def name="define_moniker_request_response_message(begin_function_name, functions)">\
+## Define a proto request and response messages for Moniker function.
+<%def name="define_moniker_request_response_messages(begin_function_name, functions)">\
 <%
   non_streaming_function_name = begin_function_name.replace("Begin", "")
   input_parameters, output_parameters = common_helpers.get_data_moniker_function_parameters(functions[non_streaming_function_name])
-
   request_parameters = proto_helpers.get_message_parameter_definitions(input_parameters)
   response_parameters = proto_helpers.get_message_parameter_definitions(output_parameters)
   request_message_type = common_helpers.get_data_moniker_request_message_type(begin_function_name)

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -165,7 +165,7 @@ ${mako_helper.define_ivi_dance_with_a_twist_method_body(function_name=function_n
 %   elif common_helpers.has_repeated_varargs_parameter(parameters):
 ${mako_helper.define_repeated_varargs_method_body(function_name=function_name, function_data=function_data, parameters=parameters)}
 %   elif common_helpers.is_function_in_streaming_functions(function_name, streaming_functions_to_generate):
-${mako_helper.define_streaming_api_body(function_name=function_name, function_data=function_data, parameters=parameters)}
+${mako_helper.define_streaming_api_body(function_name=function_name, parameters=parameters)}
 %   else:
 ${mako_helper.define_simple_method_body(function_name=function_name, function_data=function_data, parameters=parameters)}
 %   endif

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -13,7 +13,7 @@ custom_types = common_helpers.get_custom_types(config)
 has_async_functions = any(service_helpers.get_async_functions(functions))
 has_two_dimension_functions = any(service_helpers.get_functions_with_two_dimension_param(functions))
 functions_to_generate = service_helpers.filter_proto_rpc_functions_to_generate(functions)
-streaming_functions_to_generate = common_helpers.filter_moniker_streaming_functions (functions, functions_to_generate)
+streaming_functions_to_generate = common_helpers.filter_moniker_streaming_functions(functions, functions_to_generate)
 # If there are any non-mockable functions, we need to call the library directly, which
 # means we need another include file
 any_non_mockable_functions = any(not common_helpers.can_mock_function(functions[name]['parameters']) for name in functions_to_generate)
@@ -67,8 +67,11 @@ namespace ${config["namespace_component"]}_grpc {
 <%
 function_data = functions[function_name]
 parameters = function_data['parameters']
+non_streaming_function_name = function_name.replace("Begin", "")
+input_parameters, output_parameters = common_helpers.get_data_moniker_function_parameters(functions[non_streaming_function_name])
+has_input_parameters = len(input_parameters) != 0
 %>
-${mako_helper.define_moniker_streaming_struct(function_name=function_name, parameters=parameters)}\
+${mako_helper.define_moniker_streaming_struct(begin_function_name=function_name, parameters=parameters, has_input_parameters=has_input_parameters)}\
 % endfor
 
 % if any_ivi_dance_functions:

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -118,12 +118,11 @@ ${mako_helper.define_moniker_streaming_struct(function_name=function_name, param
   ${mako_helper.register_moniker_functions(function_name)}\
 % endfor
   }
+
 % endif
 % for function_name in streaming_functions_to_generate:
-<%
-function_data = functions[function_name]
-%>
-${mako_helper.define_moniker_function_body(function_name=function_name, function_data=function_data)}\
+${mako_helper.define_moniker_function_body(function_name=function_name, functions=functions)}\
+
 % endfor
 % for function_name in service_helpers.filter_proto_rpc_functions_to_generate(functions):
 <%

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -313,7 +313,6 @@ ${populate_response(function_data=function_data, parameters=parameters)}\
   non_streaming_function_name = function_name.replace("Begin", "")
   non_streaming_function_parameters = functions[non_streaming_function_name]['parameters']
   arg_string = service_helpers.create_args(non_streaming_function_parameters)
-  c_api_name = service_helpers.get_c_api_name(function_name)
   output_parameters = [p for p in non_streaming_function_parameters if common_helpers.is_output_parameter(p)]
 %>\
 ::grpc::Status ${moniker_function_name}(void* data, google::protobuf::Arena& arena, google::protobuf::Any& packedData)
@@ -327,7 +326,7 @@ ${initialize_output_params(output_parameters)}\
 ${streaming_handle_in_direction(streaming_param)}\
     % endif
 
-    auto status = library->${c_api_name}(${arg_string});
+    auto status = library->${non_streaming_function_name}(${arg_string});
 
 ${populate_moniker_response_for_out_functions(output_parameters, streaming_param)}\
     return ::grpc::Status::OK;

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -431,6 +431,11 @@ ${set_response_values(output_parameters=output_parameters, init_method=false)}\
       ## But that needs `context` parameter which is not available in Moniker functions.
       return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
     }
+% else:
+    if (status < 0)
+    {
+      return ::grpc::Status(grpc::StatusCode::UNKNOWN, "ni-error: " + status);
+    }
 % endif
 </%def>
 

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -278,12 +278,13 @@ ${populate_response(function_data=function_data, parameters=parameters)}\
     ni::data_monikers::DataMonikerService::RegisterMonikerEndpoint("${moniker_function_name}", ${moniker_function_name});
 </%def>
 
-<%def name="define_moniker_streaming_struct(function_name, parameters)">\
+<%def name="define_moniker_streaming_struct(begin_function_name, parameters, has_input_parameters)">\
 <%
   config = data['config']
   service_class_prefix = config["service_class_prefix"]
-  struct_name = common_helpers.get_data_moniker_struct_name(function_name)
-  request_response_data_type = common_helpers.get_data_moniker_request_response_data_type(function_name)
+  struct_name = common_helpers.get_data_moniker_struct_name(begin_function_name)
+  request_message_type = common_helpers.get_data_moniker_request_message_type(begin_function_name)
+  response_message_type = common_helpers.get_data_moniker_response_message_type(begin_function_name)
   streaming_params_to_include = common_helpers.get_input_streaming_params(parameters)
 %>\
   struct ${struct_name}
@@ -298,7 +299,10 @@ ${populate_response(function_data=function_data, parameters=parameters)}\
      ${parameter['type']} ${parameter_name};
 % endif
 % endfor
-     ${service_class_prefix.lower()}_grpc::${request_response_data_type} data;
+% if has_input_parameters:
+     ${service_class_prefix.lower()}_grpc::${request_message_type} request;
+% endif
+     ${service_class_prefix.lower()}_grpc::${response_message_type} response;
      std::shared_ptr<${service_class_prefix}LibraryInterface> library;
   };
 </%def>

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -480,8 +480,8 @@ ${initialize_input_param(function_name, param, parameters)}\
 <%
   grpc_field_name = common_helpers.get_grpc_field_name(param)
 %>\
-      data->mutable_response()->mutable_${grpc_field_name}()->Reserve(request->${size_param_name}());
-      data->mutable_response()->mutable_${grpc_field_name}()->Resize(request->${size_param_name}(), 0);
+      data->response.mutable_${grpc_field_name}()->Reserve(request->${size_param_name}());
+      data->response.mutable_${grpc_field_name}()->Resize(request->${size_param_name}(), 0);
 % endif
 % endfor
 </%def>

--- a/source/tests/integration/ni_fake_fpga_streaming_tests.cpp
+++ b/source/tests/integration/ni_fake_fpga_streaming_tests.cpp
@@ -133,8 +133,8 @@ TEST_F(NiFakeFpgaStreamingTests, StreamRead_scalar)
   for (int i = 0; i < 5; i++)
   {
     // Read data
-    nifpga_grpc::I32Data read_value_i32;
-    nifpga_grpc::I64Data read_value_i64;
+    nifpga_grpc::ReadI32StreamingResponse read_value_i32;
+    nifpga_grpc::ReadI64StreamingResponse read_value_i64;
 
     ni::data_monikers::MonikerReadResponse read_result;
     stream->Read(&read_result);
@@ -181,18 +181,18 @@ TEST_F(NiFakeFpgaStreamingTests, StreamRead_Array)
 
   for (int i = 0; i < 5; i++) {
     // Read data
-    nifpga_grpc::ArrayI32Data read_values_i32;
-    nifpga_grpc::ArrayI64Data read_values_i64;
+    nifpga_grpc::ReadArrayI32StreamingResponse read_values_i32;
+    nifpga_grpc::ReadArrayI64StreamingResponse read_values_i64;
 
     ni::data_monikers::MonikerReadResponse read_result;
     stream->Read(&read_result);
 
     read_result.data().values(0).UnpackTo(&read_values_i32);
     read_result.data().values(1).UnpackTo(&read_values_i64);
-    ASSERT_THAT(read_values_i32.value(), SizeIs(10));
-    ASSERT_THAT(read_values_i32.value(), ElementsAreArray(data_int_i32));
-    ASSERT_THAT(read_values_i64.value(), SizeIs(9));
-    ASSERT_THAT(read_values_i64.value(), ElementsAreArray(data_int_i64));
+    ASSERT_THAT(read_values_i32.array(), SizeIs(10));
+    ASSERT_THAT(read_values_i32.array(), ElementsAreArray(data_int_i32));
+    ASSERT_THAT(read_values_i64.array(), SizeIs(9));
+    ASSERT_THAT(read_values_i64.array(), ElementsAreArray(data_int_i64));
   }
 
   moniker_context.TryCancel();
@@ -319,18 +319,18 @@ TEST_F(NiFakeFpgaStreamingTests, StreamReadWrite_Array)
 
     write_stream->Write(write_data_request);
 
-    nifpga_grpc::ArrayI32Data read_values_i32;
-    nifpga_grpc::ArrayI64Data read_values_i64;
+    nifpga_grpc::ReadArrayI32StreamingResponse read_values_i32;
+    nifpga_grpc::ReadArrayI64StreamingResponse read_values_i64;
 
     ni::data_monikers::MonikerReadResponse read_result;
     write_stream->Read(&read_result);
 
     read_result.data().values(0).UnpackTo(&read_values_i32);
     read_result.data().values(1).UnpackTo(&read_values_i64);
-    ASSERT_THAT(read_values_i32.value(), SizeIs(read_size_i32));
-    ASSERT_THAT(read_values_i32.value(), ElementsAreArray(read_data_int32));
-    ASSERT_THAT(read_values_i64.value(), SizeIs(read_size_i64));
-    ASSERT_THAT(read_values_i64.value(), ElementsAreArray(read_data_int64));
+    ASSERT_THAT(read_values_i32.array(), SizeIs(read_size_i32));
+    ASSERT_THAT(read_values_i32.array(), ElementsAreArray(read_data_int32));
+    ASSERT_THAT(read_values_i64.array(), SizeIs(read_size_i64));
+    ASSERT_THAT(read_values_i64.array(), ElementsAreArray(read_data_int64));
   }
 
   write_stream->WritesDone();
@@ -405,18 +405,18 @@ TEST_F(NiFakeFpgaStreamingTests, DISABLED_SidebandStreamReadWrite_Array)
 
     WriteSidebandMessage(sideband_token, write_data_request);
 
-    nifpga_grpc::ArrayI32Data read_values_i32;
-    nifpga_grpc::ArrayI64Data read_values_i64;
+    nifpga_grpc::ReadArrayI32StreamingResponse read_values_i32;
+    nifpga_grpc::ReadArrayI64StreamingResponse read_values_i64;
 
     ni::data_monikers::SidebandReadResponse read_result;
     ReadSidebandMessage(sideband_token, &read_result);
 
     read_result.values().values(0).UnpackTo(&read_values_i32);
     read_result.values().values(1).UnpackTo(&read_values_i64);
-    ASSERT_THAT(read_values_i32.value(), SizeIs(10));
-    ASSERT_THAT(read_values_i32.value(), ElementsAreArray(data_int32));
-    ASSERT_THAT(read_values_i64.value(), SizeIs(9));
-    ASSERT_THAT(read_values_i64.value(), ElementsAreArray(data_int64));
+    ASSERT_THAT(read_values_i32.array(), SizeIs(10));
+    ASSERT_THAT(read_values_i32.array(), ElementsAreArray(data_int32));
+    ASSERT_THAT(read_values_i64.array(), SizeIs(9));
+    ASSERT_THAT(read_values_i64.array(), ElementsAreArray(data_int64));
   }
 
   ni::data_monikers::SidebandWriteRequest cancel_request;


### PR DESCRIPTION
### What does this Pull Request accomplish?
- Values returned from streaming APIs are now in `<function-name>StreamingResponse` message.
- Most of the custom codegen written for Moniker APIs was needed because output was not in standard "response" message. With this change, I was able to delete most of the custom codegen written for streaming functionality.

### Why should this Pull Request be merged?
Moniker functions used for streaming data to/from clients used to return custom data types defined in `custom_proto.mako` file for DAQ and FPGA. This has multiple limitations.
- The custom types had only one field `value` for streaming. Read APIs with multiple out parameters need multiple values in response.
- Response was not provided in standard `<function-name>Response` message that other grpc APIs use.


### What testing has been done?
- Existing integration tests for FPGA streaming APIs pass.
- Executed sample client tests with StreamRead/StreamWrite and validated results.