### PR TITLE
Bump version number in CMakeLists.txt from 2.12.0 to 2.13.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18.0)
 
 project(ni_grpc_device_server
   LANGUAGES C CXX
-  VERSION 2.12.0)
+  VERSION 2.13.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Bumps version in main to 2.13.0 while 2.12.0 is preparing for release

### Why should this Pull Request be merged?

Version number is bumped every release

### What testing has been done?

No testing performed

### Additional Information

This was also bumped in Azdo !1000584 to update ni-central /src/grpc_device/pipeline/templates/version.yml for Azdo Feature 3173174.