### PR TITLE
Compress Release Artifacts

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -122,12 +122,30 @@ jobs:
         LICENSE
         ThirdPartyNotices.txt
 
+    - name: Tar Linux Server Debug Symbols
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
+      run: >-
+        tar -cvzf ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64-debug-symbols.tar.gz
+        -C ${GITHUB_WORKSPACE}/build
+        ni_grpc_device_server.dbg
+        -C ${GITHUB_WORKSPACE}
+        LICENSE
+        ThirdPartyNotices.txt
+
     - name: Upload Linux Server Binaries Artifact
       uses: actions/upload-artifact@v4
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
         name: ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64
         path: ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64.tar.gz
+        retention-days: 5
+
+    - name: Upload Linux Server Debug Symbols Artifact
+      uses: actions/upload-artifact@v4
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
+      with:
+        name: ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64-debug-symbols
+        path: ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64-debug-symbols.tar.gz
         retention-days: 5
 
     - name: Tar Linux Test Binaries

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -38,6 +38,11 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
+        name: ni-grpc-device-server-linux-glibc2_31-x64-debug-symbols
+        path: downloads/artifacts
+
+    - uses: actions/download-artifact@v4
+      with:
         name: ni-grpc-device-server-ni-linux-rt-x64
         path: downloads/artifacts
 
@@ -54,7 +59,12 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-server-windows-x64-debug-symbols
-        path: downloads/artifacts
+        path: downloads/ni-grpc-device-server-windows-x64-debug-symbols
+
+    - uses: vimtor/action-zip@v1
+      with:
+        files: downloads/ni-grpc-device-server-windows-x64-debug-symbols
+        dest: downloads/artifacts/ni-grpc-device-server-windows-x64-debug-symbols.zip
 
     - name: "Get previous tag"
       id: previoustag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,6 +672,20 @@ add_custom_command(
    COMMAND  ${PYTHON_EXE} ${codegen_dir}/generate_server_capabilities.py ${metadata_dir}/
             -o $<TARGET_FILE_DIR:ni_grpc_device_server>/)
 
+#----------------------------------------------------------------------
+# Split binary into release and debug symbols for Linux/GCC
+#----------------------------------------------------------------------
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  add_custom_command(
+     TARGET ni_grpc_device_server POST_BUILD
+     COMMAND  ${CMAKE_OBJCOPY} ARGS --only-keep-debug $<TARGET_FILE:ni_grpc_device_server>
+              $<TARGET_FILE:ni_grpc_device_server>.dbg
+     COMMAND  ${CMAKE_OBJCOPY} ARGS --strip-debug $<TARGET_FILE:ni_grpc_device_server>
+     COMMAND  ${CMAKE_OBJCOPY} ARGS --add-gnu-debuglink=$<TARGET_FILE:ni_grpc_device_server>.dbg
+              $<TARGET_FILE:ni_grpc_device_server>
+     DEPENDS  ni_grpc_device_server)
+endif()
+
 # Link test executable against gtest
 add_executable(IntegrationTestsRunner
     "imports/include/nierr_Status.cpp"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Resolves #1206 ([AB#3442600](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3442600)) and #1207 ([AB#3442605](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3442605))

### Why should this Pull Request be merged?

Currently, the Linux release binary is 336 MB even when tarred, and the Windows PDB file is 1.35 GB. Splitting the Linux binary into release and debug symbols artifacts, as well as zipping the Windows PDB file, should help reduce the sizes of these files when downloaded.

### What testing has been done?

CI build

Update: Ran [workflow on forked repo](https://github.com/Raul2113/grpc-device/actions/runs/19049200939):
<img width="2127" height="1285" alt="image" src="https://github.com/user-attachments/assets/6cdf6a1a-b1c2-44d0-bfc0-8bcf57c83726" />

As can be seen, the Linux binary has been successfully split into release and debug symbols, while the Windows PDB is zipped. The artifact sizes are also reasonable:
<img width="743" height="115" alt="image" src="https://github.com/user-attachments/assets/c5f16eba-a704-4e53-8732-11878624f033" />

