### PR TITLE
Separate out feature toggles for moniker streaming and sideband streaming

### DIFF
--- a/generated/nidaqmx/nidaqmx_service_registrar.cpp
+++ b/generated/nidaqmx/nidaqmx_service_registrar.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<void> register_service(
       toggles);
     builder.RegisterService(service.get());
 
-    if (ni::data_monikers::is_sideband_streaming_enabled(feature_toggles)) {
+    if (ni::data_monikers::is_moniker_streaming_enabled(feature_toggles)) {
       nidaqmx_grpc::RegisterMonikerEndpoints();
     }
 

--- a/generated/nifpga/nifpga_service_registrar.cpp
+++ b/generated/nifpga/nifpga_service_registrar.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<void> register_service(
       toggles);
     builder.RegisterService(service.get());
 
-    if (ni::data_monikers::is_sideband_streaming_enabled(feature_toggles)) {
+    if (ni::data_monikers::is_moniker_streaming_enabled(feature_toggles)) {
       nifpga_grpc::RegisterMonikerEndpoints();
     }
 

--- a/source/codegen/templates/service_registrar.cpp.mako
+++ b/source/codegen/templates/service_registrar.cpp.mako
@@ -48,7 +48,7 @@ std::shared_ptr<void> register_service(
     builder.RegisterService(service.get());
 % if config.get("has_moniker_streaming_apis", False):
 
-    if (ni::data_monikers::is_sideband_streaming_enabled(feature_toggles)) {
+    if (ni::data_monikers::is_moniker_streaming_enabled(feature_toggles)) {
 <%
   namespace = f"{config['namespace_component']}_grpc"
 %>\

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -114,7 +114,7 @@ static void RunServer(const ServerConfiguration& config)
       return;
     }
     server = builder.BuildAndStart();
-    if (ni::data_monikers::is_sideband_streaming_enabled(config.feature_toggles)) {
+    if (ni::data_monikers::is_moniker_streaming_enabled(config.feature_toggles)) {
       auto sideband_socket_thread = new std::thread(RunSidebandSocketsAccept, config.sideband_address.c_str(), config.sideband_port);
       ni::data_monikers::configure_moniker_stream_processor(config.stream_processor);
       // auto sideband_rdma_send_thread = new std::thread(AcceptSidebandRdmaSendRequests);
@@ -266,7 +266,7 @@ int main(int argc, char** argv)
 #if defined(_WIN32)
   nidevice_grpc::set_console_ctrl_handler(&StopServer);
 #else
-  if (ni::data_monikers::is_sideband_streaming_enabled(config.feature_toggles)) {
+  if (ni::data_monikers::is_moniker_streaming_enabled(config.feature_toggles)) {
     SysFsWrite("/dev/cgroup/cpuset/system_set/cpus", "0-5");
     SysFsWrite("/dev/cgroup/cpuset/LabVIEW_ScanEngine_set", "0-5");
     SysFsWrite("/dev/cgroup/cpuset/LabVIEW_tl_set/cpus", "6-8");

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -115,10 +115,12 @@ static void RunServer(const ServerConfiguration& config)
     }
     server = builder.BuildAndStart();
     if (ni::data_monikers::is_moniker_streaming_enabled(config.feature_toggles)) {
-      auto sideband_socket_thread = new std::thread(RunSidebandSocketsAccept, config.sideband_address.c_str(), config.sideband_port);
       ni::data_monikers::configure_moniker_stream_processor(config.stream_processor);
+      if (ni::data_monikers::is_moniker_streaming_sideband_support_enabled(config.feature_toggles)) {
+      auto sideband_socket_thread = new std::thread(RunSidebandSocketsAccept, config.sideband_address.c_str(), config.sideband_port);
       // auto sideband_rdma_send_thread = new std::thread(AcceptSidebandRdmaSendRequests);
       // auto sideband_rdma_recv_thread = new std::thread(AcceptSidebandRdmaReceiveRequests);
+      }
     }
   }
 

--- a/source/server/core_services_registrar.cpp
+++ b/source/server/core_services_registrar.cpp
@@ -27,7 +27,7 @@ void register_core_services(
     feature_toggles,
     *server_reset_observer_registrar));
 
-  if (ni::data_monikers::is_sideband_streaming_enabled(feature_toggles)) {
+  if (ni::data_monikers::is_moniker_streaming_enabled(feature_toggles)) {
     auto moniker_service = std::make_shared<ni::data_monikers::DataMonikerService>();
     server_builder.RegisterService(moniker_service.get());
     service_vector->push_back(moniker_service);

--- a/source/server/data_moniker_service.cpp
+++ b/source/server/data_moniker_service.cpp
@@ -58,6 +58,11 @@ bool is_moniker_streaming_enabled(const nidevice_grpc::FeatureToggles& feature_t
   return feature_toggles.is_feature_enabled("moniker_streaming", nidevice_grpc::FeatureToggles::CodeReadiness::kNextRelease);
 }
 
+bool is_moniker_streaming_sideband_support_enabled(const nidevice_grpc::FeatureToggles& feature_toggles)
+{
+  return feature_toggles.is_feature_enabled("moniker_streaming_sideband_support", nidevice_grpc::FeatureToggles::CodeReadiness::kNextRelease);
+}
+
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 DataMonikerService* DataMonikerService::s_Server;

--- a/source/server/data_moniker_service.cpp
+++ b/source/server/data_moniker_service.cpp
@@ -53,9 +53,9 @@ void configure_moniker_stream_processor(const MonikerStreamProcessor& stream_pro
   s_StreamProcessor = stream_processor;
 }
 
-bool is_sideband_streaming_enabled(const nidevice_grpc::FeatureToggles& feature_toggles)
+bool is_moniker_streaming_enabled(const nidevice_grpc::FeatureToggles& feature_toggles)
 {
-  return feature_toggles.is_feature_enabled("sideband_streaming", nidevice_grpc::FeatureToggles::CodeReadiness::kNextRelease);
+  return feature_toggles.is_feature_enabled("moniker_streaming", nidevice_grpc::FeatureToggles::CodeReadiness::kNextRelease);
 }
 
 //---------------------------------------------------------------------

--- a/source/server/data_moniker_service.h
+++ b/source/server/data_moniker_service.h
@@ -19,6 +19,7 @@ namespace ni::data_monikers
 {
     void configure_moniker_stream_processor(const MonikerStreamProcessor& stream_processor);
     bool is_moniker_streaming_enabled(const nidevice_grpc::FeatureToggles& feature_toggles);
+    bool is_moniker_streaming_sideband_support_enabled(const nidevice_grpc::FeatureToggles& feature_toggles);
     void set_cpu_affinity(int cpu);
     //---------------------------------------------------------------------
     //---------------------------------------------------------------------

--- a/source/server/data_moniker_service.h
+++ b/source/server/data_moniker_service.h
@@ -18,7 +18,7 @@
 namespace ni::data_monikers
 {
     void configure_moniker_stream_processor(const MonikerStreamProcessor& stream_processor);
-    bool is_sideband_streaming_enabled(const nidevice_grpc::FeatureToggles& feature_toggles);
+    bool is_moniker_streaming_enabled(const nidevice_grpc::FeatureToggles& feature_toggles);
     void set_cpu_affinity(int cpu);
     //---------------------------------------------------------------------
     //---------------------------------------------------------------------


### PR DESCRIPTION
### What does this Pull Request accomplish?

We had single feature toggle `sideband-streaming` for moniker based streaming as well as sideband streaming support for moniker based streaming. This change separates out both of these into different feature toggles.

### Why should this Pull Request be merged?

Moniker based streaming that uses sideband streaming mechanism opens up unsecured raw socket for communication. To make grpc-device more secure, we want sideband streaming to be OFF by default so that additional port is not opened up for users that don't need sideband based streaming mechanism. Since moniker based streaming is behind feature toggle, I have added sideband streaming with moniker as a feature toggle as well. In future, sideband streaming using moniker could be a configuration instead of feature toggle.

### What testing has been done?
Validated with local client examples that
- Moniker streaming APIs are enabled only when `moniker_streaming` feature toggle is set to `true`.
- Sideband streaming is enabled only when both `moniker_streaming` and `moniker_streaming_sideband_support` feature toggles are set to `true`.