### PR TITLE
Making DPDCfgApplyDPDUserLookupTableInterleavedIQ as special

### DIFF
--- a/generated/nirfmxspecan/nirfmxspecan_compilation_test.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_compilation_test.cpp
@@ -702,9 +702,9 @@ int32 DPDCfgApplyDPDUserLookupTable(niRFmxInstrHandle instrumentHandle, char sel
   return RFmxSpecAn_DPDCfgApplyDPDUserLookupTable(instrumentHandle, selectorString, lutInputPowers, lutComplexGains, arraySize);
 }
 
-int32 DPDCfgApplyDPDUserLookupTableInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[])
+int32 DPDCfgApplyDPDUserLookupTableInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[], int32 arraySize)
 {
-  return RFmxSpecAn_DPDCfgApplyDPDUserLookupTable(instrumentHandle, selectorString, lutInputPowers, reinterpret_cast<NIComplexSingle*>(lutComplexGains));
+  return RFmxSpecAn_DPDCfgApplyDPDUserLookupTable(instrumentHandle, selectorString, lutInputPowers, reinterpret_cast<NIComplexSingle*>(lutComplexGains), arraySize);
 }
 
 int32 DPDCfgApplyDPDUserLookupTableSplit(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGainsI[], float32 lutComplexGainsQ[], int32 arraySize)

--- a/generated/nirfmxspecan/nirfmxspecan_library.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_library.cpp
@@ -1643,12 +1643,12 @@ int32 NiRFmxSpecAnLibrary::DPDCfgApplyDPDUserLookupTable(niRFmxInstrHandle instr
   return function_pointers_.DPDCfgApplyDPDUserLookupTable(instrumentHandle, selectorString, lutInputPowers, lutComplexGains, arraySize);
 }
 
-int32 NiRFmxSpecAnLibrary::DPDCfgApplyDPDUserLookupTableInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[])
+int32 NiRFmxSpecAnLibrary::DPDCfgApplyDPDUserLookupTableInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[], int32 arraySize)
 {
   if (!function_pointers_.DPDCfgApplyDPDUserLookupTableInterleavedIQ) {
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxSpecAn_DPDCfgApplyDPDUserLookupTable.");
   }
-  return function_pointers_.DPDCfgApplyDPDUserLookupTableInterleavedIQ(instrumentHandle, selectorString, lutInputPowers, reinterpret_cast<NIComplexSingle*>(lutComplexGains));
+  return function_pointers_.DPDCfgApplyDPDUserLookupTableInterleavedIQ(instrumentHandle, selectorString, lutInputPowers, reinterpret_cast<NIComplexSingle*>(lutComplexGains), arraySize);
 }
 
 int32 NiRFmxSpecAnLibrary::DPDCfgApplyDPDUserLookupTableSplit(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGainsI[], float32 lutComplexGainsQ[], int32 arraySize)

--- a/generated/nirfmxspecan/nirfmxspecan_library.h
+++ b/generated/nirfmxspecan/nirfmxspecan_library.h
@@ -160,7 +160,7 @@ class NiRFmxSpecAnLibrary : public nirfmxspecan_grpc::NiRFmxSpecAnLibraryInterfa
   int32 DPDCfgApplyDPDUserDPDPolynomialInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 dpdPolynomial[], int32 arraySize) override;
   int32 DPDCfgApplyDPDUserDPDPolynomialSplit(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 dpdPolynomialI[], float32 dpdPolynomialQ[], int32 arraySize) override;
   int32 DPDCfgApplyDPDUserLookupTable(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], NIComplexSingle lutComplexGains[], int32 arraySize) override;
-  int32 DPDCfgApplyDPDUserLookupTableInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[]) override;
+  int32 DPDCfgApplyDPDUserLookupTableInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[], int32 arraySize) override;
   int32 DPDCfgApplyDPDUserLookupTableSplit(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGainsI[], float32 lutComplexGainsQ[], int32 arraySize) override;
   int32 DPDCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount) override;
   int32 DPDCfgDPDModel(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 dpdModel) override;

