### PR TITLE
Update github hosted runners from ubuntu-20.04 to -22.04 + remove ubuntu system tests

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -21,7 +21,7 @@ jobs:
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
-            os: ubuntu-20.04,
+            os: ubuntu-latest,
             cc: "gcc-9", cxx: "g++-9",
             glibc_version: "2_31",
             cmake_generator: '-G "Ninja"',

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -21,7 +21,7 @@ jobs:
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
-            os: ubuntu-latest,
+            os: ubuntu-22.04,
             cc: "gcc-9", cxx: "g++-9",
             glibc_version: "2_31",
             cmake_generator: '-G "Ninja"',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
   run_win_system_tests:
     needs: build_desktop
     uses: ./.github/workflows/run_win_system_tests.yml
-  run_ubuntu_system_tests:
-    needs: build_desktop
-    uses: ./.github/workflows/run_ubuntu_system_tests.yml
   create_client_artifacts:
     uses: ./.github/workflows/create_client_artifacts.yml
   create_release:

--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -18,7 +18,7 @@ jobs:
           }
         - {
             name: "Linux Artifacts", artifact: "Linux.tar.xz",
-            os: ubuntu-latest,
+            os: ubuntu-22.04,
           }
 
     steps:

--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -18,7 +18,7 @@ jobs:
           }
         - {
             name: "Linux Artifacts", artifact: "Linux.tar.xz",
-            os: ubuntu-20.04,
+            os: ubuntu-latest,
           }
 
     steps:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Swaps GH actions from using Ubuntu 20.04 to latest 22.04 and removes ubuntu system tests from PR checks

### Why should this Pull Request be merged?

20.04 is now deprecated, so now all actions attempting to use 20.04 are failing

Updating the AWS machine is causing some issues and we have the windows system tests to rely on along with internal testing that run the same tests on both windows and ubuntu

### What testing has been done?

None