### PR TITLE
Make sideband_port configuration return default if not present.

### DIFF
--- a/source/server/server_configuration_parser.cpp
+++ b/source/server/server_configuration_parser.cpp
@@ -144,7 +144,12 @@ int ServerConfigurationParser::parse_max_message_size() const
 
 int ServerConfigurationParser::parse_sideband_port() const
 {
-  return parse_port_with_key(kSidebandPortJsonKey);
+  try {
+    return parse_port_with_key(kSidebandPortJsonKey);
+  }
+  catch (const UnspecifiedPortException&) {
+    return DEFAULT_SIDEBAND_PORT;
+  }
 }
 
 FeatureToggles ServerConfigurationParser::parse_feature_toggles() const

--- a/source/server/server_configuration_parser.h
+++ b/source/server/server_configuration_parser.h
@@ -23,6 +23,7 @@ static const char* kInvalidFeatureToggleMessage = "Feature Toggles must be speci
 static const char* kInvalidCodeReadinessMessage = "code_readiness must be a string in [Release, RestrictedRelease, NextRelease, RestrictedNextRelease, Incomplete, Prototype].\n\n";
 static const char* kDefaultAddress = "[::]";
 constexpr int UNLIMITED_MAX_MESSAGE_SIZE = -1;
+constexpr int DEFAULT_SIDEBAND_PORT = 50055;
 
 class ServerConfigurationParser {
  public:


### PR DESCRIPTION
### What does this Pull Request accomplish?

The sideband port was previously a required entry in the configuration file and would throw an exception if the entry was not available. Ideally, the presence of this entry in the file should not be mandatory. This PR fix that.

### Why should this Pull Request be merged?

- Return the default sideband port if the sideband_port entry is unavailable.

### What testing has been done?

Able to run the server without the entry in the file.