--- a/generated/nirfmxspecan/nirfmxspecan_library_interface.h
+++ b/generated/nirfmxspecan/nirfmxspecan_library_interface.h
@@ -154,7 +154,7 @@ class NiRFmxSpecAnLibraryInterface {
   virtual int32 DPDCfgApplyDPDUserDPDPolynomialInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 dpdPolynomial[], int32 arraySize) = 0;
   virtual int32 DPDCfgApplyDPDUserDPDPolynomialSplit(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 dpdPolynomialI[], float32 dpdPolynomialQ[], int32 arraySize) = 0;
   virtual int32 DPDCfgApplyDPDUserLookupTable(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], NIComplexSingle lutComplexGains[], int32 arraySize) = 0;
-  virtual int32 DPDCfgApplyDPDUserLookupTableInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[]) = 0;
+  virtual int32 DPDCfgApplyDPDUserLookupTableInterleavedIQ(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[], int32 arraySize) = 0;
   virtual int32 DPDCfgApplyDPDUserLookupTableSplit(niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGainsI[], float32 lutComplexGainsQ[], int32 arraySize) = 0;
   virtual int32 DPDCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount) = 0;
   virtual int32 DPDCfgDPDModel(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 dpdModel) = 0;

--- a/generated/nirfmxspecan/nirfmxspecan_mock_library.h
+++ b/generated/nirfmxspecan/nirfmxspecan_mock_library.h
@@ -156,7 +156,7 @@ class NiRFmxSpecAnMockLibrary : public nirfmxspecan_grpc::NiRFmxSpecAnLibraryInt
   MOCK_METHOD(int32, DPDCfgApplyDPDUserDPDPolynomialInterleavedIQ, (niRFmxInstrHandle instrumentHandle, char selectorString[], float32 dpdPolynomial[], int32 arraySize), (override));
   MOCK_METHOD(int32, DPDCfgApplyDPDUserDPDPolynomialSplit, (niRFmxInstrHandle instrumentHandle, char selectorString[], float32 dpdPolynomialI[], float32 dpdPolynomialQ[], int32 arraySize), (override));
   MOCK_METHOD(int32, DPDCfgApplyDPDUserLookupTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], NIComplexSingle lutComplexGains[], int32 arraySize), (override));
-  MOCK_METHOD(int32, DPDCfgApplyDPDUserLookupTableInterleavedIQ, (niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[]), (override));
+  MOCK_METHOD(int32, DPDCfgApplyDPDUserLookupTableInterleavedIQ, (niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGains[], int32 arraySize), (override));
   MOCK_METHOD(int32, DPDCfgApplyDPDUserLookupTableSplit, (niRFmxInstrHandle instrumentHandle, char selectorString[], float32 lutInputPowers[], float32 lutComplexGainsI[], float32 lutComplexGainsQ[], int32 arraySize), (override));
   MOCK_METHOD(int32, DPDCfgAveraging, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount), (override));
   MOCK_METHOD(int32, DPDCfgDPDModel, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 dpdModel), (override));

--- a/source/codegen/metadata/nirfmxspecan/functions_addon.py
+++ b/source/codegen/metadata/nirfmxspecan/functions_addon.py
@@ -94,6 +94,12 @@ functions_override_metadata = {
                 },
                 'type': 'float32[]',
                 'value_converted_to_c_representation': 'reinterpret_cast<NIComplexSingle*>(lutComplexGains)'
+            },
+            {
+                'direction': 'in',
+                'include_in_proto': False,
+                'name': 'arraySize',
+                'type': 'int32',
             }
         ],
         'returns': 'int32'


### PR DESCRIPTION
### What does this Pull Request accomplish?
Making DPDCfgApplyDPDUserLookupTableInterleavedIQ as special API as the metadata cannot be generated with the current limitations on the scrapigen tool. 

### Why should this Pull Request be merged?
To generate appropriate code for the DPDCfgApplyDPDUserLookupTableInterleavedIQ API as the metadata cannot be generated with the current limitations on the scrapigen tool. 

### What testing has been done?
PR Build
