### PR TITLE
Make sideband port configurable via json file.

### DIFF
--- a/source/config/localhost_config.json
+++ b/source/config/localhost_config.json
@@ -2,6 +2,7 @@
     "address": "[::1]",
     "port": 31763,
     "sideband_address": "[::1]",
+    "sideband_port": 50050,
     "security" : {
        "server_cert": "",
        "server_key": "",

--- a/source/config/localhost_config.json
+++ b/source/config/localhost_config.json
@@ -1,7 +1,6 @@
 {
     "address": "[::1]",
     "port": 31763,
-    "sideband_address": "[::1]",
     "sideband_port": 50050,
     "security" : {
        "server_cert": "",

--- a/source/config/localhost_config.json
+++ b/source/config/localhost_config.json
@@ -1,6 +1,7 @@
 {
     "address": "[::1]",
     "port": 31763,
+    "sideband_address": "[::1]",
     "sideband_port": 50055,
     "security" : {
        "server_cert": "",

--- a/source/config/localhost_config.json
+++ b/source/config/localhost_config.json
@@ -1,7 +1,7 @@
 {
     "address": "[::1]",
     "port": 31763,
-    "sideband_port": 50050,
+    "sideband_port": 50055,
     "security" : {
        "server_cert": "",
        "server_key": "",

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -29,12 +29,13 @@ using FeatureToggles = nidevice_grpc::FeatureToggles;
 
 struct ServerConfiguration {
   std::string config_file_path;
-  std::string server_address;
-  std::string sideband_address;
+  std::string address;
   std::string server_cert;
   std::string server_key;
   std::string root_cert;
   int max_message_size;
+  int server_port;
+  int sideband_port;
   nidevice_grpc::FeatureToggles feature_toggles;
 };
 
@@ -47,8 +48,9 @@ static ServerConfiguration GetConfiguration(const std::string& config_file_path)
         : nidevice_grpc::ServerConfigurationParser(config_file_path);
 
     config.config_file_path = server_config_parser.get_config_file_path();
-    config.server_address = server_config_parser.parse_address();
-    config.sideband_address = server_config_parser.parse_sideband_address();
+    config.address = server_config_parser.parse_bind_address();
+    config.server_port = server_config_parser.parse_port();
+    config.sideband_port = server_config_parser.parse_sideband_port();
     config.server_cert = server_config_parser.parse_server_cert();
     config.server_key = server_config_parser.parse_server_key();
     config.root_cert = server_config_parser.parse_root_cert();
@@ -92,7 +94,8 @@ static void RunServer(const ServerConfiguration& config)
   grpc::ServerBuilder builder;
   int listeningPort = 0;
   nidevice_grpc::ServerSecurityConfiguration server_security_config(config.server_cert, config.server_key, config.root_cert);
-  builder.AddListeningPort(config.server_address, server_security_config.get_credentials(), &listeningPort);
+  std::string server_address = config.address + ":" + std::to_string(config.server_port);
+  builder.AddListeningPort(server_address, server_security_config.get_credentials(), &listeningPort);
 
   auto services = nidevice_grpc::register_all_services(builder, config.feature_toggles);
 
@@ -110,7 +113,7 @@ static void RunServer(const ServerConfiguration& config)
     }
     server = builder.BuildAndStart();
     if (ni::data_monikers::is_sideband_streaming_enabled(config.feature_toggles)) {
-      auto sideband_socket_thread = new std::thread(RunSidebandSocketsAccept, config.sideband_address.c_str(), 50055);
+      auto sideband_socket_thread = new std::thread(RunSidebandSocketsAccept, config.address.c_str(), config.sideband_port);
       // auto sideband_rdma_send_thread = new std::thread(AcceptSidebandRdmaSendRequests);
       // auto sideband_rdma_recv_thread = new std::thread(AcceptSidebandRdmaReceiveRequests);
     }
@@ -119,7 +122,7 @@ static void RunServer(const ServerConfiguration& config)
   if (!server) {
     nidevice_grpc::logging::log(
         nidevice_grpc::logging::Level_Error,
-        "Server failed to start on %s", config.server_address.c_str());
+        "Server failed to start on %s", server_address.c_str());
     exit(EXIT_FAILURE);
   }
 

--- a/source/server/server_configuration_parser.cpp
+++ b/source/server/server_configuration_parser.cpp
@@ -17,6 +17,7 @@ namespace nidevice_grpc {
 static const char* kDefaultFilename = "server_config.json";
 static const char* kAddressJsonKey = "address";
 static const char* kPortJsonKey = "port";
+static const char* kSidebandAddressJsonKey = "sideband_address";
 static const char* kSidebandPortJsonKey = "sideband_port";
 static const char* kServerCertJsonKey = "server_cert";
 static const char* kServerKeyJsonKey = "server_key";
@@ -100,6 +101,12 @@ std::string ServerConfigurationParser::parse_address() const
 {
   auto address = parse_bind_address() + ":" + std::to_string(parse_port());
   return address;
+}
+
+std::string ServerConfigurationParser::parse_sideband_address() const
+{
+  auto it = config_file_.find(kSidebandAddressJsonKey);
+  return it != config_file_.end() ? it->get<std::string>() : "";
 }
 
 std::string ServerConfigurationParser::parse_server_cert() const

--- a/source/server/server_configuration_parser.cpp
+++ b/source/server/server_configuration_parser.cpp
@@ -17,7 +17,7 @@ namespace nidevice_grpc {
 static const char* kDefaultFilename = "server_config.json";
 static const char* kAddressJsonKey = "address";
 static const char* kPortJsonKey = "port";
-static const char* kSidebandAddressJsonKey = "sideband_address";
+static const char* kSidebandPortJsonKey = "sideband_port";
 static const char* kServerCertJsonKey = "server_cert";
 static const char* kServerKeyJsonKey = "server_key";
 static const char* kRootCertJsonKey = "root_cert";
@@ -102,12 +102,6 @@ std::string ServerConfigurationParser::parse_address() const
   return address;
 }
 
-std::string ServerConfigurationParser::parse_sideband_address() const
-{
-  auto it = config_file_.find(kSidebandAddressJsonKey);
-  return it != config_file_.end() ? it->get<std::string>() : "";
-}
-
 std::string ServerConfigurationParser::parse_server_cert() const
 {
   auto file_name = parse_key_from_security_section(kServerCertJsonKey);
@@ -139,6 +133,21 @@ int ServerConfigurationParser::parse_max_message_size() const
   }
 
   return UNLIMITED_MAX_MESSAGE_SIZE;
+}
+
+int ServerConfigurationParser::parse_sideband_port() const
+{
+  auto sideband_port = config_file_.find(kSidebandPortJsonKey);
+  if (sideband_port != config_file_.end()) {
+    try {
+      return sideband_port->get<int>();
+    }
+    catch (const nlohmann::json::type_error& ex) {
+      throw InvalidMaxMessageSizeException(ex.what());
+    }
+  }
+
+  return DEFAULT_SIDEBAND_PORT;
 }
 
 FeatureToggles ServerConfigurationParser::parse_feature_toggles() const

--- a/source/server/server_configuration_parser.cpp
+++ b/source/server/server_configuration_parser.cpp
@@ -144,17 +144,7 @@ int ServerConfigurationParser::parse_max_message_size() const
 
 int ServerConfigurationParser::parse_sideband_port() const
 {
-  auto sideband_port = config_file_.find(kSidebandPortJsonKey);
-  if (sideband_port != config_file_.end()) {
-    try {
-      return sideband_port->get<int>();
-    }
-    catch (const nlohmann::json::type_error& ex) {
-      throw InvalidMaxMessageSizeException(ex.what());
-    }
-  }
-
-  return DEFAULT_SIDEBAND_PORT;
+  return parse_port_with_key(kSidebandPortJsonKey);
 }
 
 FeatureToggles ServerConfigurationParser::parse_feature_toggles() const
@@ -270,9 +260,14 @@ std::string ServerConfigurationParser::parse_bind_address() const
 
 int ServerConfigurationParser::parse_port() const
 {
+  return parse_port_with_key(kPortJsonKey);
+}
+
+int ServerConfigurationParser::parse_port_with_key(const std::string& key) const
+{
   int parsed_port = -1;
 
-  auto it = config_file_.find(kPortJsonKey);
+  auto it = config_file_.find(key);
   if (it != config_file_.end()) {
     try {
       parsed_port = it->get<int>();

--- a/source/server/server_configuration_parser.h
+++ b/source/server/server_configuration_parser.h
@@ -37,12 +37,11 @@ class ServerConfigurationParser {
   const std::string& get_config_file_path() const { return config_file_path_; }
 
   std::string parse_address() const;
-  std::string parse_bind_address() const;
+  std::string parse_sideband_address() const;
   std::string parse_server_cert() const;
   std::string parse_server_key() const;
   std::string parse_root_cert() const;
   int parse_max_message_size() const;
-  int parse_port() const;
   int parse_sideband_port() const;
   FeatureToggles parse_feature_toggles() const;
   FeatureToggles::CodeReadiness parse_code_readiness() const;
@@ -104,6 +103,8 @@ class ServerConfigurationParser {
   static std::string read_keycert(const std::string& filename);
   static std::string get_certs_directory(const std::string& config_file_path);
   std::string parse_key_from_security_section(const char* key) const;
+  std::string parse_bind_address() const;
+  int parse_port() const;
 
   std::string config_file_path_;
   nlohmann::json config_file_;

--- a/source/server/server_configuration_parser.h
+++ b/source/server/server_configuration_parser.h
@@ -23,6 +23,7 @@ static const char* kInvalidFeatureToggleMessage = "Feature Toggles must be speci
 static const char* kInvalidCodeReadinessMessage = "code_readiness must be a string in [Release, RestrictedRelease, NextRelease, RestrictedNextRelease, Incomplete, Prototype].\n\n";
 static const char* kDefaultAddress = "[::]";
 constexpr int UNLIMITED_MAX_MESSAGE_SIZE = -1;
+constexpr int DEFAULT_SIDEBAND_PORT = 50055;
 
 class ServerConfigurationParser {
  public:
@@ -36,11 +37,13 @@ class ServerConfigurationParser {
   const std::string& get_config_file_path() const { return config_file_path_; }
 
   std::string parse_address() const;
-  std::string parse_sideband_address() const;
+  std::string parse_bind_address() const;
   std::string parse_server_cert() const;
   std::string parse_server_key() const;
   std::string parse_root_cert() const;
   int parse_max_message_size() const;
+  int parse_port() const;
+  int parse_sideband_port() const;
   FeatureToggles parse_feature_toggles() const;
   FeatureToggles::CodeReadiness parse_code_readiness() const;
 
@@ -101,8 +104,6 @@ class ServerConfigurationParser {
   static std::string read_keycert(const std::string& filename);
   static std::string get_certs_directory(const std::string& config_file_path);
   std::string parse_key_from_security_section(const char* key) const;
-  std::string parse_bind_address() const;
-  int parse_port() const;
 
   std::string config_file_path_;
   nlohmann::json config_file_;

--- a/source/server/server_configuration_parser.h
+++ b/source/server/server_configuration_parser.h
@@ -23,7 +23,6 @@ static const char* kInvalidFeatureToggleMessage = "Feature Toggles must be speci
 static const char* kInvalidCodeReadinessMessage = "code_readiness must be a string in [Release, RestrictedRelease, NextRelease, RestrictedNextRelease, Incomplete, Prototype].\n\n";
 static const char* kDefaultAddress = "[::]";
 constexpr int UNLIMITED_MAX_MESSAGE_SIZE = -1;
-constexpr int DEFAULT_SIDEBAND_PORT = 50055;
 
 class ServerConfigurationParser {
  public:
@@ -105,6 +104,7 @@ class ServerConfigurationParser {
   std::string parse_key_from_security_section(const char* key) const;
   std::string parse_bind_address() const;
   int parse_port() const;
+  int parse_port_with_key(const std::string& key) const;
 
   std::string config_file_path_;
   nlohmann::json config_file_;


### PR DESCRIPTION
### What does this Pull Request accomplish?
There were some unresolved comments in the [previous PR](https://github.com/ni/grpc-device/pull/1113). Two of them are being addressed in this PR.

- The sideband port should not be hardcoded and instead should be configurable via service_cofig.json file.
### Why should this Pull Request be merged?
- Exposed a new member sideband_port and used that for initialization.
- Created out a helper which extracts port. Used it at two places for extracting port.

### What testing has been done?

- No functional behavior change for grpc-server.
- We can now configure the sideband port.