### PR TITLE
fix sideband race condition by passing std::string instead of char* to thread proc

### DIFF
--- a/source/server/data_moniker_service.cpp
+++ b/source/server/data_moniker_service.cpp
@@ -168,6 +168,7 @@ Status DataMonikerService::BeginSidebandStream(ServerContext* context, const Beg
 
   char identifier[32] = {};
   InitOwnerSidebandData(strategy, bufferSize, identifier);
+  std::string identifierString(identifier);
   
   response->set_strategy(request->strategy());
   response->set_sideband_identifier(identifier);
@@ -179,7 +180,7 @@ Status DataMonikerService::BeginSidebandStream(ServerContext* context, const Beg
   auto readers = new EndpointList();
   InitiateMonikerList(request->monikers(), readers, writers);
 
-  auto thread = new std::thread(RunSidebandReadWriteLoop, identifier, strategy, readers, writers);
+  auto thread = new std::thread(RunSidebandReadWriteLoop, identifierString, strategy, readers, writers);
   thread->detach();
 
   return Status::OK;


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes a race condition in the sideband streaming code path.
GetOwnerSidebandDataToken inside the read/write loop of the server waits on being passed in the right "usage_id".
BeginSidebandStreaming  calls the read/write loop in a separate thread at the server and passes in the usage_id which was stored in a stack variable of char[]. 

std::thread takes in the Function RunSidebandReadWriteLoop that has a string parameter for the usage_id.
When a char[] object is passed to the method, it does try to do a deep copy of the params for thread execution. 
In between there is some time that the calling thread stack can unwind removing the memory for the usage_id. If that happens and is happening always unless we are debugging and we know where to delay.

Instead we would convert that char[] to a string object that will get passed to the RunSidebandReadWriteLoop . The std::string copy constructor ensures that the data is already deep copied that is passed for the thread object creation which happens on the current thread and not the new thread. So it ensures that when the std::thread does its own deep copy of the thread params, it has a valid copy
ref : https://stackoverflow.com/questions/65518555/stdthread-arguments-are-copied-on-the-new-thread
ref : https://en.cppreference.com/w/cpp/thread/thread/thread

### Why should this Pull Request be merged?

fixes a race condition for sideband streaming.

### What testing has been done?

Tested the server and client app locally and it runs successfully.
