### PR TITLE
docs: Update Linux build prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,6 @@ For Debian/Ubuntu, install git, cmake (3.18.0 or newer), and mako:
 > sudo apt-get install g++
 > sudo apt-get install python3-venv  # for ensurepip
 > sudo apt-get install ninja-build   # optional
-> python -m pip install mako
 ```
 
 For NI Linux RT, install packagegroup-core-buildessential, git, git-perltools, cmake (3.18.0 or newer), python3-utils, and mako:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add more packages to the Linux build prerequisites.

Remove `python -m pip install mako` since the build uses a venv now.

### Why should this Pull Request be merged?

I tried following the instructions on a fresh Ubuntu WSL environment and both ensurepip and g++ were missing.

### What testing has been done?

N/A