### PR TITLE
Bump up grpc-device version to 2.11 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12.0)
 
 project(ni_grpc_device_server
   LANGUAGES C CXX
-  VERSION 2.10.0)
+  VERSION 2.11.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Bump up grpc-device version to 2.11

### Why should this Pull Request be merged?

2.10 release for grpc-device is published and mainline version needs to be bumped up to higher number

### What testing has been done?

N/A