### PR TITLE
nirfsg :Fix ivi-dance-with-a-twist buffer sizing for GetAllNamedWaveformNames, GetAllScriptNames, and GetScript

### DIFF
--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -1806,21 +1806,19 @@ namespace nirfsg_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.name());
-
+      ViInt32 actual_buffer_size {};
       while (true) {
-        auto status = library_->GetAllNamedWaveformNames(vi, nullptr, 0, nullptr);
+        auto status = library_->GetAllNamedWaveformNames(vi, nullptr, 0, &actual_buffer_size);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForViSession(context, status, vi);
         }
-        ViInt32 buffer_size = status;
-
         std::string waveform_names;
-        if (buffer_size > 0) {
-            waveform_names.resize(buffer_size - 1);
+        if (actual_buffer_size > 0) {
+            waveform_names.resize(actual_buffer_size - 1);
         }
-        ViInt32 actual_buffer_size {};
+        auto buffer_size = actual_buffer_size;
         status = library_->GetAllNamedWaveformNames(vi, (ViChar*)waveform_names.data(), buffer_size, &actual_buffer_size);
-        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(buffer_size)) {
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
         }
@@ -1851,21 +1849,19 @@ namespace nirfsg_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.name());
-
+      ViInt32 actual_buffer_size {};
       while (true) {
-        auto status = library_->GetAllScriptNames(vi, nullptr, 0, nullptr);
+        auto status = library_->GetAllScriptNames(vi, nullptr, 0, &actual_buffer_size);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForViSession(context, status, vi);
         }
-        ViInt32 buffer_size = status;
-
         std::string script_names;
-        if (buffer_size > 0) {
-            script_names.resize(buffer_size - 1);
+        if (actual_buffer_size > 0) {
+            script_names.resize(actual_buffer_size - 1);
         }
-        ViInt32 actual_buffer_size {};
+        auto buffer_size = actual_buffer_size;
         status = library_->GetAllScriptNames(vi, (ViChar*)script_names.data(), buffer_size, &actual_buffer_size);
-        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(buffer_size)) {
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
         }
@@ -1898,21 +1894,19 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto script_name_mbcs = convert_from_grpc<std::string>(request->script_name());
       auto script_name = script_name_mbcs.c_str();
-
+      ViInt32 actual_buffer_size {};
       while (true) {
-        auto status = library_->GetScript(vi, script_name, nullptr, 0, nullptr);
+        auto status = library_->GetScript(vi, script_name, nullptr, 0, &actual_buffer_size);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForViSession(context, status, vi);
         }
-        ViInt32 buffer_size = status;
-
         std::string script;
-        if (buffer_size > 0) {
-            script.resize(buffer_size - 1);
+        if (actual_buffer_size > 0) {
+            script.resize(actual_buffer_size - 1);
         }
-        ViInt32 actual_buffer_size {};
+        auto buffer_size = actual_buffer_size;
         status = library_->GetScript(vi, script_name, (ViChar*)script.data(), buffer_size, &actual_buffer_size);
-        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(buffer_size)) {
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
         }

--- a/source/codegen/metadata/nirfsg/functions.py
+++ b/source/codegen/metadata/nirfsg/functions.py
@@ -1042,8 +1042,9 @@ functions = {
                 'direction': 'out',
                 'name': 'waveformNames',
                 'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'bufferSize'
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'bufferSize',
+                    'value_twist': 'actualBufferSize'
                 },
                 'type': 'ViChar[]'
             },
@@ -1071,8 +1072,9 @@ functions = {
                 'direction': 'out',
                 'name': 'scriptNames',
                 'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'bufferSize'
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'bufferSize',
+                    'value_twist': 'actualBufferSize'
                 },
                 'type': 'ViChar[]'
             },
@@ -1105,8 +1107,9 @@ functions = {
                 'direction': 'out',
                 'name': 'Script',
                 'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'bufferSize'
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'bufferSize',
+                    'value_twist': 'actualBufferSize'
                 },
                 'type': 'ViChar[]'
             },


### PR DESCRIPTION
### What does this Pull Request accomplish?
This PR fixes a bug in three nirfsg gRPC API functions (GetAllNamedWaveformNames, GetAllScriptNames, and GetScript) where the 'ivi-dance' buffer sizing mechanism was incorrectly used instead of 'ivi-dance-with-a-twist'.
Due to this nullptr was passed instead of value of actual_buffer_size while these methods were tested against gRPC

### Why should this Pull Request be merged?
This PR will resolve the bug of three APIs and will use the correct value instead of nullptr.

### What testing has been done?
Manually inspected generated files and ensured the changes are as expected.
