### PR TITLE
Remove cpu pinning for core server

### DIFF
--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -267,24 +267,6 @@ int main(int argc, char** argv)
 #endif
 #if defined(_WIN32)
   nidevice_grpc::set_console_ctrl_handler(&StopServer);
-#else
-  if (ni::data_monikers::is_moniker_streaming_enabled(config.feature_toggles)) {
-    SysFsWrite("/dev/cgroup/cpuset/system_set/cpus", "0-5");
-    SysFsWrite("/dev/cgroup/cpuset/LabVIEW_ScanEngine_set", "0-5");
-    SysFsWrite("/dev/cgroup/cpuset/LabVIEW_tl_set/cpus", "6-8");
-    SysFsWrite("/dev/cgroup/cpuset/LabVIEW_tl_set/cpu_exclusive", "1");
-
-    sched_param schedParam;
-    schedParam.sched_priority = 95;
-    sched_setscheduler(0, SCHED_FIFO, &schedParam);
-
-    cpu_set_t cpuSet;
-    CPU_ZERO(&cpuSet);
-    CPU_SET(6, &cpuSet);
-    sched_setaffinity(0, sizeof(cpu_set_t), &cpuSet);
-
-    mlockall(MCL_CURRENT | MCL_FUTURE);
-  }
 #endif
 
   RunServer(config);


### PR DESCRIPTION
### What does this Pull Request accomplish?

For core server thread, there were hardcoded values for setting cpu affinity. This change removes that code.

### Why should this Pull Request be merged?

Earlier change which made some of the [cpu affinity settings configurable](https://github.com/ni/grpc-device/pull/1136) through `server_config.json` left out making server thread pinning configurable because this code just sets affinity for main thread that launches server. This doesn't really change anything performance-wise apart from server launch time.

CPU pinning for main server thread was added when we added support for moniker based streaming and was taken as is from prototype branch for moniker streaming. This code is not needed.

### What testing has been done?

Build passes and able to launch grpc-device server