### PR TITLE
examples: Update to Python 3.9+ and typeshed version of gRPC stubs

### DIFF
--- a/examples/poetry.lock
+++ b/examples/poetry.lock
@@ -72,20 +72,6 @@ files = [
 ]
 
 [[package]]
-name = "grpc-stubs"
-version = "1.53.0.5"
-description = "Mypy stubs for gRPC"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "grpc-stubs-1.53.0.5.tar.gz", hash = "sha256:3e1b642775cbc3e0c6332cfcedfccb022176db87e518757bef3a1241397be406"},
-    {file = "grpc_stubs-1.53.0.5-py3-none-any.whl", hash = "sha256:04183fb65a1b166a1febb9627e3d9647d3926ccc2dfe049fe7b6af243428dbe1"},
-]
-
-[package.dependencies]
-grpcio = "*"
-
-[[package]]
 name = "grpcio"
 version = "1.70.0"
 description = "HTTP/2-based RPC framework"
@@ -416,6 +402,20 @@ files = [
 ]
 
 [[package]]
+name = "types-grpcio"
+version = "1.0.0.20250426"
+description = "Typing stubs for grpcio"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "types_grpcio-1.0.0.20250426-py3-none-any.whl", hash = "sha256:7931b4ec0bedb8af7c53910ed54edeb8be964251ecf0c4f0234f95e472a90ce3"},
+    {file = "types_grpcio-1.0.0.20250426.tar.gz", hash = "sha256:a079034b1c32520b1218bd50187539352b8ff495cf9b91a7c98772a3baf5f1d1"},
+]
+
+[package.dependencies]
+types-protobuf = "*"
+
+[[package]]
 name = "types-protobuf"
 version = "5.29.1.20241207"
 description = "Typing stubs for protobuf"
@@ -439,5 +439,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<3.12"
-content-hash = "9bbfc7bab3e2790fc13ca7d2e2292555eae9023b50855cd8f739e1f78c26559f"
+python-versions = ">=3.9,<3.12"
+content-hash = "106b2197aff31b13c544af1b07049838b9838d5ed096bc42dfc7c7f17d93c450"

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Christian Aguilar <christian.aguilar@ni.com>"]
 package-mode = false
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.9,<3.12"
 grpcio = "^1.49.1"
 
 [tool.poetry.group.dev.dependencies]
@@ -14,7 +14,7 @@ grpcio-tools = "1.49.1"
 mypy = ">=1.0"
 mypy-protobuf = ">=3.6.0"
 types-protobuf = ">=5.28.3.20241203"
-grpc-stubs = ">=1.53"
+types-grpcio = ">=1.0"
 black = ">=23.3.0"
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
### What does this Pull Request accomplish?

Replace `grpc-stubs` with `types-grpcio`.

Update minimum supported Python version to 3.9 because `types-grpcio` does not support 3.8. This is also consistent with NI's ADE support policy:

> NI products that support or integrate with Python will drop official support for all Python versions that have reached their end of life [EOL](https://devguide.python.org/devcycle/#end-of-life-branches) . This should be done at the next release of the product following the EOL date for a given Python version

### Why should this Pull Request be merged?

The `grpc-stubs` package is archived and will not be updated.

### What testing has been done?

PR build