### PR TITLE
Re-Export session.proto

### DIFF
--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -25,6 +25,10 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v4
 
+    - name: Initialize ni-apis submodule
+      run: |
+        git submodule update --init third_party/ni-apis
+        
     - name: Setup python3
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Resolves [AB#3436352](https://dev.azure.com/ni/DevCentral/_workitems/edit/3436352/) 

### Why should this Pull Request be merged?

[This PR](https://github.com/ni/grpc-device/pull/1201) introduced the above bug, which needs to be fixed to prevent update-depslock pipelines from continuing to fail.

### What testing has been done?

CI build - the artifacts generated by the CI should include session.proto. This indicates that it will be included in the ni-grpc-devices-restricted-files export when it runs on AzDO.
