### PR TITLE
Adding server version always in the command display

### DIFF
--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -88,6 +88,15 @@ static void RunServer(const ServerConfiguration& config)
         config.config_file_path.c_str());
   }
 
+  std::string string_kNiDeviceGrpcBranchName(nidevice_grpc::kNiDeviceGrpcBranchName);
+  if (string_kNiDeviceGrpcBranchName.rfind("releases", 0) == 0) {
+    nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Info, nidevice_grpc::kNiDeviceGrpcFileVersion);
+  }
+  else {
+    nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Info, nidevice_grpc::kNiDeviceGrpcFileVersion);
+    nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Info, "dev");
+  }
+
   grpc::EnableDefaultHealthCheckService(true);
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 


### PR DESCRIPTION
Is quite important to know what version of the server is running and not only when the --version is passed.

### What does this Pull Request accomplish?

The server when executed will always display the version running.

### Why should this Pull Request be merged?

All software needs to have a way to know the version running irrespective if a tag was passed. This ensure in our customers that they know the correct version is running.

Ideally, this should be queryable by a client but that's a task for another day.

### What testing has been done?

None.
