### PR TITLE
github: Update AzDO area path

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -29,7 +29,7 @@ jobs:
           github_token: "${{ secrets.GH_REPO_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
-          ado_area_path: "DevCentral\\Product RnD\\Platform HW and SW\\Core SW and Drivers\\Platform HW and Drivers\\Drivers\\Customer Facing"
+          ado_area_path: "DevCentral\\Product RnD\\Platform HW and SW\\Core SW and Drivers\\Platform HW and Drivers\\Drivers\\Platform Drivers Ownership NIC"
           ado_wit: "${{ steps.choose_work_item_type.outputs.work_item_type }}"
           ado_new_state: "New"
           ado_active_state: "Active"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update the AzDO area path for syncing issues.

Old: "DevCentral\Product RnD\Platform HW and SW\Core SW and Drivers\Platform HW and Drivers\Drivers\Customer Facing"
New: "DevCentral\Product RnD\Platform HW and SW\Core SW and Drivers\Platform HW and Drivers\Drivers\Platform Drivers Ownership NIC"

### Why should this Pull Request be merged?

Creating an issue fails with an error: https://github.com/ni/grpc-device/actions/runs/22406477790/job/64867630330

```
Run danhellem/github-actions-issue-to-work-item@45eb3b46e684f2acd2954f02ef70350c835ee4bb
Set values from payload & env
Check to see if work item already exists
No work item found, creating work item from issue
Error: creatWorkItem failed
Error: TF401347: Invalid tree name given for work item -1, field 'System.AreaPath'.
    at RestClient.<anonymous> (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/45eb3b46e684f2acd2954f02ef70350c835ee4bb/node_modules/typed-rest-client/RestClient.js:202:31)
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/45eb3b46e684f2acd2954f02ef70350c835ee4bb/node_modules/typed-rest-client/RestClient.js:6:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  statusCode: 400,
  result: {
    '$id': '1',
    innerException: null,
    message: "TF401347: Invalid tree name given for work item -1, field 'System.AreaPath'.",
    typeName: 'Microsoft.TeamFoundation.WorkItemTracking.Server.WorkItemFieldInvalidTreeNameException, Microsoft.TeamFoundation.WorkItemTracking.Server',
    typeKey: 'WorkItemFieldInvalidTreeNameException',
    errorCode: 600171,
    eventId: 3200
  }
}
Error: Error: TF401347: Invalid tree name given for work item -1, field 'System.AreaPath'.
Work item value is -1, exiting action
```

Unfortunately, GitHub only notifies the person who created or updated a GitHub issue, not the repo admins.

### What testing has been done?

None