### PR TITLE
Pull in 26.0 finals of nifgen driver grpc-device metadata

### DIFF
--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FGEN API metadata version 23.0.0f157
+// This file is generated from NI-FGEN API metadata version 26.0.0f146
 //---------------------------------------------------------------------
 // Proto file for the NI-FGEN Metadata
 //---------------------------------------------------------------------
@@ -100,8 +100,6 @@ service NiFgen {
   rpc GetExtCalRecommendedInterval(GetExtCalRecommendedIntervalRequest) returns (GetExtCalRecommendedIntervalResponse);
   rpc GetFIRFilterCoefficients(GetFIRFilterCoefficientsRequest) returns (GetFIRFilterCoefficientsResponse);
   rpc GetHardwareState(GetHardwareStateRequest) returns (GetHardwareStateResponse);
-  rpc GetNextCoercionRecord(GetNextCoercionRecordRequest) returns (GetNextCoercionRecordResponse);
-  rpc GetNextInterchangeWarning(GetNextInterchangeWarningRequest) returns (GetNextInterchangeWarningResponse);
   rpc GetSelfCalLastDateAndTime(GetSelfCalLastDateAndTimeRequest) returns (GetSelfCalLastDateAndTimeResponse);
   rpc GetSelfCalLastTemp(GetSelfCalLastTempRequest) returns (GetSelfCalLastTempResponse);
   rpc GetSelfCalSupported(GetSelfCalSupportedRequest) returns (GetSelfCalSupportedResponse);
@@ -678,6 +676,12 @@ enum RouteSignalTo {
   ROUTE_SIGNAL_TO_NIFGEN_VAL_PXI_STAR = 131;
 }
 
+enum ScriptTriggerDigitalEdgeEdge {
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_UNSPECIFIED = 0;
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_RISING_EDGE = 101;
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_FALLING_EDGE = 102;
+}
+
 enum SequenceHandle {
   SEQUENCE_HANDLE_UNSPECIFIED = 0;
   SEQUENCE_HANDLE_NIFGEN_VAL_ALL_SEQUENCES = -1;
@@ -698,6 +702,12 @@ enum Signal {
   SIGNAL_NIFGEN_VAL_STARTED_EVENT = 106;
   SIGNAL_NIFGEN_VAL_DONE_EVENT = 107;
   SIGNAL_NIFGEN_VAL_DATA_MARKER_EVENT = 108;
+}
+
+enum StartTriggerDigitalEdgeEdge {
+  START_TRIGGER_DIGITAL_EDGE_EDGE_UNSPECIFIED = 0;
+  START_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_RISING_EDGE = 101;
+  START_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_FALLING_EDGE = 102;
 }
 
 enum Trigger {
@@ -1005,7 +1015,10 @@ message ConfigureDigitalEdgeScriptTriggerRequest {
   nidevice_grpc.Session vi = 1;
   string trigger_id = 2;
   string source = 3;
-  sint32 edge = 4;
+  oneof edge_enum {
+    ScriptTriggerDigitalEdgeEdge edge = 4;
+    sint32 edge_raw = 5;
+  }
 }
 
 message ConfigureDigitalEdgeScriptTriggerResponse {
@@ -1015,7 +1028,10 @@ message ConfigureDigitalEdgeScriptTriggerResponse {
 message ConfigureDigitalEdgeStartTriggerRequest {
   nidevice_grpc.Session vi = 1;
   string source = 2;
-  sint32 edge = 3;
+  oneof edge_enum {
+    StartTriggerDigitalEdgeEdge edge = 3;
+    sint32 edge_raw = 4;
+  }
 }
 
 message ConfigureDigitalEdgeStartTriggerResponse {
@@ -1619,24 +1635,6 @@ message GetHardwareStateResponse {
   int32 status = 1;
   HardwareState state = 2;
   sint32 state_raw = 3;
-}
-
-message GetNextCoercionRecordRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetNextCoercionRecordResponse {
-  int32 status = 1;
-  string coercion_record = 2;
-}
-
-message GetNextInterchangeWarningRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetNextInterchangeWarningResponse {
-  int32 status = 1;
-  string interchange_warning = 2;
 }
 
 message GetSelfCalLastDateAndTimeRequest {

--- a/generated/nifgen/nifgen_client.cpp
+++ b/generated/nifgen/nifgen_client.cpp
@@ -534,7 +534,7 @@ configure_custom_fir_filter_coefficients(const StubPtr& stub, const nidevice_grp
 }
 
 ConfigureDigitalEdgeScriptTriggerResponse
-configure_digital_edge_script_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& trigger_id, const std::string& source, const pb::int32& edge)
+configure_digital_edge_script_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& trigger_id, const std::string& source, const simple_variant<ScriptTriggerDigitalEdgeEdge, pb::int32>& edge)
 {
   ::grpc::ClientContext context;
 
@@ -542,7 +542,14 @@ configure_digital_edge_script_trigger(const StubPtr& stub, const nidevice_grpc::
   request.mutable_vi()->CopyFrom(vi);
   request.set_trigger_id(trigger_id);
   request.set_source(source);
-  request.set_edge(edge);
+  const auto edge_ptr = edge.get_if<ScriptTriggerDigitalEdgeEdge>();
+  const auto edge_raw_ptr = edge.get_if<pb::int32>();
+  if (edge_ptr) {
+    request.set_edge(*edge_ptr);
+  }
+  else if (edge_raw_ptr) {
+    request.set_edge_raw(*edge_raw_ptr);
+  }
 
   auto response = ConfigureDigitalEdgeScriptTriggerResponse{};
 
@@ -554,14 +561,21 @@ configure_digital_edge_script_trigger(const StubPtr& stub, const nidevice_grpc::
 }
 
 ConfigureDigitalEdgeStartTriggerResponse
-configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& source, const pb::int32& edge)
+configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& source, const simple_variant<StartTriggerDigitalEdgeEdge, pb::int32>& edge)
 {
   ::grpc::ClientContext context;
 
   auto request = ConfigureDigitalEdgeStartTriggerRequest{};
   request.mutable_vi()->CopyFrom(vi);
   request.set_source(source);
-  request.set_edge(edge);
+  const auto edge_ptr = edge.get_if<StartTriggerDigitalEdgeEdge>();
+  const auto edge_raw_ptr = edge.get_if<pb::int32>();
+  if (edge_ptr) {
+    request.set_edge(*edge_ptr);
+  }
+  else if (edge_raw_ptr) {
+    request.set_edge_raw(*edge_raw_ptr);
+  }
 
   auto response = ConfigureDigitalEdgeStartTriggerResponse{};
 
@@ -1667,40 +1681,6 @@ get_hardware_state(const StubPtr& stub, const nidevice_grpc::Session& vi)
 
   raise_if_error(
       stub->GetHardwareState(&context, request, &response),
-      context);
-
-  return response;
-}
-
-GetNextCoercionRecordResponse
-get_next_coercion_record(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = GetNextCoercionRecordRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = GetNextCoercionRecordResponse{};
-
-  raise_if_error(
-      stub->GetNextCoercionRecord(&context, request, &response),
-      context);
-
-  return response;
-}
-
-GetNextInterchangeWarningResponse
-get_next_interchange_warning(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = GetNextInterchangeWarningRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = GetNextInterchangeWarningResponse{};
-
-  raise_if_error(
-      stub->GetNextInterchangeWarning(&context, request, &response),
       context);
 
   return response;

--- a/generated/nifgen/nifgen_client.h
+++ b/generated/nifgen/nifgen_client.h
@@ -47,8 +47,8 @@ ConfigureArbWaveformResponse configure_arb_waveform(const StubPtr& stub, const n
 ConfigureChannelsResponse configure_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channels);
 ConfigureClockModeResponse configure_clock_mode(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ClockMode, pb::int32>& clock_mode);
 ConfigureCustomFIRFilterCoefficientsResponse configure_custom_fir_filter_coefficients(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name, const std::vector<double>& coefficients_array);
-ConfigureDigitalEdgeScriptTriggerResponse configure_digital_edge_script_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& trigger_id, const std::string& source, const pb::int32& edge);
-ConfigureDigitalEdgeStartTriggerResponse configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& source, const pb::int32& edge);
+ConfigureDigitalEdgeScriptTriggerResponse configure_digital_edge_script_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& trigger_id, const std::string& source, const simple_variant<ScriptTriggerDigitalEdgeEdge, pb::int32>& edge);
+ConfigureDigitalEdgeStartTriggerResponse configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& source, const simple_variant<StartTriggerDigitalEdgeEdge, pb::int32>& edge);
 ConfigureDigitalLevelScriptTriggerResponse configure_digital_level_script_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& trigger_id, const std::string& source, const simple_variant<TriggerWhen, pb::int32>& trigger_when);
 ConfigureFreqListResponse configure_freq_list(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name, const pb::int32& frequency_list_handle, const double& amplitude, const double& dc_offset, const double& start_phase);
 ConfigureFrequencyResponse configure_frequency(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name, const double& frequency);
@@ -105,8 +105,6 @@ GetExtCalLastTempResponse get_ext_cal_last_temp(const StubPtr& stub, const nidev
 GetExtCalRecommendedIntervalResponse get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetFIRFilterCoefficientsResponse get_fir_filter_coefficients(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name);
 GetHardwareStateResponse get_hardware_state(const StubPtr& stub, const nidevice_grpc::Session& vi);
-GetNextCoercionRecordResponse get_next_coercion_record(const StubPtr& stub, const nidevice_grpc::Session& vi);
-GetNextInterchangeWarningResponse get_next_interchange_warning(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetSelfCalLastDateAndTimeResponse get_self_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetSelfCalLastTempResponse get_self_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetSelfCalSupportedResponse get_self_cal_supported(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/generated/nifgen/nifgen_compilation_test.cpp
+++ b/generated/nifgen/nifgen_compilation_test.cpp
@@ -422,16 +422,6 @@ ViStatus GetHardwareState(ViSession vi, ViInt32* state)
   return niFgen_GetHardwareState(vi, state);
 }
 
-ViStatus GetNextCoercionRecord(ViSession vi, ViInt32 bufferSize, ViChar coercionRecord[])
-{
-  return niFgen_GetNextCoercionRecord(vi, bufferSize, coercionRecord);
-}
-
-ViStatus GetNextInterchangeWarning(ViSession vi, ViInt32 bufferSize, ViChar interchangeWarning[])
-{
-  return niFgen_GetNextInterchangeWarning(vi, bufferSize, interchangeWarning);
-}
-
 ViStatus GetSelfCalLastDateAndTime(ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute)
 {
   return niFgen_GetSelfCalLastDateAndTime(vi, year, month, day, hour, minute);
@@ -467,12 +457,12 @@ ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViS
   return niFgen_init(resourceName, idQuery, resetDevice, vi);
 }
 
-ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViString optionString, ViSession* vi)
+ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi)
 {
   return niFgen_InitWithOptions(resourceName, idQuery, resetDevice, optionString, vi);
 }
 
-ViStatus InitializeWithChannels(ViRsrc resourceName, ViString channelName, ViBoolean resetDevice, ViString optionString, ViSession* vi)
+ViStatus InitializeWithChannels(ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi)
 {
   return niFgen_InitializeWithChannels(resourceName, channelName, resetDevice, optionString, vi);
 }

--- a/generated/nifgen/nifgen_library.cpp
+++ b/generated/nifgen/nifgen_library.cpp
@@ -111,8 +111,6 @@ NiFgenLibrary::NiFgenLibrary(std::shared_ptr<nidevice_grpc::SharedLibraryInterfa
   function_pointers_.GetExtCalRecommendedInterval = reinterpret_cast<GetExtCalRecommendedIntervalPtr>(shared_library_->get_function_pointer("niFgen_GetExtCalRecommendedInterval"));
   function_pointers_.GetFIRFilterCoefficients = reinterpret_cast<GetFIRFilterCoefficientsPtr>(shared_library_->get_function_pointer("niFgen_GetFIRFilterCoefficients"));
   function_pointers_.GetHardwareState = reinterpret_cast<GetHardwareStatePtr>(shared_library_->get_function_pointer("niFgen_GetHardwareState"));
-  function_pointers_.GetNextCoercionRecord = reinterpret_cast<GetNextCoercionRecordPtr>(shared_library_->get_function_pointer("niFgen_GetNextCoercionRecord"));
-  function_pointers_.GetNextInterchangeWarning = reinterpret_cast<GetNextInterchangeWarningPtr>(shared_library_->get_function_pointer("niFgen_GetNextInterchangeWarning"));
   function_pointers_.GetSelfCalLastDateAndTime = reinterpret_cast<GetSelfCalLastDateAndTimePtr>(shared_library_->get_function_pointer("niFgen_GetSelfCalLastDateAndTime"));
   function_pointers_.GetSelfCalLastTemp = reinterpret_cast<GetSelfCalLastTempPtr>(shared_library_->get_function_pointer("niFgen_GetSelfCalLastTemp"));
   function_pointers_.GetSelfCalSupported = reinterpret_cast<GetSelfCalSupportedPtr>(shared_library_->get_function_pointer("niFgen_GetSelfCalSupported"));
@@ -148,6 +146,7 @@ NiFgenLibrary::NiFgenLibrary(std::shared_ptr<nidevice_grpc::SharedLibraryInterfa
   function_pointers_.SetAttributeViSession = reinterpret_cast<SetAttributeViSessionPtr>(shared_library_->get_function_pointer("niFgen_SetAttributeViSession"));
   function_pointers_.SetAttributeViString = reinterpret_cast<SetAttributeViStringPtr>(shared_library_->get_function_pointer("niFgen_SetAttributeViString"));
   function_pointers_.SetNamedWaveformNextWritePosition = reinterpret_cast<SetNamedWaveformNextWritePositionPtr>(shared_library_->get_function_pointer("niFgen_SetNamedWaveformNextWritePosition"));
+  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_->get_function_pointer("niFgen_SetRuntimeEnvironment"));
   function_pointers_.SetWaveformNextWritePosition = reinterpret_cast<SetWaveformNextWritePositionPtr>(shared_library_->get_function_pointer("niFgen_SetWaveformNextWritePosition"));
   function_pointers_.UnlockSession = reinterpret_cast<UnlockSessionPtr>(shared_library_->get_function_pointer("niFgen_UnlockSession"));
   function_pointers_.WaitUntilDone = reinterpret_cast<WaitUntilDonePtr>(shared_library_->get_function_pointer("niFgen_WaitUntilDone"));
@@ -161,7 +160,6 @@ NiFgenLibrary::NiFgenLibrary(std::shared_ptr<nidevice_grpc::SharedLibraryInterfa
   function_pointers_.WriteScript = reinterpret_cast<WriteScriptPtr>(shared_library_->get_function_pointer("niFgen_WriteScript"));
   function_pointers_.WriteWaveform = reinterpret_cast<WriteWaveformPtr>(shared_library_->get_function_pointer("niFgen_WriteWaveform"));
   function_pointers_.WriteWaveformComplexF64 = reinterpret_cast<WriteWaveformComplexF64Ptr>(shared_library_->get_function_pointer("niFgen_WriteWaveformComplexF64"));
-  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_->get_function_pointer("niFgen_SetRuntimeEnvironment"));
 
   if (function_pointers_.SetRuntimeEnvironment) {
     this->SetRuntimeEnvironment(nidevice_grpc::kNiDeviceGrpcOriginalFileName, nidevice_grpc::kNiDeviceGrpcFileVersion, "", "");
@@ -844,22 +842,6 @@ ViStatus NiFgenLibrary::GetHardwareState(ViSession vi, ViInt32* state)
   return function_pointers_.GetHardwareState(vi, state);
 }
 
-ViStatus NiFgenLibrary::GetNextCoercionRecord(ViSession vi, ViInt32 bufferSize, ViChar coercionRecord[])
-{
-  if (!function_pointers_.GetNextCoercionRecord) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_GetNextCoercionRecord.");
-  }
-  return function_pointers_.GetNextCoercionRecord(vi, bufferSize, coercionRecord);
-}
-
-ViStatus NiFgenLibrary::GetNextInterchangeWarning(ViSession vi, ViInt32 bufferSize, ViChar interchangeWarning[])
-{
-  if (!function_pointers_.GetNextInterchangeWarning) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_GetNextInterchangeWarning.");
-  }
-  return function_pointers_.GetNextInterchangeWarning(vi, bufferSize, interchangeWarning);
-}
-
 ViStatus NiFgenLibrary::GetSelfCalLastDateAndTime(ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute)
 {
   if (!function_pointers_.GetSelfCalLastDateAndTime) {
@@ -916,7 +898,7 @@ ViStatus NiFgenLibrary::Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean r
   return function_pointers_.Init(resourceName, idQuery, resetDevice, vi);
 }
 
-ViStatus NiFgenLibrary::InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViString optionString, ViSession* vi)
+ViStatus NiFgenLibrary::InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi)
 {
   if (!function_pointers_.InitWithOptions) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFgen_InitWithOptions.");
@@ -924,7 +906,7 @@ ViStatus NiFgenLibrary::InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, 
   return function_pointers_.InitWithOptions(resourceName, idQuery, resetDevice, optionString, vi);
 }
 
-ViStatus NiFgenLibrary::InitializeWithChannels(ViRsrc resourceName, ViString channelName, ViBoolean resetDevice, ViString optionString, ViSession* vi)
+ViStatus NiFgenLibrary::InitializeWithChannels(ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi)
 {
   if (!function_pointers_.InitializeWithChannels) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFgen_InitializeWithChannels.");
@@ -1140,6 +1122,14 @@ ViStatus NiFgenLibrary::SetNamedWaveformNextWritePosition(ViSession vi, ViConstS
   return function_pointers_.SetNamedWaveformNextWritePosition(vi, channelName, waveformName, relativeTo, offset);
 }
 
+ViStatus NiFgenLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
+{
+  if (!function_pointers_.SetRuntimeEnvironment) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_SetRuntimeEnvironment.");
+  }
+  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
+}
+
 ViStatus NiFgenLibrary::SetWaveformNextWritePosition(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 relativeTo, ViInt32 offset)
 {
   if (!function_pointers_.SetWaveformNextWritePosition) {
@@ -1242,14 +1232,6 @@ ViStatus NiFgenLibrary::WriteWaveformComplexF64(ViSession vi, ViConstString chan
     throw nidevice_grpc::LibraryLoadException("Could not find niFgen_WriteWaveformComplexF64.");
   }
   return function_pointers_.WriteWaveformComplexF64(vi, channelName, numberOfSamples, data, waveformHandle);
-}
-
-ViStatus NiFgenLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
-{
-  if (!function_pointers_.SetRuntimeEnvironment) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_SetRuntimeEnvironment.");
-  }
-  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
 }
 
 bool NiFgenLibrary::is_runtime_environment_set() const { return this->runtime_environment_set_; }

--- a/generated/nifgen/nifgen_library.h
+++ b/generated/nifgen/nifgen_library.h
@@ -104,8 +104,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus GetExtCalRecommendedInterval(ViSession vi, ViInt32* months) override;
   ViStatus GetFIRFilterCoefficients(ViSession vi, ViConstString channelName, ViInt32 arraySize, ViReal64 coefficientsArray[], ViInt32* numberOfCoefficientsRead) override;
   ViStatus GetHardwareState(ViSession vi, ViInt32* state) override;
-  ViStatus GetNextCoercionRecord(ViSession vi, ViInt32 bufferSize, ViChar coercionRecord[]) override;
-  ViStatus GetNextInterchangeWarning(ViSession vi, ViInt32 bufferSize, ViChar interchangeWarning[]) override;
   ViStatus GetSelfCalLastDateAndTime(ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute) override;
   ViStatus GetSelfCalLastTemp(ViSession vi, ViReal64* temperature) override;
   ViStatus GetSelfCalSupported(ViSession vi, ViBoolean* selfCalSupported) override;
@@ -113,8 +111,8 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]) override;
   ViStatus ImportAttributeConfigurationFile(ViSession vi, ViConstString filePath) override;
   ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi) override;
-  ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViString optionString, ViSession* vi) override;
-  ViStatus InitializeWithChannels(ViRsrc resourceName, ViString channelName, ViBoolean resetDevice, ViString optionString, ViSession* vi) override;
+  ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi) override;
+  ViStatus InitializeWithChannels(ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi) override;
   ViStatus InitiateGeneration(ViSession vi) override;
   ViStatus InvalidateAllAttributes(ViSession vi) override;
   ViStatus IsDone(ViSession vi, ViBoolean* done) override;
@@ -141,6 +139,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus SetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession attributeValue) override;
   ViStatus SetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue) override;
   ViStatus SetNamedWaveformNextWritePosition(ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 relativeTo, ViInt32 offset) override;
+  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) override;
   ViStatus SetWaveformNextWritePosition(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 relativeTo, ViInt32 offset) override;
   ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock) override;
   ViStatus WaitUntilDone(ViSession vi, ViInt32 maxTime) override;
@@ -154,7 +153,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus WriteScript(ViSession vi, ViConstString channelName, ViConstString script) override;
   ViStatus WriteWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViReal64 data[]) override;
   ViStatus WriteWaveformComplexF64(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct data[], ViInt32 waveformHandle) override;
-  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) override;
   bool is_runtime_environment_set() const; // needed to test that we properly call SetRuntimeEnvironment
 
  private:
@@ -241,8 +239,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using GetExtCalRecommendedIntervalPtr = decltype(&niFgen_GetExtCalRecommendedInterval);
   using GetFIRFilterCoefficientsPtr = decltype(&niFgen_GetFIRFilterCoefficients);
   using GetHardwareStatePtr = decltype(&niFgen_GetHardwareState);
-  using GetNextCoercionRecordPtr = decltype(&niFgen_GetNextCoercionRecord);
-  using GetNextInterchangeWarningPtr = decltype(&niFgen_GetNextInterchangeWarning);
   using GetSelfCalLastDateAndTimePtr = decltype(&niFgen_GetSelfCalLastDateAndTime);
   using GetSelfCalLastTempPtr = decltype(&niFgen_GetSelfCalLastTemp);
   using GetSelfCalSupportedPtr = decltype(&niFgen_GetSelfCalSupported);
@@ -278,6 +274,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using SetAttributeViSessionPtr = decltype(&niFgen_SetAttributeViSession);
   using SetAttributeViStringPtr = decltype(&niFgen_SetAttributeViString);
   using SetNamedWaveformNextWritePositionPtr = decltype(&niFgen_SetNamedWaveformNextWritePosition);
+  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
   using SetWaveformNextWritePositionPtr = decltype(&niFgen_SetWaveformNextWritePosition);
   using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitUntilDonePtr = decltype(&niFgen_WaitUntilDone);
@@ -291,7 +288,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using WriteScriptPtr = decltype(&niFgen_WriteScript);
   using WriteWaveformPtr = decltype(&niFgen_WriteWaveform);
   using WriteWaveformComplexF64Ptr = decltype(&niFgen_WriteWaveformComplexF64);
-  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
   typedef struct FunctionPointers {
     AbortGenerationPtr AbortGeneration;
@@ -377,8 +373,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     GetExtCalRecommendedIntervalPtr GetExtCalRecommendedInterval;
     GetFIRFilterCoefficientsPtr GetFIRFilterCoefficients;
     GetHardwareStatePtr GetHardwareState;
-    GetNextCoercionRecordPtr GetNextCoercionRecord;
-    GetNextInterchangeWarningPtr GetNextInterchangeWarning;
     GetSelfCalLastDateAndTimePtr GetSelfCalLastDateAndTime;
     GetSelfCalLastTempPtr GetSelfCalLastTemp;
     GetSelfCalSupportedPtr GetSelfCalSupported;
@@ -414,6 +408,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     SetAttributeViSessionPtr SetAttributeViSession;
     SetAttributeViStringPtr SetAttributeViString;
     SetNamedWaveformNextWritePositionPtr SetNamedWaveformNextWritePosition;
+    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
     SetWaveformNextWritePositionPtr SetWaveformNextWritePosition;
     UnlockSessionPtr UnlockSession;
     WaitUntilDonePtr WaitUntilDone;
@@ -427,7 +422,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     WriteScriptPtr WriteScript;
     WriteWaveformPtr WriteWaveform;
     WriteWaveformComplexF64Ptr WriteWaveformComplexF64;
-    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
   } FunctionLoadStatus;
 
   std::shared_ptr<nidevice_grpc::SharedLibraryInterface> shared_library_;

--- a/generated/nifgen/nifgen_library_interface.h
+++ b/generated/nifgen/nifgen_library_interface.h
@@ -98,8 +98,6 @@ class NiFgenLibraryInterface {
   virtual ViStatus GetExtCalRecommendedInterval(ViSession vi, ViInt32* months) = 0;
   virtual ViStatus GetFIRFilterCoefficients(ViSession vi, ViConstString channelName, ViInt32 arraySize, ViReal64 coefficientsArray[], ViInt32* numberOfCoefficientsRead) = 0;
   virtual ViStatus GetHardwareState(ViSession vi, ViInt32* state) = 0;
-  virtual ViStatus GetNextCoercionRecord(ViSession vi, ViInt32 bufferSize, ViChar coercionRecord[]) = 0;
-  virtual ViStatus GetNextInterchangeWarning(ViSession vi, ViInt32 bufferSize, ViChar interchangeWarning[]) = 0;
   virtual ViStatus GetSelfCalLastDateAndTime(ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute) = 0;
   virtual ViStatus GetSelfCalLastTemp(ViSession vi, ViReal64* temperature) = 0;
   virtual ViStatus GetSelfCalSupported(ViSession vi, ViBoolean* selfCalSupported) = 0;
@@ -107,8 +105,8 @@ class NiFgenLibraryInterface {
   virtual ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]) = 0;
   virtual ViStatus ImportAttributeConfigurationFile(ViSession vi, ViConstString filePath) = 0;
   virtual ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi) = 0;
-  virtual ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViString optionString, ViSession* vi) = 0;
-  virtual ViStatus InitializeWithChannels(ViRsrc resourceName, ViString channelName, ViBoolean resetDevice, ViString optionString, ViSession* vi) = 0;
+  virtual ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi) = 0;
+  virtual ViStatus InitializeWithChannels(ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi) = 0;
   virtual ViStatus InitiateGeneration(ViSession vi) = 0;
   virtual ViStatus InvalidateAllAttributes(ViSession vi) = 0;
   virtual ViStatus IsDone(ViSession vi, ViBoolean* done) = 0;
@@ -135,6 +133,7 @@ class NiFgenLibraryInterface {
   virtual ViStatus SetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession attributeValue) = 0;
   virtual ViStatus SetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue) = 0;
   virtual ViStatus SetNamedWaveformNextWritePosition(ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 relativeTo, ViInt32 offset) = 0;
+  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
   virtual ViStatus SetWaveformNextWritePosition(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 relativeTo, ViInt32 offset) = 0;
   virtual ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock) = 0;
   virtual ViStatus WaitUntilDone(ViSession vi, ViInt32 maxTime) = 0;
@@ -148,7 +147,6 @@ class NiFgenLibraryInterface {
   virtual ViStatus WriteScript(ViSession vi, ViConstString channelName, ViConstString script) = 0;
   virtual ViStatus WriteWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViReal64 data[]) = 0;
   virtual ViStatus WriteWaveformComplexF64(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct data[], ViInt32 waveformHandle) = 0;
-  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
 };
 
 }  // namespace nifgen_grpc

--- a/generated/nifgen/nifgen_mock_library.h
+++ b/generated/nifgen/nifgen_mock_library.h
@@ -100,8 +100,6 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, GetExtCalRecommendedInterval, (ViSession vi, ViInt32* months), (override));
   MOCK_METHOD(ViStatus, GetFIRFilterCoefficients, (ViSession vi, ViConstString channelName, ViInt32 arraySize, ViReal64 coefficientsArray[], ViInt32* numberOfCoefficientsRead), (override));
   MOCK_METHOD(ViStatus, GetHardwareState, (ViSession vi, ViInt32* state), (override));
-  MOCK_METHOD(ViStatus, GetNextCoercionRecord, (ViSession vi, ViInt32 bufferSize, ViChar coercionRecord[]), (override));
-  MOCK_METHOD(ViStatus, GetNextInterchangeWarning, (ViSession vi, ViInt32 bufferSize, ViChar interchangeWarning[]), (override));
   MOCK_METHOD(ViStatus, GetSelfCalLastDateAndTime, (ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute), (override));
   MOCK_METHOD(ViStatus, GetSelfCalLastTemp, (ViSession vi, ViReal64* temperature), (override));
   MOCK_METHOD(ViStatus, GetSelfCalSupported, (ViSession vi, ViBoolean* selfCalSupported), (override));
@@ -109,8 +107,8 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, ImportAttributeConfigurationBuffer, (ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]), (override));
   MOCK_METHOD(ViStatus, ImportAttributeConfigurationFile, (ViSession vi, ViConstString filePath), (override));
   MOCK_METHOD(ViStatus, Init, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi), (override));
-  MOCK_METHOD(ViStatus, InitWithOptions, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViString optionString, ViSession* vi), (override));
-  MOCK_METHOD(ViStatus, InitializeWithChannels, (ViRsrc resourceName, ViString channelName, ViBoolean resetDevice, ViString optionString, ViSession* vi), (override));
+  MOCK_METHOD(ViStatus, InitWithOptions, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi), (override));
+  MOCK_METHOD(ViStatus, InitializeWithChannels, (ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, InitiateGeneration, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, InvalidateAllAttributes, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, IsDone, (ViSession vi, ViBoolean* done), (override));
@@ -137,6 +135,7 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, SetAttributeViSession, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViString, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue), (override));
   MOCK_METHOD(ViStatus, SetNamedWaveformNextWritePosition, (ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 relativeTo, ViInt32 offset), (override));
+  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
   MOCK_METHOD(ViStatus, SetWaveformNextWritePosition, (ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 relativeTo, ViInt32 offset), (override));
   MOCK_METHOD(ViStatus, UnlockSession, (ViSession vi, ViBoolean* callerHasLock), (override));
   MOCK_METHOD(ViStatus, WaitUntilDone, (ViSession vi, ViInt32 maxTime), (override));
@@ -150,7 +149,6 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, WriteScript, (ViSession vi, ViConstString channelName, ViConstString script), (override));
   MOCK_METHOD(ViStatus, WriteWaveform, (ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViReal64 data[]), (override));
   MOCK_METHOD(ViStatus, WriteWaveformComplexF64, (ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct data[], ViInt32 waveformHandle), (override));
-  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
 };
 
 }  // namespace unit

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -782,7 +782,22 @@ namespace nifgen_grpc {
       auto trigger_id = trigger_id_mbcs.c_str();
       auto source_mbcs = convert_from_grpc<std::string>(request->source());
       auto source = source_mbcs.c_str();
-      ViInt32 edge = request->edge();
+      ViInt32 edge;
+      switch (request->edge_enum_case()) {
+        case nifgen_grpc::ConfigureDigitalEdgeScriptTriggerRequest::EdgeEnumCase::kEdge: {
+          edge = static_cast<ViInt32>(request->edge());
+          break;
+        }
+        case nifgen_grpc::ConfigureDigitalEdgeScriptTriggerRequest::EdgeEnumCase::kEdgeRaw: {
+          edge = static_cast<ViInt32>(request->edge_raw());
+          break;
+        }
+        case nifgen_grpc::ConfigureDigitalEdgeScriptTriggerRequest::EdgeEnumCase::EDGE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for edge was not specified or out of range");
+          break;
+        }
+      }
+
       auto status = library_->ConfigureDigitalEdgeScriptTrigger(vi, trigger_id, source, edge);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -807,7 +822,22 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto source_mbcs = convert_from_grpc<std::string>(request->source());
       auto source = source_mbcs.c_str();
-      ViInt32 edge = request->edge();
+      ViInt32 edge;
+      switch (request->edge_enum_case()) {
+        case nifgen_grpc::ConfigureDigitalEdgeStartTriggerRequest::EdgeEnumCase::kEdge: {
+          edge = static_cast<ViInt32>(request->edge());
+          break;
+        }
+        case nifgen_grpc::ConfigureDigitalEdgeStartTriggerRequest::EdgeEnumCase::kEdgeRaw: {
+          edge = static_cast<ViInt32>(request->edge_raw());
+          break;
+        }
+        case nifgen_grpc::ConfigureDigitalEdgeStartTriggerRequest::EdgeEnumCase::EDGE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for edge was not specified or out of range");
+          break;
+        }
+      }
+
       auto status = library_->ConfigureDigitalEdgeStartTrigger(vi, source, edge);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2475,92 +2505,6 @@ namespace nifgen_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::GetNextCoercionRecord(::grpc::ServerContext* context, const GetNextCoercionRecordRequest* request, GetNextCoercionRecordResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
-
-      while (true) {
-        auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
-        if (!status_ok(status)) {
-          return ConvertApiErrorStatusForViSession(context, status, vi);
-        }
-        ViInt32 buffer_size = status;
-
-        std::string coercion_record;
-        if (buffer_size > 0) {
-            coercion_record.resize(buffer_size - 1);
-        }
-        status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(buffer_size)) {
-          // buffer is now too small, try again
-          continue;
-        }
-        if (!status_ok(status)) {
-          return ConvertApiErrorStatusForViSession(context, status, vi);
-        }
-        response->set_status(status);
-        std::string coercion_record_utf8;
-        convert_to_grpc(coercion_record, &coercion_record_utf8);
-        response->set_coercion_record(coercion_record_utf8);
-        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
-        return ::grpc::Status::OK;
-      }
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::GetNextInterchangeWarning(::grpc::ServerContext* context, const GetNextInterchangeWarningRequest* request, GetNextInterchangeWarningResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
-
-      while (true) {
-        auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
-        if (!status_ok(status)) {
-          return ConvertApiErrorStatusForViSession(context, status, vi);
-        }
-        ViInt32 buffer_size = status;
-
-        std::string interchange_warning;
-        if (buffer_size > 0) {
-            interchange_warning.resize(buffer_size - 1);
-        }
-        status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(buffer_size)) {
-          // buffer is now too small, try again
-          continue;
-        }
-        if (!status_ok(status)) {
-          return ConvertApiErrorStatusForViSession(context, status, vi);
-        }
-        response->set_status(status);
-        std::string interchange_warning_utf8;
-        convert_to_grpc(interchange_warning, &interchange_warning_utf8);
-        response->set_interchange_warning(interchange_warning_utf8);
-        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
-        return ::grpc::Status::OK;
-      }
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiFgenService::GetSelfCalLastDateAndTime(::grpc::ServerContext* context, const GetSelfCalLastDateAndTimeRequest* request, GetSelfCalLastDateAndTimeResponse* response)
   {
     if (context->IsCancelled()) {
@@ -2764,7 +2708,7 @@ namespace nifgen_grpc {
       ViBoolean id_query = request->id_query();
       ViBoolean reset_device = request->reset_device();
       auto option_string_mbcs = convert_from_grpc<std::string>(request->option_string());
-      ViString option_string = (ViString)option_string_mbcs.c_str();
+      auto option_string = option_string_mbcs.c_str();
       auto initialization_behavior = request->initialization_behavior();
 
       bool new_session_initialized {};
@@ -2802,10 +2746,10 @@ namespace nifgen_grpc {
       auto resource_name_mbcs = convert_from_grpc<std::string>(request->resource_name());
       ViRsrc resource_name = (ViRsrc)resource_name_mbcs.c_str();
       auto channel_name_mbcs = convert_from_grpc<std::string>(request->channel_name());
-      ViString channel_name = (ViString)channel_name_mbcs.c_str();
+      auto channel_name = channel_name_mbcs.c_str();
       ViBoolean reset_device = request->reset_device();
       auto option_string_mbcs = convert_from_grpc<std::string>(request->option_string());
-      ViString option_string = (ViString)option_string_mbcs.c_str();
+      auto option_string = option_string_mbcs.c_str();
       auto initialization_behavior = request->initialization_behavior();
 
       bool new_session_initialized {};

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -125,8 +125,6 @@ public:
   ::grpc::Status GetExtCalRecommendedInterval(::grpc::ServerContext* context, const GetExtCalRecommendedIntervalRequest* request, GetExtCalRecommendedIntervalResponse* response) override;
   ::grpc::Status GetFIRFilterCoefficients(::grpc::ServerContext* context, const GetFIRFilterCoefficientsRequest* request, GetFIRFilterCoefficientsResponse* response) override;
   ::grpc::Status GetHardwareState(::grpc::ServerContext* context, const GetHardwareStateRequest* request, GetHardwareStateResponse* response) override;
-  ::grpc::Status GetNextCoercionRecord(::grpc::ServerContext* context, const GetNextCoercionRecordRequest* request, GetNextCoercionRecordResponse* response) override;
-  ::grpc::Status GetNextInterchangeWarning(::grpc::ServerContext* context, const GetNextInterchangeWarningRequest* request, GetNextInterchangeWarningResponse* response) override;
   ::grpc::Status GetSelfCalLastDateAndTime(::grpc::ServerContext* context, const GetSelfCalLastDateAndTimeRequest* request, GetSelfCalLastDateAndTimeResponse* response) override;
   ::grpc::Status GetSelfCalLastTemp(::grpc::ServerContext* context, const GetSelfCalLastTempRequest* request, GetSelfCalLastTempResponse* response) override;
   ::grpc::Status GetSelfCalSupported(::grpc::ServerContext* context, const GetSelfCalSupportedRequest* request, GetSelfCalSupportedResponse* response) override;

--- a/source/codegen/metadata/nifgen/attributes.py
+++ b/source/codegen/metadata/nifgen/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0f157
+# This file is generated from NI-FGEN API metadata version 26.0.0f146
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifgen/config.py
+++ b/source/codegen/metadata/nifgen/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0f157
+# This file is generated from NI-FGEN API metadata version 26.0.0f146
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0f157',
+    'api_version': '26.0.0f146',
     'c_function_prefix': 'niFgen_',
     'c_header': 'niFgen.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nifgen/enums.py
+++ b/source/codegen/metadata/nifgen/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0f157
+# This file is generated from NI-FGEN API metadata version 26.0.0f146
 enums = {
     'AddressType': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifgen/functions.py
+++ b/source/codegen/metadata/nifgen/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0f157
+# This file is generated from NI-FGEN API metadata version 26.0.0f146
 functions = {
     'AbortGeneration': {
         'codegen_method': 'public',
@@ -681,6 +681,7 @@ functions = {
             {
                 'cppName': 'edge',
                 'direction': 'in',
+                'enum': 'ScriptTriggerDigitalEdgeEdge',
                 'grpc_type': 'sint32',
                 'name': 'edge',
                 'type': 'ViInt32'
@@ -708,6 +709,7 @@ functions = {
             {
                 'cppName': 'edge',
                 'direction': 'in',
+                'enum': 'StartTriggerDigitalEdgeEdge',
                 'grpc_type': 'sint32',
                 'name': 'edge',
                 'type': 'ViInt32'
@@ -2564,72 +2566,6 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'GetNextCoercionRecord': {
-        'codegen_method': 'public',
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'cppName': 'bufferSize',
-                'direction': 'in',
-                'grpc_type': 'sint32',
-                'include_in_proto': False,
-                'is_size_param': True,
-                'name': 'bufferSize',
-                'type': 'ViInt32'
-            },
-            {
-                'cppName': 'coercionRecord',
-                'direction': 'out',
-                'grpc_type': 'string',
-                'name': 'coercionRecord',
-                'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'bufferSize'
-                },
-                'type': 'ViChar[]'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'GetNextInterchangeWarning': {
-        'codegen_method': 'public',
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'cppName': 'bufferSize',
-                'direction': 'in',
-                'grpc_type': 'sint32',
-                'include_in_proto': False,
-                'is_size_param': True,
-                'name': 'bufferSize',
-                'type': 'ViInt32'
-            },
-            {
-                'cppName': 'interchangeWarning',
-                'direction': 'out',
-                'grpc_type': 'string',
-                'name': 'interchangeWarning',
-                'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'bufferSize'
-                },
-                'type': 'ViChar[]'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'GetSelfCalLastDateAndTime': {
         'codegen_method': 'public',
         'parameters': [
@@ -2892,7 +2828,7 @@ functions = {
                 'direction': 'in',
                 'grpc_type': 'string',
                 'name': 'optionString',
-                'type': 'ViString'
+                'type': 'ViConstString'
             },
             {
                 'cppName': 'vi',
@@ -2944,7 +2880,7 @@ functions = {
                 'direction': 'in',
                 'grpc_type': 'string',
                 'name': 'channelName',
-                'type': 'ViString'
+                'type': 'ViConstString'
             },
             {
                 'cppName': 'resetDevice',
@@ -2958,7 +2894,7 @@ functions = {
                 'direction': 'in',
                 'grpc_type': 'string',
                 'name': 'optionString',
-                'type': 'ViString'
+                'type': 'ViConstString'
             },
             {
                 'cppName': 'vi',
@@ -3709,6 +3645,40 @@ functions = {
                 'grpc_type': 'sint32',
                 'name': 'offset',
                 'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'environment',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'environmentVersion',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved1',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved2',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved2',
+                'type': 'ViConstString'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/nifgen/nifgen.proto
+++ b/source/codegen/metadata/nifgen/nifgen.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FGEN API metadata version 23.0.0f157
+// This file is generated from NI-FGEN API metadata version 26.0.0f146
 //---------------------------------------------------------------------
 // Proto file for the NI-FGEN Metadata
 //---------------------------------------------------------------------
@@ -17,220 +17,202 @@ import "nidevice.proto";
 import "session.proto";
 
 service NiFgen {
-  rpc AbortGeneration(AbortGenerationRequest) returns (AbortGenerationResponse);
-  rpc AdjustSampleClockRelativeDelay(AdjustSampleClockRelativeDelayRequest) returns (AdjustSampleClockRelativeDelayResponse);
-  rpc AllocateNamedWaveform(AllocateNamedWaveformRequest) returns (AllocateNamedWaveformResponse);
-  rpc AllocateWaveform(AllocateWaveformRequest) returns (AllocateWaveformResponse);
-  rpc CheckAttributeViBoolean(CheckAttributeViBooleanRequest) returns (CheckAttributeViBooleanResponse);
-  rpc CheckAttributeViInt32(CheckAttributeViInt32Request) returns (CheckAttributeViInt32Response);
-  rpc CheckAttributeViInt64(CheckAttributeViInt64Request) returns (CheckAttributeViInt64Response);
-  rpc CheckAttributeViReal64(CheckAttributeViReal64Request) returns (CheckAttributeViReal64Response);
-  rpc CheckAttributeViSession(CheckAttributeViSessionRequest) returns (CheckAttributeViSessionResponse);
-  rpc CheckAttributeViString(CheckAttributeViStringRequest) returns (CheckAttributeViStringResponse);
-  rpc ClearArbMemory(ClearArbMemoryRequest) returns (ClearArbMemoryResponse);
-  rpc ClearArbSequence(ClearArbSequenceRequest) returns (ClearArbSequenceResponse);
-  rpc ClearArbWaveform(ClearArbWaveformRequest) returns (ClearArbWaveformResponse);
-  rpc ClearError(ClearErrorRequest) returns (ClearErrorResponse);
-  rpc ClearFreqList(ClearFreqListRequest) returns (ClearFreqListResponse);
-  rpc ClearInterchangeWarnings(ClearInterchangeWarningsRequest) returns (ClearInterchangeWarningsResponse);
-  rpc ClearUserStandardWaveform(ClearUserStandardWaveformRequest) returns (ClearUserStandardWaveformResponse);
-  rpc Close(CloseRequest) returns (CloseResponse);
-  rpc Commit(CommitRequest) returns (CommitResponse);
-  rpc ConfigureAmplitude(ConfigureAmplitudeRequest) returns (ConfigureAmplitudeResponse);
-  rpc ConfigureArbSequence(ConfigureArbSequenceRequest) returns (ConfigureArbSequenceResponse);
-  rpc ConfigureArbWaveform(ConfigureArbWaveformRequest) returns (ConfigureArbWaveformResponse);
-  rpc ConfigureChannels(ConfigureChannelsRequest) returns (ConfigureChannelsResponse);
-  rpc ConfigureClockMode(ConfigureClockModeRequest) returns (ConfigureClockModeResponse);
-  rpc ConfigureCustomFIRFilterCoefficients(ConfigureCustomFIRFilterCoefficientsRequest) returns (ConfigureCustomFIRFilterCoefficientsResponse);
-  rpc ConfigureDigitalEdgeScriptTrigger(ConfigureDigitalEdgeScriptTriggerRequest) returns (ConfigureDigitalEdgeScriptTriggerResponse);
-  rpc ConfigureDigitalEdgeStartTrigger(ConfigureDigitalEdgeStartTriggerRequest) returns (ConfigureDigitalEdgeStartTriggerResponse);
-  rpc ConfigureDigitalLevelScriptTrigger(ConfigureDigitalLevelScriptTriggerRequest) returns (ConfigureDigitalLevelScriptTriggerResponse);
-  rpc ConfigureFreqList(ConfigureFreqListRequest) returns (ConfigureFreqListResponse);
-  rpc ConfigureFrequency(ConfigureFrequencyRequest) returns (ConfigureFrequencyResponse);
-  rpc ConfigureOperationMode(ConfigureOperationModeRequest) returns (ConfigureOperationModeResponse);
-  rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
-  rpc ConfigureOutputImpedance(ConfigureOutputImpedanceRequest) returns (ConfigureOutputImpedanceResponse);
-  rpc ConfigureOutputMode(ConfigureOutputModeRequest) returns (ConfigureOutputModeResponse);
-  rpc ConfigureP2PEndpointFullnessStartTrigger(ConfigureP2PEndpointFullnessStartTriggerRequest) returns (ConfigureP2PEndpointFullnessStartTriggerResponse);
-  rpc ConfigureReferenceClock(ConfigureReferenceClockRequest) returns (ConfigureReferenceClockResponse);
-  rpc ConfigureSampleClockSource(ConfigureSampleClockSourceRequest) returns (ConfigureSampleClockSourceResponse);
-  rpc ConfigureSampleRate(ConfigureSampleRateRequest) returns (ConfigureSampleRateResponse);
-  rpc ConfigureSoftwareEdgeScriptTrigger(ConfigureSoftwareEdgeScriptTriggerRequest) returns (ConfigureSoftwareEdgeScriptTriggerResponse);
-  rpc ConfigureSoftwareEdgeStartTrigger(ConfigureSoftwareEdgeStartTriggerRequest) returns (ConfigureSoftwareEdgeStartTriggerResponse);
-  rpc ConfigureStandardWaveform(ConfigureStandardWaveformRequest) returns (ConfigureStandardWaveformResponse);
-  rpc ConfigureSynchronization(ConfigureSynchronizationRequest) returns (ConfigureSynchronizationResponse);
-  rpc ConfigureTriggerMode(ConfigureTriggerModeRequest) returns (ConfigureTriggerModeResponse);
-  rpc CreateAdvancedArbSequence(CreateAdvancedArbSequenceRequest) returns (CreateAdvancedArbSequenceResponse);
-  rpc CreateArbSequence(CreateArbSequenceRequest) returns (CreateArbSequenceResponse);
-  rpc CreateFreqList(CreateFreqListRequest) returns (CreateFreqListResponse);
-  rpc CreateWaveformComplexF64(CreateWaveformComplexF64Request) returns (CreateWaveformComplexF64Response);
-  rpc CreateWaveformF64(CreateWaveformF64Request) returns (CreateWaveformF64Response);
-  rpc CreateWaveformFromFileF64(CreateWaveformFromFileF64Request) returns (CreateWaveformFromFileF64Response);
-  rpc CreateWaveformFromFileHWS(CreateWaveformFromFileHWSRequest) returns (CreateWaveformFromFileHWSResponse);
-  rpc CreateWaveformFromFileI16(CreateWaveformFromFileI16Request) returns (CreateWaveformFromFileI16Response);
-  rpc CreateWaveformI16(CreateWaveformI16Request) returns (CreateWaveformI16Response);
-  rpc DefineUserStandardWaveform(DefineUserStandardWaveformRequest) returns (DefineUserStandardWaveformResponse);
-  rpc DeleteNamedWaveform(DeleteNamedWaveformRequest) returns (DeleteNamedWaveformResponse);
-  rpc DeleteScript(DeleteScriptRequest) returns (DeleteScriptResponse);
-  rpc Disable(DisableRequest) returns (DisableResponse);
-  rpc DisableAnalogFilter(DisableAnalogFilterRequest) returns (DisableAnalogFilterResponse);
-  rpc DisableDigitalFilter(DisableDigitalFilterRequest) returns (DisableDigitalFilterResponse);
-  rpc DisableDigitalPatterning(DisableDigitalPatterningRequest) returns (DisableDigitalPatterningResponse);
-  rpc DisableScriptTrigger(DisableScriptTriggerRequest) returns (DisableScriptTriggerResponse);
-  rpc DisableStartTrigger(DisableStartTriggerRequest) returns (DisableStartTriggerResponse);
-  rpc EnableAnalogFilter(EnableAnalogFilterRequest) returns (EnableAnalogFilterResponse);
-  rpc EnableDigitalFilter(EnableDigitalFilterRequest) returns (EnableDigitalFilterResponse);
-  rpc EnableDigitalPatterning(EnableDigitalPatterningRequest) returns (EnableDigitalPatterningResponse);
-  rpc ErrorHandler(ErrorHandlerRequest) returns (ErrorHandlerResponse);
-  rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
-  rpc ErrorQuery(ErrorQueryRequest) returns (ErrorQueryResponse);
-  rpc ExportAttributeConfigurationBuffer(ExportAttributeConfigurationBufferRequest) returns (ExportAttributeConfigurationBufferResponse);
-  rpc ExportAttributeConfigurationFile(ExportAttributeConfigurationFileRequest) returns (ExportAttributeConfigurationFileResponse);
-  rpc ExportSignal(ExportSignalRequest) returns (ExportSignalResponse);
-  rpc GetAttributeViBoolean(GetAttributeViBooleanRequest) returns (GetAttributeViBooleanResponse);
-  rpc GetAttributeViInt32(GetAttributeViInt32Request) returns (GetAttributeViInt32Response);
-  rpc GetAttributeViInt64(GetAttributeViInt64Request) returns (GetAttributeViInt64Response);
-  rpc GetAttributeViReal64(GetAttributeViReal64Request) returns (GetAttributeViReal64Response);
-  rpc GetAttributeViSession(GetAttributeViSessionRequest) returns (GetAttributeViSessionResponse);
-  rpc GetAttributeViString(GetAttributeViStringRequest) returns (GetAttributeViStringResponse);
-  rpc GetChannelName(GetChannelNameRequest) returns (GetChannelNameResponse);
-  rpc GetError(GetErrorRequest) returns (GetErrorResponse);
-  rpc GetExtCalLastDateAndTime(GetExtCalLastDateAndTimeRequest) returns (GetExtCalLastDateAndTimeResponse);
-  rpc GetExtCalLastTemp(GetExtCalLastTempRequest) returns (GetExtCalLastTempResponse);
-  rpc GetExtCalRecommendedInterval(GetExtCalRecommendedIntervalRequest) returns (GetExtCalRecommendedIntervalResponse);
-  rpc GetFIRFilterCoefficients(GetFIRFilterCoefficientsRequest) returns (GetFIRFilterCoefficientsResponse);
-  rpc GetHardwareState(GetHardwareStateRequest) returns (GetHardwareStateResponse);
-  rpc GetNextCoercionRecord(GetNextCoercionRecordRequest) returns (GetNextCoercionRecordResponse);
-  rpc GetNextInterchangeWarning(GetNextInterchangeWarningRequest) returns (GetNextInterchangeWarningResponse);
-  rpc GetSelfCalLastDateAndTime(GetSelfCalLastDateAndTimeRequest) returns (GetSelfCalLastDateAndTimeResponse);
-  rpc GetSelfCalLastTemp(GetSelfCalLastTempRequest) returns (GetSelfCalLastTempResponse);
-  rpc GetSelfCalSupported(GetSelfCalSupportedRequest) returns (GetSelfCalSupportedResponse);
-  rpc GetStreamEndpointHandle(GetStreamEndpointHandleRequest) returns (GetStreamEndpointHandleResponse);
-  rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
-  rpc ImportAttributeConfigurationFile(ImportAttributeConfigurationFileRequest) returns (ImportAttributeConfigurationFileResponse);
   rpc Init(InitRequest) returns (InitResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
   rpc InitializeWithChannels(InitializeWithChannelsRequest) returns (InitializeWithChannelsResponse);
-  rpc InitiateGeneration(InitiateGenerationRequest) returns (InitiateGenerationResponse);
-  rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
-  rpc IsDone(IsDoneRequest) returns (IsDoneResponse);
-  rpc ManualEnableP2PStream(ManualEnableP2PStreamRequest) returns (ManualEnableP2PStreamResponse);
-  rpc QueryArbSeqCapabilities(QueryArbSeqCapabilitiesRequest) returns (QueryArbSeqCapabilitiesResponse);
-  rpc QueryArbWfmCapabilities(QueryArbWfmCapabilitiesRequest) returns (QueryArbWfmCapabilitiesResponse);
-  rpc QueryFreqListCapabilities(QueryFreqListCapabilitiesRequest) returns (QueryFreqListCapabilitiesResponse);
-  rpc ReadCurrentTemperature(ReadCurrentTemperatureRequest) returns (ReadCurrentTemperatureResponse);
+  rpc Close(CloseRequest) returns (CloseResponse);
   rpc Reset(ResetRequest) returns (ResetResponse);
-  rpc ResetAttribute(ResetAttributeRequest) returns (ResetAttributeResponse);
-  rpc ResetDevice(ResetDeviceRequest) returns (ResetDeviceResponse);
-  rpc ResetInterchangeCheck(ResetInterchangeCheckRequest) returns (ResetInterchangeCheckResponse);
-  rpc ResetWithDefaults(ResetWithDefaultsRequest) returns (ResetWithDefaultsResponse);
-  rpc RevisionQuery(RevisionQueryRequest) returns (RevisionQueryResponse);
-  rpc RouteSignalOut(RouteSignalOutRequest) returns (RouteSignalOutResponse);
-  rpc SelfCal(SelfCalRequest) returns (SelfCalResponse);
   rpc SelfTest(SelfTestRequest) returns (SelfTestResponse);
-  rpc SendSoftwareEdgeTrigger(SendSoftwareEdgeTriggerRequest) returns (SendSoftwareEdgeTriggerResponse);
-  rpc SetAttributeViBoolean(SetAttributeViBooleanRequest) returns (SetAttributeViBooleanResponse);
-  rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
-  rpc SetAttributeViInt64(SetAttributeViInt64Request) returns (SetAttributeViInt64Response);
-  rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
-  rpc SetAttributeViSession(SetAttributeViSessionRequest) returns (SetAttributeViSessionResponse);
-  rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
-  rpc SetNamedWaveformNextWritePosition(SetNamedWaveformNextWritePositionRequest) returns (SetNamedWaveformNextWritePositionResponse);
-  rpc SetWaveformNextWritePosition(SetWaveformNextWritePositionRequest) returns (SetWaveformNextWritePositionResponse);
+  rpc ErrorQuery(ErrorQueryRequest) returns (ErrorQueryResponse);
+  rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
+  rpc RevisionQuery(RevisionQueryRequest) returns (RevisionQueryResponse);
+  rpc GetError(GetErrorRequest) returns (GetErrorResponse);
+  rpc ClearError(ClearErrorRequest) returns (ClearErrorResponse);
+  rpc ErrorHandler(ErrorHandlerRequest) returns (ErrorHandlerResponse);
+  rpc GetChannelName(GetChannelNameRequest) returns (GetChannelNameResponse);
+  rpc ResetInterchangeCheck(ResetInterchangeCheckRequest) returns (ResetInterchangeCheckResponse);
+  rpc ClearInterchangeWarnings(ClearInterchangeWarningsRequest) returns (ClearInterchangeWarningsResponse);
+  rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
+  rpc ResetWithDefaults(ResetWithDefaultsRequest) returns (ResetWithDefaultsResponse);
+  rpc Disable(DisableRequest) returns (DisableResponse);
+  rpc Commit(CommitRequest) returns (CommitResponse);
+  rpc GetHardwareState(GetHardwareStateRequest) returns (GetHardwareStateResponse);
   rpc WaitUntilDone(WaitUntilDoneRequest) returns (WaitUntilDoneResponse);
-  rpc WriteBinary16Waveform(WriteBinary16WaveformRequest) returns (WriteBinary16WaveformResponse);
-  rpc WriteComplexBinary16Waveform(WriteComplexBinary16WaveformRequest) returns (WriteComplexBinary16WaveformResponse);
-  rpc WriteNamedWaveformComplexF64(WriteNamedWaveformComplexF64Request) returns (WriteNamedWaveformComplexF64Response);
-  rpc WriteNamedWaveformComplexI16(WriteNamedWaveformComplexI16Request) returns (WriteNamedWaveformComplexI16Response);
+  rpc IsDone(IsDoneRequest) returns (IsDoneResponse);
+  rpc ResetDevice(ResetDeviceRequest) returns (ResetDeviceResponse);
+  rpc ConfigureOperationMode(ConfigureOperationModeRequest) returns (ConfigureOperationModeResponse);
+  rpc ConfigureOutputMode(ConfigureOutputModeRequest) returns (ConfigureOutputModeResponse);
+  rpc ConfigureReferenceClock(ConfigureReferenceClockRequest) returns (ConfigureReferenceClockResponse);
+  rpc ConfigureOutputImpedance(ConfigureOutputImpedanceRequest) returns (ConfigureOutputImpedanceResponse);
+  rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
+  rpc ConfigureChannels(ConfigureChannelsRequest) returns (ConfigureChannelsResponse);
+  rpc InitiateGeneration(InitiateGenerationRequest) returns (InitiateGenerationResponse);
+  rpc AbortGeneration(AbortGenerationRequest) returns (AbortGenerationResponse);
+  rpc ConfigureStandardWaveform(ConfigureStandardWaveformRequest) returns (ConfigureStandardWaveformResponse);
+  rpc DefineUserStandardWaveform(DefineUserStandardWaveformRequest) returns (DefineUserStandardWaveformResponse);
+  rpc ClearUserStandardWaveform(ClearUserStandardWaveformRequest) returns (ClearUserStandardWaveformResponse);
+  rpc ConfigureFrequency(ConfigureFrequencyRequest) returns (ConfigureFrequencyResponse);
+  rpc ConfigureAmplitude(ConfigureAmplitudeRequest) returns (ConfigureAmplitudeResponse);
+  rpc QueryArbWfmCapabilities(QueryArbWfmCapabilitiesRequest) returns (QueryArbWfmCapabilitiesResponse);
+  rpc CreateWaveformF64(CreateWaveformF64Request) returns (CreateWaveformF64Response);
+  rpc CreateWaveformI16(CreateWaveformI16Request) returns (CreateWaveformI16Response);
+  rpc CreateWaveformComplexF64(CreateWaveformComplexF64Request) returns (CreateWaveformComplexF64Response);
+  rpc CreateWaveformFromFileI16(CreateWaveformFromFileI16Request) returns (CreateWaveformFromFileI16Response);
+  rpc CreateWaveformFromFileF64(CreateWaveformFromFileF64Request) returns (CreateWaveformFromFileF64Response);
+  rpc ConfigureSampleRate(ConfigureSampleRateRequest) returns (ConfigureSampleRateResponse);
+  rpc ConfigureArbWaveform(ConfigureArbWaveformRequest) returns (ConfigureArbWaveformResponse);
+  rpc ClearArbWaveform(ClearArbWaveformRequest) returns (ClearArbWaveformResponse);
+  rpc AllocateNamedWaveform(AllocateNamedWaveformRequest) returns (AllocateNamedWaveformResponse);
+  rpc SetNamedWaveformNextWritePosition(SetNamedWaveformNextWritePositionRequest) returns (SetNamedWaveformNextWritePositionResponse);
   rpc WriteNamedWaveformF64(WriteNamedWaveformF64Request) returns (WriteNamedWaveformF64Response);
   rpc WriteNamedWaveformI16(WriteNamedWaveformI16Request) returns (WriteNamedWaveformI16Response);
-  rpc WriteP2PEndpointI16(WriteP2PEndpointI16Request) returns (WriteP2PEndpointI16Response);
+  rpc WriteNamedWaveformComplexF64(WriteNamedWaveformComplexF64Request) returns (WriteNamedWaveformComplexF64Response);
+  rpc WriteNamedWaveformComplexI16(WriteNamedWaveformComplexI16Request) returns (WriteNamedWaveformComplexI16Response);
+  rpc DeleteNamedWaveform(DeleteNamedWaveformRequest) returns (DeleteNamedWaveformResponse);
+  rpc QueryArbSeqCapabilities(QueryArbSeqCapabilitiesRequest) returns (QueryArbSeqCapabilitiesResponse);
+  rpc CreateArbSequence(CreateArbSequenceRequest) returns (CreateArbSequenceResponse);
+  rpc CreateAdvancedArbSequence(CreateAdvancedArbSequenceRequest) returns (CreateAdvancedArbSequenceResponse);
+  rpc ConfigureArbSequence(ConfigureArbSequenceRequest) returns (ConfigureArbSequenceResponse);
+  rpc ClearArbSequence(ClearArbSequenceRequest) returns (ClearArbSequenceResponse);
+  rpc ClearArbMemory(ClearArbMemoryRequest) returns (ClearArbMemoryResponse);
+  rpc QueryFreqListCapabilities(QueryFreqListCapabilitiesRequest) returns (QueryFreqListCapabilitiesResponse);
+  rpc CreateFreqList(CreateFreqListRequest) returns (CreateFreqListResponse);
+  rpc ConfigureFreqList(ConfigureFreqListRequest) returns (ConfigureFreqListResponse);
+  rpc ClearFreqList(ClearFreqListRequest) returns (ClearFreqListResponse);
   rpc WriteScript(WriteScriptRequest) returns (WriteScriptResponse);
+  rpc DeleteScript(DeleteScriptRequest) returns (DeleteScriptResponse);
+  rpc ExportSignal(ExportSignalRequest) returns (ExportSignalResponse);
+  rpc RouteSignalOut(RouteSignalOutRequest) returns (RouteSignalOutResponse);
+  rpc SendSoftwareEdgeTrigger(SendSoftwareEdgeTriggerRequest) returns (SendSoftwareEdgeTriggerResponse);
+  rpc ConfigureDigitalEdgeStartTrigger(ConfigureDigitalEdgeStartTriggerRequest) returns (ConfigureDigitalEdgeStartTriggerResponse);
+  rpc ConfigureSoftwareEdgeStartTrigger(ConfigureSoftwareEdgeStartTriggerRequest) returns (ConfigureSoftwareEdgeStartTriggerResponse);
+  rpc DisableStartTrigger(DisableStartTriggerRequest) returns (DisableStartTriggerResponse);
+  rpc ConfigureP2PEndpointFullnessStartTrigger(ConfigureP2PEndpointFullnessStartTriggerRequest) returns (ConfigureP2PEndpointFullnessStartTriggerResponse);
+  rpc ConfigureDigitalEdgeScriptTrigger(ConfigureDigitalEdgeScriptTriggerRequest) returns (ConfigureDigitalEdgeScriptTriggerResponse);
+  rpc ConfigureDigitalLevelScriptTrigger(ConfigureDigitalLevelScriptTriggerRequest) returns (ConfigureDigitalLevelScriptTriggerResponse);
+  rpc ConfigureSoftwareEdgeScriptTrigger(ConfigureSoftwareEdgeScriptTriggerRequest) returns (ConfigureSoftwareEdgeScriptTriggerResponse);
+  rpc DisableScriptTrigger(DisableScriptTriggerRequest) returns (DisableScriptTriggerResponse);
+  rpc ConfigureClockMode(ConfigureClockModeRequest) returns (ConfigureClockModeResponse);
+  rpc AdjustSampleClockRelativeDelay(AdjustSampleClockRelativeDelayRequest) returns (AdjustSampleClockRelativeDelayResponse);
+  rpc AllocateWaveform(AllocateWaveformRequest) returns (AllocateWaveformResponse);
+  rpc SetWaveformNextWritePosition(SetWaveformNextWritePositionRequest) returns (SetWaveformNextWritePositionResponse);
   rpc WriteWaveform(WriteWaveformRequest) returns (WriteWaveformResponse);
+  rpc WriteBinary16Waveform(WriteBinary16WaveformRequest) returns (WriteBinary16WaveformResponse);
   rpc WriteWaveformComplexF64(WriteWaveformComplexF64Request) returns (WriteWaveformComplexF64Response);
+  rpc WriteComplexBinary16Waveform(WriteComplexBinary16WaveformRequest) returns (WriteComplexBinary16WaveformResponse);
+  rpc SelfCal(SelfCalRequest) returns (SelfCalResponse);
+  rpc GetSelfCalSupported(GetSelfCalSupportedRequest) returns (GetSelfCalSupportedResponse);
+  rpc GetSelfCalLastDateAndTime(GetSelfCalLastDateAndTimeRequest) returns (GetSelfCalLastDateAndTimeResponse);
+  rpc GetExtCalLastDateAndTime(GetExtCalLastDateAndTimeRequest) returns (GetExtCalLastDateAndTimeResponse);
+  rpc GetSelfCalLastTemp(GetSelfCalLastTempRequest) returns (GetSelfCalLastTempResponse);
+  rpc GetExtCalLastTemp(GetExtCalLastTempRequest) returns (GetExtCalLastTempResponse);
+  rpc GetExtCalRecommendedInterval(GetExtCalRecommendedIntervalRequest) returns (GetExtCalRecommendedIntervalResponse);
+  rpc ReadCurrentTemperature(ReadCurrentTemperatureRequest) returns (ReadCurrentTemperatureResponse);
+  rpc ConfigureCustomFIRFilterCoefficients(ConfigureCustomFIRFilterCoefficientsRequest) returns (ConfigureCustomFIRFilterCoefficientsResponse);
+  rpc GetFIRFilterCoefficients(GetFIRFilterCoefficientsRequest) returns (GetFIRFilterCoefficientsResponse);
+  rpc GetStreamEndpointHandle(GetStreamEndpointHandleRequest) returns (GetStreamEndpointHandleResponse);
+  rpc WriteP2PEndpointI16(WriteP2PEndpointI16Request) returns (WriteP2PEndpointI16Response);
+  rpc ConfigureSynchronization(ConfigureSynchronizationRequest) returns (ConfigureSynchronizationResponse);
+  rpc EnableDigitalPatterning(EnableDigitalPatterningRequest) returns (EnableDigitalPatterningResponse);
+  rpc DisableDigitalPatterning(DisableDigitalPatterningRequest) returns (DisableDigitalPatterningResponse);
+  rpc EnableDigitalFilter(EnableDigitalFilterRequest) returns (EnableDigitalFilterResponse);
+  rpc DisableDigitalFilter(DisableDigitalFilterRequest) returns (DisableDigitalFilterResponse);
+  rpc EnableAnalogFilter(EnableAnalogFilterRequest) returns (EnableAnalogFilterResponse);
+  rpc DisableAnalogFilter(DisableAnalogFilterRequest) returns (DisableAnalogFilterResponse);
+  rpc ConfigureSampleClockSource(ConfigureSampleClockSourceRequest) returns (ConfigureSampleClockSourceResponse);
+  rpc ConfigureTriggerMode(ConfigureTriggerModeRequest) returns (ConfigureTriggerModeResponse);
+  rpc ImportAttributeConfigurationFile(ImportAttributeConfigurationFileRequest) returns (ImportAttributeConfigurationFileResponse);
+  rpc ExportAttributeConfigurationFile(ExportAttributeConfigurationFileRequest) returns (ExportAttributeConfigurationFileResponse);
+  rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
+  rpc ExportAttributeConfigurationBuffer(ExportAttributeConfigurationBufferRequest) returns (ExportAttributeConfigurationBufferResponse);
+  rpc SetAttributeViInt64(SetAttributeViInt64Request) returns (SetAttributeViInt64Response);
+  rpc CheckAttributeViInt64(CheckAttributeViInt64Request) returns (CheckAttributeViInt64Response);
+  rpc GetAttributeViInt64(GetAttributeViInt64Request) returns (GetAttributeViInt64Response);
+  rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
+  rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
+  rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
+  rpc SetAttributeViBoolean(SetAttributeViBooleanRequest) returns (SetAttributeViBooleanResponse);
+  rpc SetAttributeViSession(SetAttributeViSessionRequest) returns (SetAttributeViSessionResponse);
+  rpc CheckAttributeViInt32(CheckAttributeViInt32Request) returns (CheckAttributeViInt32Response);
+  rpc CheckAttributeViReal64(CheckAttributeViReal64Request) returns (CheckAttributeViReal64Response);
+  rpc CheckAttributeViString(CheckAttributeViStringRequest) returns (CheckAttributeViStringResponse);
+  rpc CheckAttributeViBoolean(CheckAttributeViBooleanRequest) returns (CheckAttributeViBooleanResponse);
+  rpc CheckAttributeViSession(CheckAttributeViSessionRequest) returns (CheckAttributeViSessionResponse);
+  rpc GetAttributeViInt32(GetAttributeViInt32Request) returns (GetAttributeViInt32Response);
+  rpc GetAttributeViReal64(GetAttributeViReal64Request) returns (GetAttributeViReal64Response);
+  rpc GetAttributeViString(GetAttributeViStringRequest) returns (GetAttributeViStringResponse);
+  rpc GetAttributeViBoolean(GetAttributeViBooleanRequest) returns (GetAttributeViBooleanResponse);
+  rpc GetAttributeViSession(GetAttributeViSessionRequest) returns (GetAttributeViSessionResponse);
+  rpc ResetAttribute(ResetAttributeRequest) returns (ResetAttributeResponse);
+  rpc ManualEnableP2PStream(ManualEnableP2PStreamRequest) returns (ManualEnableP2PStreamResponse);
+  rpc CreateWaveformFromFileHWS(CreateWaveformFromFileHWSRequest) returns (CreateWaveformFromFileHWSResponse);
 }
 
 enum NiFgenAttribute {
   NIFGEN_ATTRIBUTE_UNSPECIFIED = 0;
-  NIFGEN_ATTRIBUTE_RANGE_CHECK = 1050002;
-  NIFGEN_ATTRIBUTE_QUERY_INSTRUMENT_STATUS = 1050003;
-  NIFGEN_ATTRIBUTE_CACHE = 1050004;
-  NIFGEN_ATTRIBUTE_SIMULATE = 1050005;
-  NIFGEN_ATTRIBUTE_RECORD_COERCIONS = 1050006;
-  NIFGEN_ATTRIBUTE_DRIVER_SETUP = 1050007;
-  NIFGEN_ATTRIBUTE_INTERCHANGE_CHECK = 1050021;
-  NIFGEN_ATTRIBUTE_CHANNEL_COUNT = 1050203;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_PREFIX = 1050302;
-  NIFGEN_ATTRIBUTE_IO_RESOURCE_DESCRIPTOR = 1050304;
-  NIFGEN_ATTRIBUTE_LOGICAL_NAME = 1050305;
-  NIFGEN_ATTRIBUTE_SUPPORTED_INSTRUMENT_MODELS = 1050327;
-  NIFGEN_ATTRIBUTE_GROUP_CAPABILITIES = 1050401;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_MAJOR_VERSION = 1050503;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_MINOR_VERSION = 1050504;
-  NIFGEN_ATTRIBUTE_INSTRUMENT_FIRMWARE_REVISION = 1050510;
-  NIFGEN_ATTRIBUTE_INSTRUMENT_MANUFACTURER = 1050511;
-  NIFGEN_ATTRIBUTE_INSTRUMENT_MODEL = 1050512;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_VENDOR = 1050513;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_DESCRIPTION = 1050514;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_CLASS_SPEC_MAJOR_VERSION = 1050515;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_CLASS_SPEC_MINOR_VERSION = 1050516;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_REVISION = 1050551;
-  NIFGEN_ATTRIBUTE_ID_QUERY_RESPONSE = 1150001;
-  NIFGEN_ATTRIBUTE_DIGITAL_PATTERN_ENABLED = 1150101;
-  NIFGEN_ATTRIBUTE_DIGITAL_FILTER_ENABLED = 1150102;
-  NIFGEN_ATTRIBUTE_ANALOG_FILTER_ENABLED = 1150103;
-  NIFGEN_ATTRIBUTE_FILTER_CORRECTION_FREQUENCY = 1150104;
-  NIFGEN_ATTRIBUTE_SYNC_DUTY_CYCLE_HIGH = 1150105;
-  NIFGEN_ATTRIBUTE_UPDATE_CLOCK_SOURCE = 1150106;
-  NIFGEN_ATTRIBUTE_REF_CLOCK_FREQUENCY = 1150107;
-  NIFGEN_ATTRIBUTE_TRIGGER_MODE = 1150108;
-  NIFGEN_ATTRIBUTE_CLOCK_MODE = 1150110;
-  NIFGEN_ATTRIBUTE_SYNCHRONIZATION = 1150111;
-  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_SOURCE = 1150112;
-  NIFGEN_ATTRIBUTE_REFERENCE_CLOCK_SOURCE = 1150113;
-  NIFGEN_ATTRIBUTE_FREQ_LIST_HANDLE = 1150208;
-  NIFGEN_ATTRIBUTE_MAX_NUM_FREQ_LISTS = 1150209;
-  NIFGEN_ATTRIBUTE_MIN_FREQ_LIST_LENGTH = 1150210;
-  NIFGEN_ATTRIBUTE_MAX_FREQ_LIST_LENGTH = 1150211;
-  NIFGEN_ATTRIBUTE_MIN_FREQ_LIST_DURATION = 1150212;
-  NIFGEN_ATTRIBUTE_MAX_FREQ_LIST_DURATION = 1150213;
-  NIFGEN_ATTRIBUTE_FREQ_LIST_DURATION_QUANTUM = 1150214;
-  NIFGEN_ATTRIBUTE_BUS_TYPE = 1150215;
-  NIFGEN_ATTRIBUTE_VIDEO_WAVEFORM_TYPE = 1150216;
-  NIFGEN_ATTRIBUTE_DIGITAL_FILTER_INTERPOLATION_FACTOR = 1150218;
-  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_DIVISOR = 1150219;
-  NIFGEN_ATTRIBUTE_LOAD_IMPEDANCE = 1150220;
+  NIFGEN_ATTRIBUTE_OUTPUT_MODE = 1250001;
+  NIFGEN_ATTRIBUTE_OUTPUT_ENABLED = 1250003;
+  NIFGEN_ATTRIBUTE_DIGITAL_GAIN = 1150254;
   NIFGEN_ATTRIBUTE_ANALOG_PATH = 1150222;
-  NIFGEN_ATTRIBUTE_GAIN_DAC_VALUE = 1150223;
-  NIFGEN_ATTRIBUTE_OFFSET_DAC_VALUE = 1150224;
-  NIFGEN_ATTRIBUTE_OSCILLATOR_FREQ_DAC_VALUE = 1150225;
-  NIFGEN_ATTRIBUTE_PRE_AMPLIFIER_ATTENUATION = 1150228;
-  NIFGEN_ATTRIBUTE_POST_AMPLIFIER_ATTENUATION = 1150229;
-  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_TIMEBASE_DIVISOR = 1150230;
-  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_ABSOLUTE_DELAY = 1150231;
-  NIFGEN_ATTRIBUTE_OSCILLATOR_PHASE_DAC_VALUE = 1150232;
-  NIFGEN_ATTRIBUTE_EXTERNAL_CLOCK_DELAY_BINARY_VALUE = 1150233;
+  NIFGEN_ATTRIBUTE_LOAD_IMPEDANCE = 1150220;
+  NIFGEN_ATTRIBUTE_OUTPUT_IMPEDANCE = 1250004;
+  NIFGEN_ATTRIBUTE_TERMINAL_CONFIGURATION = 1150365;
+  NIFGEN_ATTRIBUTE_COMMON_MODE_OFFSET = 1150366;
+  NIFGEN_ATTRIBUTE_CHANNEL_DELAY = 1150369;
+  NIFGEN_ATTRIBUTE_ABSOLUTE_DELAY = 1150413;
+  NIFGEN_ATTRIBUTE_ANALOG_FILTER_ENABLED = 1150103;
+  NIFGEN_ATTRIBUTE_DIGITAL_FILTER_ENABLED = 1150102;
+  NIFGEN_ATTRIBUTE_DIGITAL_FILTER_INTERPOLATION_FACTOR = 1150218;
+  NIFGEN_ATTRIBUTE_FLATNESS_CORRECTION_ENABLED = 1150323;
   NIFGEN_ATTRIBUTE_ANALOG_DATA_MASK = 1150234;
   NIFGEN_ATTRIBUTE_ANALOG_STATIC_VALUE = 1150235;
   NIFGEN_ATTRIBUTE_DIGITAL_DATA_MASK = 1150236;
   NIFGEN_ATTRIBUTE_DIGITAL_STATIC_VALUE = 1150237;
-  NIFGEN_ATTRIBUTE_FUNC_BUFFER_SIZE = 1150238;
-  NIFGEN_ATTRIBUTE_FUNC_MAX_BUFFER_SIZE = 1150239;
+  NIFGEN_ATTRIBUTE_DIGITAL_PATTERN_ENABLED = 1150101;
+  NIFGEN_ATTRIBUTE_AUX_POWER_ENABLED = 1150411;
+  NIFGEN_ATTRIBUTE_IDLE_BEHAVIOR = 1150377;
+  NIFGEN_ATTRIBUTE_IDLE_VALUE = 1150378;
+  NIFGEN_ATTRIBUTE_WAIT_BEHAVIOR = 1150379;
+  NIFGEN_ATTRIBUTE_WAIT_VALUE = 1150380;
+  NIFGEN_ATTRIBUTE_ARB_GAIN = 1250202;
+  NIFGEN_ATTRIBUTE_ARB_OFFSET = 1250203;
+  NIFGEN_ATTRIBUTE_WAVEFORM_QUANTUM = 1250206;
+  NIFGEN_ATTRIBUTE_MAX_NUM_WAVEFORMS = 1250205;
+  NIFGEN_ATTRIBUTE_MIN_WAVEFORM_SIZE = 1250207;
+  NIFGEN_ATTRIBUTE_MAX_WAVEFORM_SIZE = 1250208;
+  NIFGEN_ATTRIBUTE_ARB_WAVEFORM_HANDLE = 1250201;
+  NIFGEN_ATTRIBUTE_ARB_MARKER_POSITION = 1150327;
+  NIFGEN_ATTRIBUTE_ARB_REPEAT_COUNT = 1150328;
+  NIFGEN_ATTRIBUTE_ARB_SEQUENCE_HANDLE = 1250211;
+  NIFGEN_ATTRIBUTE_MAX_NUM_SEQUENCES = 1250212;
+  NIFGEN_ATTRIBUTE_MIN_SEQUENCE_LENGTH = 1250213;
+  NIFGEN_ATTRIBUTE_MAX_SEQUENCE_LENGTH = 1250214;
+  NIFGEN_ATTRIBUTE_MAX_LOOP_COUNT = 1250215;
+  NIFGEN_ATTRIBUTE_SCRIPT_TO_GENERATE = 1150270;
   NIFGEN_ATTRIBUTE_FILE_TRANSFER_BLOCK_SIZE = 1150240;
   NIFGEN_ATTRIBUTE_DATA_TRANSFER_BLOCK_SIZE = 1150241;
-  NIFGEN_ATTRIBUTE_MEMORY_SIZE = 1150242;
-  NIFGEN_ATTRIBUTE_SERIAL_NUMBER = 1150243;
+  NIFGEN_ATTRIBUTE_DATA_TRANSFER_MAXIMUM_BANDWIDTH = 1150373;
   NIFGEN_ATTRIBUTE_DIRECT_DMA_ENABLED = 1150244;
   NIFGEN_ATTRIBUTE_DIRECT_DMA_WINDOW_SIZE = 1150245;
+  NIFGEN_ATTRIBUTE_DIRECT_DMA_WINDOW_ADDRESS = 1150274;
+  NIFGEN_ATTRIBUTE_STREAMING_WAVEFORM_NAME = 1150326;
+  NIFGEN_ATTRIBUTE_STREAMING_WAVEFORM_HANDLE = 1150324;
+  NIFGEN_ATTRIBUTE_STREAMING_SPACE_AVAILABLE_IN_WAVEFORM = 1150325;
+  NIFGEN_ATTRIBUTE_STREAMING_WRITE_TIMEOUT = 1150409;
+  NIFGEN_ATTRIBUTE_DATA_TRANSFER_PREFERRED_PACKET_SIZE = 1150374;
+  NIFGEN_ATTRIBUTE_DATA_TRANSFER_MAXIMUM_IN_FLIGHT_READS = 1150375;
+  NIFGEN_ATTRIBUTE_PCI_DMA_OPTIMIZATIONS_ENABLED = 1150362;
   NIFGEN_ATTRIBUTE_OSP_ENABLED = 1150246;
-  NIFGEN_ATTRIBUTE_OSP_DATA_PROCESSING_MODE = 1150247;
   NIFGEN_ATTRIBUTE_OSP_IQ_RATE = 1150248;
+  NIFGEN_ATTRIBUTE_OSP_DATA_PROCESSING_MODE = 1150247;
+  NIFGEN_ATTRIBUTE_OSP_MODE = 1150370;
+  NIFGEN_ATTRIBUTE_OSP_FREQUENCY_SHIFT = 1150371;
   NIFGEN_ATTRIBUTE_OSP_CARRIER_ENABLED = 1150249;
   NIFGEN_ATTRIBUTE_OSP_CARRIER_FREQUENCY = 1150250;
   NIFGEN_ATTRIBUTE_OSP_CARRIER_PHASE_I = 1150251;
   NIFGEN_ATTRIBUTE_OSP_CARRIER_PHASE_Q = 1150252;
+  NIFGEN_ATTRIBUTE_OSP_COMPENSATE_FOR_FILTER_GROUP_DELAY = 1150389;
   NIFGEN_ATTRIBUTE_OSP_FIR_FILTER_TYPE = 1150253;
-  NIFGEN_ATTRIBUTE_DIGITAL_GAIN = 1150254;
   NIFGEN_ATTRIBUTE_OSP_FIR_FILTER_ENABLED = 1150255;
   NIFGEN_ATTRIBUTE_OSP_FIR_FILTER_INTERPOLATION = 1150256;
   NIFGEN_ATTRIBUTE_OSP_CIC_FILTER_ENABLED = 1150257;
@@ -246,11 +228,96 @@ enum NiFgenAttribute {
   NIFGEN_ATTRIBUTE_OSP_PRE_FILTER_OFFSET_Q = 1150267;
   NIFGEN_ATTRIBUTE_OSP_OVERFLOW_ERROR_REPORTING = 1150268;
   NIFGEN_ATTRIBUTE_OSP_OVERFLOW_STATUS = 1150269;
-  NIFGEN_ATTRIBUTE_SCRIPT_TO_GENERATE = 1150270;
-  NIFGEN_ATTRIBUTE_MARKER_EVENTS_COUNT = 1150271;
-  NIFGEN_ATTRIBUTE_SCRIPT_TRIGGERS_COUNT = 1150272;
-  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENTS_COUNT = 1150273;
-  NIFGEN_ATTRIBUTE_DIRECT_DMA_WINDOW_ADDRESS = 1150274;
+  NIFGEN_ATTRIBUTE_P2P_ENABLED = 1150391;
+  NIFGEN_ATTRIBUTE_P2P_DESTINATION_CHANNELS = 1150392;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_SIZE = 1150393;
+  NIFGEN_ATTRIBUTE_P2P_SPACE_AVAILABLE_IN_ENDPOINT = 1150394;
+  NIFGEN_ATTRIBUTE_P2P_MOST_SPACE_AVAILABLE_IN_ENDPOINT = 1150395;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_COUNT = 1150396;
+  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_INTERVAL = 1150400;
+  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_INITIAL_CREDITS = 1150408;
+  NIFGEN_ATTRIBUTE_P2P_MANUAL_CONFIGURATION_ENABLED = 1150397;
+  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_ADDRESS = 1150398;
+  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_ADDRESS_TYPE = 1150399;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_ADDRESS = 1150401;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_ADDRESS_TYPE = 1150402;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_SIZE = 1150403;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL = 1150410;
+  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_ADDRESS = 1150405;
+  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_ADDRESS_TYPE = 1150406;
+  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_VALUE = 1150407;
+  NIFGEN_ATTRIBUTE_FUNC_WAVEFORM = 1250101;
+  NIFGEN_ATTRIBUTE_FUNC_AMPLITUDE = 1250102;
+  NIFGEN_ATTRIBUTE_FUNC_DC_OFFSET = 1250103;
+  NIFGEN_ATTRIBUTE_FUNC_START_PHASE = 1250105;
+  NIFGEN_ATTRIBUTE_FUNC_DUTY_CYCLE_HIGH = 1250106;
+  NIFGEN_ATTRIBUTE_SYNC_DUTY_CYCLE_HIGH = 1150105;
+  NIFGEN_ATTRIBUTE_SYNC_OUT_OUTPUT_TERMINAL = 1150330;
+  NIFGEN_ATTRIBUTE_FUNC_FREQUENCY = 1250104;
+  NIFGEN_ATTRIBUTE_FUNC_BUFFER_SIZE = 1150238;
+  NIFGEN_ATTRIBUTE_FUNC_MAX_BUFFER_SIZE = 1150239;
+  NIFGEN_ATTRIBUTE_FREQ_LIST_HANDLE = 1150208;
+  NIFGEN_ATTRIBUTE_MAX_NUM_FREQ_LISTS = 1150209;
+  NIFGEN_ATTRIBUTE_MIN_FREQ_LIST_LENGTH = 1150210;
+  NIFGEN_ATTRIBUTE_MAX_FREQ_LIST_LENGTH = 1150211;
+  NIFGEN_ATTRIBUTE_MIN_FREQ_LIST_DURATION = 1150212;
+  NIFGEN_ATTRIBUTE_MAX_FREQ_LIST_DURATION = 1150213;
+  NIFGEN_ATTRIBUTE_FREQ_LIST_DURATION_QUANTUM = 1150214;
+  NIFGEN_ATTRIBUTE_REFERENCE_CLOCK_SOURCE = 1150113;
+  NIFGEN_ATTRIBUTE_REF_CLOCK_FREQUENCY = 1150107;
+  NIFGEN_ATTRIBUTE_EXPORTED_REFERENCE_CLOCK_OUTPUT_TERMINAL = 1150321;
+  NIFGEN_ATTRIBUTE_EXPORTED_ONBOARD_REFERENCE_CLOCK_OUTPUT_TERMINAL = 1150322;
+  NIFGEN_ATTRIBUTE_ARB_SAMPLE_RATE = 1250204;
+  NIFGEN_ATTRIBUTE_CLOCK_MODE = 1150110;
+  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_SOURCE = 1150112;
+  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_OUTPUT_TERMINAL = 1150320;
+  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_DIVISOR = 1150219;
+  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_TIMEBASE_SOURCE = 1150367;
+  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_TIMEBASE_RATE = 1150368;
+  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_TIMEBASE_OUTPUT_TERMINAL = 1150329;
+  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_TIMEBASE_DIVISOR = 1150230;
+  NIFGEN_ATTRIBUTE_EXTERNAL_SAMPLE_CLOCK_MULTIPLIER = 1150376;
+  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_ABSOLUTE_DELAY = 1150231;
+  NIFGEN_ATTRIBUTE_OSCILLATOR_PHASE_DAC_VALUE = 1150232;
+  NIFGEN_ATTRIBUTE_EXTERNAL_CLOCK_DELAY_BINARY_VALUE = 1150233;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_TERMINAL = 1150312;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_BEHAVIOR = 1150342;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_POLARITY = 1150313;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_WIDTH = 1150340;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_WIDTH_UNITS = 1150341;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_TOGGLE_INITIAL_STATE = 1150343;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_DELAY = 1150354;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_DELAY_UNITS = 1150355;
+  NIFGEN_ATTRIBUTE_ALL_MARKER_EVENTS_LIVE_STATUS = 1150344;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_LIVE_STATUS = 1150345;
+  NIFGEN_ATTRIBUTE_ALL_MARKER_EVENTS_LATCHED_STATUS = 1150349;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_LATCHED_STATUS = 1150350;
+  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_DATA_BIT_NUMBER = 1150337;
+  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_LEVEL_POLARITY = 1150338;
+  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_OUTPUT_TERMINAL = 1150339;
+  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_OUTPUT_TERMINAL = 1150310;
+  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_LEVEL_ACTIVE_LEVEL = 1150311;
+  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_LIVE_STATUS = 1150348;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_OUTPUT_TERMINAL = 1150314;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_OUTPUT_BEHAVIOR = 1150331;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_LEVEL_ACTIVE_LEVEL = 1150316;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_POLARITY = 1150318;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_WIDTH_UNITS = 1150333;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_WIDTH = 1150335;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_DELAY = 1150356;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_DELAY_UNITS = 1150357;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_LATCHED_STATUS = 1150352;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_OUTPUT_TERMINAL = 1150315;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_OUTPUT_BEHAVIOR = 1150332;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_LEVEL_ACTIVE_LEVEL = 1150317;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_POLARITY = 1150319;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_WIDTH_UNITS = 1150334;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_WIDTH = 1150336;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_DELAY = 1150358;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_DELAY_UNITS = 1150359;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_LATCHED_STATUS = 1150351;
+  NIFGEN_ATTRIBUTE_TRIGGER_MODE = 1150108;
+  NIFGEN_ATTRIBUTE_BURST_COUNT = 1250350;
   NIFGEN_ATTRIBUTE_START_TRIGGER_TYPE = 1150280;
   NIFGEN_ATTRIBUTE_DIGITAL_EDGE_START_TRIGGER_SOURCE = 1150281;
   NIFGEN_ATTRIBUTE_DIGITAL_EDGE_START_TRIGGER_EDGE = 1150282;
@@ -261,122 +328,99 @@ enum NiFgenAttribute {
   NIFGEN_ATTRIBUTE_DIGITAL_LEVEL_SCRIPT_TRIGGER_SOURCE = 1150293;
   NIFGEN_ATTRIBUTE_DIGITAL_LEVEL_SCRIPT_TRIGGER_ACTIVE_LEVEL = 1150294;
   NIFGEN_ATTRIBUTE_EXPORTED_SCRIPT_TRIGGER_OUTPUT_TERMINAL = 1150295;
-  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_OUTPUT_TERMINAL = 1150310;
-  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_LEVEL_ACTIVE_LEVEL = 1150311;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_TERMINAL = 1150312;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_POLARITY = 1150313;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_OUTPUT_TERMINAL = 1150314;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_OUTPUT_TERMINAL = 1150315;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_LEVEL_ACTIVE_LEVEL = 1150316;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_LEVEL_ACTIVE_LEVEL = 1150317;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_POLARITY = 1150318;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_POLARITY = 1150319;
-  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_OUTPUT_TERMINAL = 1150320;
-  NIFGEN_ATTRIBUTE_EXPORTED_REFERENCE_CLOCK_OUTPUT_TERMINAL = 1150321;
-  NIFGEN_ATTRIBUTE_EXPORTED_ONBOARD_REFERENCE_CLOCK_OUTPUT_TERMINAL = 1150322;
-  NIFGEN_ATTRIBUTE_FLATNESS_CORRECTION_ENABLED = 1150323;
-  NIFGEN_ATTRIBUTE_STREAMING_WAVEFORM_HANDLE = 1150324;
-  NIFGEN_ATTRIBUTE_STREAMING_SPACE_AVAILABLE_IN_WAVEFORM = 1150325;
-  NIFGEN_ATTRIBUTE_STREAMING_WAVEFORM_NAME = 1150326;
-  NIFGEN_ATTRIBUTE_ARB_MARKER_POSITION = 1150327;
-  NIFGEN_ATTRIBUTE_ARB_REPEAT_COUNT = 1150328;
-  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_TIMEBASE_OUTPUT_TERMINAL = 1150329;
-  NIFGEN_ATTRIBUTE_SYNC_OUT_OUTPUT_TERMINAL = 1150330;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_OUTPUT_BEHAVIOR = 1150331;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_OUTPUT_BEHAVIOR = 1150332;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_WIDTH_UNITS = 1150333;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_WIDTH_UNITS = 1150334;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_WIDTH = 1150335;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_WIDTH = 1150336;
-  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_DATA_BIT_NUMBER = 1150337;
-  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_LEVEL_POLARITY = 1150338;
-  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_OUTPUT_TERMINAL = 1150339;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_WIDTH = 1150340;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_WIDTH_UNITS = 1150341;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_BEHAVIOR = 1150342;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_TOGGLE_INITIAL_STATE = 1150343;
-  NIFGEN_ATTRIBUTE_ALL_MARKER_EVENTS_LIVE_STATUS = 1150344;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_LIVE_STATUS = 1150345;
-  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_LIVE_STATUS = 1150348;
-  NIFGEN_ATTRIBUTE_ALL_MARKER_EVENTS_LATCHED_STATUS = 1150349;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_LATCHED_STATUS = 1150350;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_LATCHED_STATUS = 1150351;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_LATCHED_STATUS = 1150352;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_DELAY = 1150354;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_DELAY_UNITS = 1150355;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_DELAY = 1150356;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_DELAY_UNITS = 1150357;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_DELAY = 1150358;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_DELAY_UNITS = 1150359;
-  NIFGEN_ATTRIBUTE_PCI_DMA_OPTIMIZATIONS_ENABLED = 1150362;
-  NIFGEN_ATTRIBUTE_TERMINAL_CONFIGURATION = 1150365;
-  NIFGEN_ATTRIBUTE_COMMON_MODE_OFFSET = 1150366;
-  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_TIMEBASE_SOURCE = 1150367;
-  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_TIMEBASE_RATE = 1150368;
-  NIFGEN_ATTRIBUTE_CHANNEL_DELAY = 1150369;
-  NIFGEN_ATTRIBUTE_OSP_MODE = 1150370;
-  NIFGEN_ATTRIBUTE_OSP_FREQUENCY_SHIFT = 1150371;
-  NIFGEN_ATTRIBUTE_DATA_TRANSFER_MAXIMUM_BANDWIDTH = 1150373;
-  NIFGEN_ATTRIBUTE_DATA_TRANSFER_PREFERRED_PACKET_SIZE = 1150374;
-  NIFGEN_ATTRIBUTE_DATA_TRANSFER_MAXIMUM_IN_FLIGHT_READS = 1150375;
-  NIFGEN_ATTRIBUTE_EXTERNAL_SAMPLE_CLOCK_MULTIPLIER = 1150376;
-  NIFGEN_ATTRIBUTE_IDLE_BEHAVIOR = 1150377;
-  NIFGEN_ATTRIBUTE_IDLE_VALUE = 1150378;
-  NIFGEN_ATTRIBUTE_WAIT_BEHAVIOR = 1150379;
-  NIFGEN_ATTRIBUTE_WAIT_VALUE = 1150380;
-  NIFGEN_ATTRIBUTE_OSP_COMPENSATE_FOR_FILTER_GROUP_DELAY = 1150389;
-  NIFGEN_ATTRIBUTE_MODULE_REVISION = 1150390;
-  NIFGEN_ATTRIBUTE_P2P_ENABLED = 1150391;
-  NIFGEN_ATTRIBUTE_P2P_DESTINATION_CHANNELS = 1150392;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_SIZE = 1150393;
-  NIFGEN_ATTRIBUTE_P2P_SPACE_AVAILABLE_IN_ENDPOINT = 1150394;
-  NIFGEN_ATTRIBUTE_P2P_MOST_SPACE_AVAILABLE_IN_ENDPOINT = 1150395;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_COUNT = 1150396;
-  NIFGEN_ATTRIBUTE_P2P_MANUAL_CONFIGURATION_ENABLED = 1150397;
-  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_ADDRESS = 1150398;
-  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_ADDRESS_TYPE = 1150399;
-  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_INTERVAL = 1150400;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_ADDRESS = 1150401;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_ADDRESS_TYPE = 1150402;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_SIZE = 1150403;
-  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_ADDRESS = 1150405;
-  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_ADDRESS_TYPE = 1150406;
-  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_VALUE = 1150407;
-  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_INITIAL_CREDITS = 1150408;
-  NIFGEN_ATTRIBUTE_STREAMING_WRITE_TIMEOUT = 1150409;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL = 1150410;
-  NIFGEN_ATTRIBUTE_AUX_POWER_ENABLED = 1150411;
+  NIFGEN_ATTRIBUTE_BUS_TYPE = 1150215;
+  NIFGEN_ATTRIBUTE_MEMORY_SIZE = 1150242;
+  NIFGEN_ATTRIBUTE_SERIAL_NUMBER = 1150243;
+  NIFGEN_ATTRIBUTE_MARKER_EVENTS_COUNT = 1150271;
+  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENTS_COUNT = 1150273;
+  NIFGEN_ATTRIBUTE_SCRIPT_TRIGGERS_COUNT = 1150272;
+  NIFGEN_ATTRIBUTE_VIDEO_WAVEFORM_TYPE = 1150216;
   NIFGEN_ATTRIBUTE_FPGA_BITFILE_PATH = 1150412;
-  NIFGEN_ATTRIBUTE_ABSOLUTE_DELAY = 1150413;
-  NIFGEN_ATTRIBUTE_OUTPUT_MODE = 1250001;
-  NIFGEN_ATTRIBUTE_OUTPUT_ENABLED = 1250003;
-  NIFGEN_ATTRIBUTE_OUTPUT_IMPEDANCE = 1250004;
-  NIFGEN_ATTRIBUTE_FUNC_WAVEFORM = 1250101;
-  NIFGEN_ATTRIBUTE_FUNC_AMPLITUDE = 1250102;
-  NIFGEN_ATTRIBUTE_FUNC_DC_OFFSET = 1250103;
-  NIFGEN_ATTRIBUTE_FUNC_FREQUENCY = 1250104;
-  NIFGEN_ATTRIBUTE_FUNC_START_PHASE = 1250105;
-  NIFGEN_ATTRIBUTE_FUNC_DUTY_CYCLE_HIGH = 1250106;
-  NIFGEN_ATTRIBUTE_ARB_WAVEFORM_HANDLE = 1250201;
-  NIFGEN_ATTRIBUTE_ARB_GAIN = 1250202;
-  NIFGEN_ATTRIBUTE_ARB_OFFSET = 1250203;
-  NIFGEN_ATTRIBUTE_ARB_SAMPLE_RATE = 1250204;
-  NIFGEN_ATTRIBUTE_MAX_NUM_WAVEFORMS = 1250205;
-  NIFGEN_ATTRIBUTE_WAVEFORM_QUANTUM = 1250206;
-  NIFGEN_ATTRIBUTE_MIN_WAVEFORM_SIZE = 1250207;
-  NIFGEN_ATTRIBUTE_MAX_WAVEFORM_SIZE = 1250208;
-  NIFGEN_ATTRIBUTE_ARB_SEQUENCE_HANDLE = 1250211;
-  NIFGEN_ATTRIBUTE_MAX_NUM_SEQUENCES = 1250212;
-  NIFGEN_ATTRIBUTE_MIN_SEQUENCE_LENGTH = 1250213;
-  NIFGEN_ATTRIBUTE_MAX_SEQUENCE_LENGTH = 1250214;
-  NIFGEN_ATTRIBUTE_MAX_LOOP_COUNT = 1250215;
+  NIFGEN_ATTRIBUTE_FILTER_CORRECTION_FREQUENCY = 1150104;
   NIFGEN_ATTRIBUTE_TRIGGER_SOURCE = 1250302;
-  NIFGEN_ATTRIBUTE_BURST_COUNT = 1250350;
+  NIFGEN_ATTRIBUTE_SYNCHRONIZATION = 1150111;
+  NIFGEN_ATTRIBUTE_ID_QUERY_RESPONSE = 1150001;
+  NIFGEN_ATTRIBUTE_GAIN_DAC_VALUE = 1150223;
+  NIFGEN_ATTRIBUTE_OFFSET_DAC_VALUE = 1150224;
+  NIFGEN_ATTRIBUTE_OSCILLATOR_FREQ_DAC_VALUE = 1150225;
+  NIFGEN_ATTRIBUTE_PRE_AMPLIFIER_ATTENUATION = 1150228;
+  NIFGEN_ATTRIBUTE_POST_AMPLIFIER_ATTENUATION = 1150229;
+  NIFGEN_ATTRIBUTE_CACHE = 1050004;
+  NIFGEN_ATTRIBUTE_RANGE_CHECK = 1050002;
+  NIFGEN_ATTRIBUTE_QUERY_INSTRUMENT_STATUS = 1050003;
+  NIFGEN_ATTRIBUTE_RECORD_COERCIONS = 1050006;
+  NIFGEN_ATTRIBUTE_SIMULATE = 1050005;
+  NIFGEN_ATTRIBUTE_INTERCHANGE_CHECK = 1050021;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_DESCRIPTION = 1050514;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_PREFIX = 1050302;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_VENDOR = 1050513;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_REVISION = 1050551;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_CLASS_SPEC_MAJOR_VERSION = 1050515;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_CLASS_SPEC_MINOR_VERSION = 1050516;
+  NIFGEN_ATTRIBUTE_SUPPORTED_INSTRUMENT_MODELS = 1050327;
+  NIFGEN_ATTRIBUTE_GROUP_CAPABILITIES = 1050401;
+  NIFGEN_ATTRIBUTE_CHANNEL_COUNT = 1050203;
+  NIFGEN_ATTRIBUTE_INSTRUMENT_MANUFACTURER = 1050511;
+  NIFGEN_ATTRIBUTE_INSTRUMENT_MODEL = 1050512;
+  NIFGEN_ATTRIBUTE_INSTRUMENT_FIRMWARE_REVISION = 1050510;
+  NIFGEN_ATTRIBUTE_MODULE_REVISION = 1150390;
+  NIFGEN_ATTRIBUTE_IO_RESOURCE_DESCRIPTOR = 1050304;
+  NIFGEN_ATTRIBUTE_LOGICAL_NAME = 1050305;
+  NIFGEN_ATTRIBUTE_DRIVER_SETUP = 1050007;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_MAJOR_VERSION = 1050503;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_MINOR_VERSION = 1050504;
+  NIFGEN_ATTRIBUTE_UPDATE_CLOCK_SOURCE = 1150106;
 }
 
-enum ByteOrder {
-  BYTE_ORDER_NIFGEN_VAL_LITTLE_ENDIAN = 0;
-  BYTE_ORDER_NIFGEN_VAL_BIG_ENDIAN = 1;
+enum OutputMode {
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_FUNC = 0;
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB = 1;
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SEQ = 2;
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_FREQ_LIST = 101;
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SCRIPT = 102;
+}
+
+enum Waveform {
+  WAVEFORM_UNSPECIFIED = 0;
+  WAVEFORM_NIFGEN_VAL_WFM_SINE = 1;
+  WAVEFORM_NIFGEN_VAL_WFM_SQUARE = 2;
+  WAVEFORM_NIFGEN_VAL_WFM_TRIANGLE = 3;
+  WAVEFORM_NIFGEN_VAL_WFM_RAMP_UP = 4;
+  WAVEFORM_NIFGEN_VAL_WFM_RAMP_DOWN = 5;
+  WAVEFORM_NIFGEN_VAL_WFM_DC = 6;
+  WAVEFORM_NIFGEN_VAL_WFM_NOISE = 101;
+  WAVEFORM_NIFGEN_VAL_WFM_USER = 102;
+}
+
+enum Signal {
+  SIGNAL_UNSPECIFIED = 0;
+  SIGNAL_NIFGEN_VAL_ONBOARD_REFERENCE_CLOCK = 1019;
+  SIGNAL_NIFGEN_VAL_SYNC_OUT = 1002;
+  SIGNAL_NIFGEN_VAL_START_TRIGGER = 1004;
+  SIGNAL_NIFGEN_VAL_MARKER_EVENT = 1001;
+  SIGNAL_NIFGEN_VAL_SAMPLE_CLOCK_TIMEBASE = 1006;
+  SIGNAL_NIFGEN_VAL_SYNCHRONIZATION = 1007;
+  SIGNAL_NIFGEN_VAL_SAMPLE_CLOCK = 101;
+  SIGNAL_NIFGEN_VAL_REFERENCE_CLOCK = 102;
+  SIGNAL_NIFGEN_VAL_SCRIPT_TRIGGER = 103;
+  SIGNAL_NIFGEN_VAL_READY_FOR_START_EVENT = 105;
+  SIGNAL_NIFGEN_VAL_STARTED_EVENT = 106;
+  SIGNAL_NIFGEN_VAL_DONE_EVENT = 107;
+  SIGNAL_NIFGEN_VAL_DATA_MARKER_EVENT = 108;
+}
+
+enum StartTriggerDigitalEdgeEdge {
+  START_TRIGGER_DIGITAL_EDGE_EDGE_UNSPECIFIED = 0;
+  START_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_RISING_EDGE = 101;
+  START_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_FALLING_EDGE = 102;
+}
+
+enum TriggerMode {
+  TRIGGER_MODE_UNSPECIFIED = 0;
+  TRIGGER_MODE_NIFGEN_VAL_SINGLE = 1;
+  TRIGGER_MODE_NIFGEN_VAL_CONTINUOUS = 2;
+  TRIGGER_MODE_NIFGEN_VAL_STEPPED = 3;
+  TRIGGER_MODE_NIFGEN_VAL_BURST = 4;
 }
 
 enum ClockMode {
@@ -385,9 +429,9 @@ enum ClockMode {
   CLOCK_MODE_NIFGEN_VAL_AUTOMATIC = 2;
 }
 
-enum FrequencyListOptions {
-  FREQUENCY_LIST_OPTIONS_UNSPECIFIED = 0;
-  FREQUENCY_LIST_OPTIONS_NIFGEN_VAL_ALL_FLISTS = -1;
+enum RelativeTo {
+  RELATIVE_TO_NIFGEN_VAL_WAVEFORM_POSITION_START = 0;
+  RELATIVE_TO_NIFGEN_VAL_WAVEFORM_POSITION_CURRENT = 1;
 }
 
 enum HardwareState {
@@ -396,6 +440,83 @@ enum HardwareState {
   HARDWARE_STATE_NIFGEN_VAL_RUNNING = 200;
   HARDWARE_STATE_NIFGEN_VAL_DONE = 600;
   HARDWARE_STATE_NIFGEN_VAL_HARDWARE_ERROR = 1000;
+}
+
+enum ByteOrder {
+  BYTE_ORDER_NIFGEN_VAL_LITTLE_ENDIAN = 0;
+  BYTE_ORDER_NIFGEN_VAL_BIG_ENDIAN = 1;
+}
+
+enum TriggerWhen {
+  TRIGGER_WHEN_UNSPECIFIED = 0;
+  TRIGGER_WHEN_NIFGEN_VAL_ACTIVE_HIGH = 101;
+  TRIGGER_WHEN_NIFGEN_VAL_ACTIVE_LOW = 102;
+}
+
+enum ScriptTriggerDigitalEdgeEdge {
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_UNSPECIFIED = 0;
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_RISING_EDGE = 101;
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_FALLING_EDGE = 102;
+}
+
+enum Trigger {
+  TRIGGER_UNSPECIFIED = 0;
+  TRIGGER_NIFGEN_VAL_START_TRIGGER = 1004;
+  TRIGGER_NIFGEN_VAL_SCRIPT_TRIGGER = 103;
+}
+
+enum FrequencyListOptions {
+  FREQUENCY_LIST_OPTIONS_UNSPECIFIED = 0;
+  FREQUENCY_LIST_OPTIONS_NIFGEN_VAL_ALL_FLISTS = -1;
+}
+
+enum RouteSignalFrom {
+  ROUTE_SIGNAL_FROM_UNSPECIFIED = 0;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_MARKER = 1001;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SYNC_OUT = 1002;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_OUT_START_TRIGGER = 1004;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_BOARD_CLOCK = 1006;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SYNCHRONIZATION = 1007;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SOFTWARE_TRIG = 2;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_REF_OUT = 1008;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_CLOCK_OUT = 1009;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_PXI_STAR = 131;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_PFI_0 = 1011;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_0 = 141;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_1 = 142;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_2 = 143;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_3 = 144;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_4 = 145;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_5 = 146;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_6 = 147;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_7 = 1010;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_ONBOARD_REFERENCE_CLOCK = 1019;
+}
+
+enum RouteSignalTo {
+  ROUTE_SIGNAL_TO_UNSPECIFIED = 0;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_0 = 141;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_1 = 142;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_2 = 143;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_3 = 144;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_4 = 145;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_5 = 146;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_6 = 147;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_7 = 1010;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_REF_OUT = 1008;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_PFI_0 = 1011;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_PFI_1 = 1012;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_PXI_STAR = 131;
+}
+
+enum SequenceHandle {
+  SEQUENCE_HANDLE_UNSPECIFIED = 0;
+  SEQUENCE_HANDLE_NIFGEN_VAL_ALL_SEQUENCES = -1;
+}
+
+enum WaveformHandle {
+  WAVEFORM_HANDLE_UNSPECIFIED = 0;
+  WAVEFORM_HANDLE_NIFGEN_VAL_ALL_WAVEFORMS = -1;
 }
 
 enum NiFgenInt32AttributeValues {
@@ -626,1078 +747,6 @@ enum NiFgenStringAttributeValuesMapped {
   NIFGEN_STRING_SAMPLE_CLOCK_TIMEBASE_SOURCE_VAL_ONBOARD_CLOCK = 19;
 }
 
-enum OutputMode {
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_FUNC = 0;
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB = 1;
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SEQ = 2;
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_FREQ_LIST = 101;
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SCRIPT = 102;
-}
-
-enum RelativeTo {
-  RELATIVE_TO_NIFGEN_VAL_WAVEFORM_POSITION_START = 0;
-  RELATIVE_TO_NIFGEN_VAL_WAVEFORM_POSITION_CURRENT = 1;
-}
-
-enum RouteSignalFrom {
-  ROUTE_SIGNAL_FROM_UNSPECIFIED = 0;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_MARKER = 1001;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SYNC_OUT = 1002;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_OUT_START_TRIGGER = 1004;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_BOARD_CLOCK = 1006;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SYNCHRONIZATION = 1007;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SOFTWARE_TRIG = 2;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_REF_OUT = 1008;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_CLOCK_OUT = 1009;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_PXI_STAR = 131;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_PFI_0 = 1011;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_0 = 141;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_1 = 142;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_2 = 143;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_3 = 144;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_4 = 145;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_5 = 146;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_6 = 147;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_7 = 1010;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_ONBOARD_REFERENCE_CLOCK = 1019;
-}
-
-enum RouteSignalTo {
-  ROUTE_SIGNAL_TO_UNSPECIFIED = 0;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_0 = 141;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_1 = 142;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_2 = 143;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_3 = 144;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_4 = 145;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_5 = 146;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_6 = 147;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_7 = 1010;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_REF_OUT = 1008;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_PFI_0 = 1011;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_PFI_1 = 1012;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_PXI_STAR = 131;
-}
-
-enum SequenceHandle {
-  SEQUENCE_HANDLE_UNSPECIFIED = 0;
-  SEQUENCE_HANDLE_NIFGEN_VAL_ALL_SEQUENCES = -1;
-}
-
-enum Signal {
-  SIGNAL_UNSPECIFIED = 0;
-  SIGNAL_NIFGEN_VAL_ONBOARD_REFERENCE_CLOCK = 1019;
-  SIGNAL_NIFGEN_VAL_SYNC_OUT = 1002;
-  SIGNAL_NIFGEN_VAL_START_TRIGGER = 1004;
-  SIGNAL_NIFGEN_VAL_MARKER_EVENT = 1001;
-  SIGNAL_NIFGEN_VAL_SAMPLE_CLOCK_TIMEBASE = 1006;
-  SIGNAL_NIFGEN_VAL_SYNCHRONIZATION = 1007;
-  SIGNAL_NIFGEN_VAL_SAMPLE_CLOCK = 101;
-  SIGNAL_NIFGEN_VAL_REFERENCE_CLOCK = 102;
-  SIGNAL_NIFGEN_VAL_SCRIPT_TRIGGER = 103;
-  SIGNAL_NIFGEN_VAL_READY_FOR_START_EVENT = 105;
-  SIGNAL_NIFGEN_VAL_STARTED_EVENT = 106;
-  SIGNAL_NIFGEN_VAL_DONE_EVENT = 107;
-  SIGNAL_NIFGEN_VAL_DATA_MARKER_EVENT = 108;
-}
-
-enum Trigger {
-  TRIGGER_UNSPECIFIED = 0;
-  TRIGGER_NIFGEN_VAL_START_TRIGGER = 1004;
-  TRIGGER_NIFGEN_VAL_SCRIPT_TRIGGER = 103;
-}
-
-enum TriggerMode {
-  TRIGGER_MODE_UNSPECIFIED = 0;
-  TRIGGER_MODE_NIFGEN_VAL_SINGLE = 1;
-  TRIGGER_MODE_NIFGEN_VAL_CONTINUOUS = 2;
-  TRIGGER_MODE_NIFGEN_VAL_STEPPED = 3;
-  TRIGGER_MODE_NIFGEN_VAL_BURST = 4;
-}
-
-enum TriggerWhen {
-  TRIGGER_WHEN_UNSPECIFIED = 0;
-  TRIGGER_WHEN_NIFGEN_VAL_ACTIVE_HIGH = 101;
-  TRIGGER_WHEN_NIFGEN_VAL_ACTIVE_LOW = 102;
-}
-
-enum Waveform {
-  WAVEFORM_UNSPECIFIED = 0;
-  WAVEFORM_NIFGEN_VAL_WFM_SINE = 1;
-  WAVEFORM_NIFGEN_VAL_WFM_SQUARE = 2;
-  WAVEFORM_NIFGEN_VAL_WFM_TRIANGLE = 3;
-  WAVEFORM_NIFGEN_VAL_WFM_RAMP_UP = 4;
-  WAVEFORM_NIFGEN_VAL_WFM_RAMP_DOWN = 5;
-  WAVEFORM_NIFGEN_VAL_WFM_DC = 6;
-  WAVEFORM_NIFGEN_VAL_WFM_NOISE = 101;
-  WAVEFORM_NIFGEN_VAL_WFM_USER = 102;
-}
-
-enum WaveformHandle {
-  WAVEFORM_HANDLE_UNSPECIFIED = 0;
-  WAVEFORM_HANDLE_NIFGEN_VAL_ALL_WAVEFORMS = -1;
-}
-
-message AbortGenerationRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message AbortGenerationResponse {
-  int32 status = 1;
-}
-
-message AdjustSampleClockRelativeDelayRequest {
-  nidevice_grpc.Session vi = 1;
-  double adjustment_time = 2;
-}
-
-message AdjustSampleClockRelativeDelayResponse {
-  int32 status = 1;
-}
-
-message AllocateNamedWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string waveform_name = 3;
-  sint32 waveform_size = 4;
-}
-
-message AllocateNamedWaveformResponse {
-  int32 status = 1;
-}
-
-message AllocateWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_size = 3;
-}
-
-message AllocateWaveformResponse {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message CheckAttributeViBooleanRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  bool attribute_value = 4;
-}
-
-message CheckAttributeViBooleanResponse {
-  int32 status = 1;
-}
-
-message CheckAttributeViInt32Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    NiFgenInt32AttributeValues attribute_value = 4;
-    sint32 attribute_value_raw = 5;
-  }
-}
-
-message CheckAttributeViInt32Response {
-  int32 status = 1;
-}
-
-message CheckAttributeViInt64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  int64 attribute_value_raw = 4;
-}
-
-message CheckAttributeViInt64Response {
-  int32 status = 1;
-}
-
-message CheckAttributeViReal64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    NiFgenReal64AttributeValues attribute_value = 4;
-    double attribute_value_raw = 5;
-  }
-}
-
-message CheckAttributeViReal64Response {
-  int32 status = 1;
-}
-
-message CheckAttributeViSessionRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  nidevice_grpc.Session attribute_value = 4;
-}
-
-message CheckAttributeViSessionResponse {
-  int32 status = 1;
-}
-
-message CheckAttributeViStringRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    string attribute_value_raw = 4;
-    NiFgenStringAttributeValuesMapped attribute_value_mapped = 5;
-  }
-}
-
-message CheckAttributeViStringResponse {
-  int32 status = 1;
-}
-
-message ClearArbMemoryRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ClearArbMemoryResponse {
-  int32 status = 1;
-}
-
-message ClearArbSequenceRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof sequence_handle_enum {
-    SequenceHandle sequence_handle = 2;
-    sint32 sequence_handle_raw = 3;
-  }
-}
-
-message ClearArbSequenceResponse {
-  int32 status = 1;
-}
-
-message ClearArbWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof waveform_handle_enum {
-    WaveformHandle waveform_handle = 2;
-    sint32 waveform_handle_raw = 3;
-  }
-}
-
-message ClearArbWaveformResponse {
-  int32 status = 1;
-}
-
-message ClearErrorRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ClearErrorResponse {
-  int32 status = 1;
-}
-
-message ClearFreqListRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof frequency_list_handle_enum {
-    FrequencyListOptions frequency_list_handle = 2;
-    sint32 frequency_list_handle_raw = 3;
-  }
-}
-
-message ClearFreqListResponse {
-  int32 status = 1;
-}
-
-message ClearInterchangeWarningsRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ClearInterchangeWarningsResponse {
-  int32 status = 1;
-}
-
-message ClearUserStandardWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message ClearUserStandardWaveformResponse {
-  int32 status = 1;
-}
-
-message CloseRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message CloseResponse {
-  int32 status = 1;
-}
-
-message CommitRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message CommitResponse {
-  int32 status = 1;
-}
-
-message ConfigureAmplitudeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double amplitude = 3;
-}
-
-message ConfigureAmplitudeResponse {
-  int32 status = 1;
-}
-
-message ConfigureArbSequenceRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 sequence_handle = 3;
-  double gain = 4;
-  double offset = 5;
-}
-
-message ConfigureArbSequenceResponse {
-  int32 status = 1;
-}
-
-message ConfigureArbWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_handle = 3;
-  double gain = 4;
-  double offset = 5;
-}
-
-message ConfigureArbWaveformResponse {
-  int32 status = 1;
-}
-
-message ConfigureChannelsRequest {
-  nidevice_grpc.Session vi = 1;
-  string channels = 2;
-}
-
-message ConfigureChannelsResponse {
-  int32 status = 1;
-}
-
-message ConfigureClockModeRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof clock_mode_enum {
-    ClockMode clock_mode = 2;
-    sint32 clock_mode_raw = 3;
-  }
-}
-
-message ConfigureClockModeResponse {
-  int32 status = 1;
-}
-
-message ConfigureCustomFIRFilterCoefficientsRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated double coefficients_array = 3;
-}
-
-message ConfigureCustomFIRFilterCoefficientsResponse {
-  int32 status = 1;
-}
-
-message ConfigureDigitalEdgeScriptTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string trigger_id = 2;
-  string source = 3;
-  sint32 edge = 4;
-}
-
-message ConfigureDigitalEdgeScriptTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureDigitalEdgeStartTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string source = 2;
-  sint32 edge = 3;
-}
-
-message ConfigureDigitalEdgeStartTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureDigitalLevelScriptTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string trigger_id = 2;
-  string source = 3;
-  oneof trigger_when_enum {
-    TriggerWhen trigger_when = 4;
-    sint32 trigger_when_raw = 5;
-  }
-}
-
-message ConfigureDigitalLevelScriptTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureFreqListRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 frequency_list_handle = 3;
-  double amplitude = 4;
-  double dc_offset = 5;
-  double start_phase = 6;
-}
-
-message ConfigureFreqListResponse {
-  int32 status = 1;
-}
-
-message ConfigureFrequencyRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double frequency = 3;
-}
-
-message ConfigureFrequencyResponse {
-  int32 status = 1;
-}
-
-message ConfigureOperationModeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 operation_mode = 3;
-}
-
-message ConfigureOperationModeResponse {
-  int32 status = 1;
-}
-
-message ConfigureOutputEnabledRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  bool enabled = 3;
-}
-
-message ConfigureOutputEnabledResponse {
-  int32 status = 1;
-}
-
-message ConfigureOutputImpedanceRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double impedance = 3;
-}
-
-message ConfigureOutputImpedanceResponse {
-  int32 status = 1;
-}
-
-message ConfigureOutputModeRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof output_mode_enum {
-    OutputMode output_mode = 2;
-    sint32 output_mode_raw = 3;
-  }
-}
-
-message ConfigureOutputModeResponse {
-  int32 status = 1;
-}
-
-message ConfigureP2PEndpointFullnessStartTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 p2p_endpoint_fullness_level = 2;
-}
-
-message ConfigureP2PEndpointFullnessStartTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureReferenceClockRequest {
-  nidevice_grpc.Session vi = 1;
-  string reference_clock_source = 2;
-  double reference_clock_frequency = 3;
-}
-
-message ConfigureReferenceClockResponse {
-  int32 status = 1;
-}
-
-message ConfigureSampleClockSourceRequest {
-  nidevice_grpc.Session vi = 1;
-  string sample_clock_source = 2;
-}
-
-message ConfigureSampleClockSourceResponse {
-  int32 status = 1;
-}
-
-message ConfigureSampleRateRequest {
-  nidevice_grpc.Session vi = 1;
-  double sample_rate = 2;
-}
-
-message ConfigureSampleRateResponse {
-  int32 status = 1;
-}
-
-message ConfigureSoftwareEdgeScriptTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string trigger_id = 2;
-}
-
-message ConfigureSoftwareEdgeScriptTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureSoftwareEdgeStartTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ConfigureSoftwareEdgeStartTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureStandardWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  oneof waveform_enum {
-    Waveform waveform = 3;
-    sint32 waveform_raw = 4;
-  }
-  double amplitude = 5;
-  double dc_offset = 6;
-  double frequency = 7;
-  double start_phase = 8;
-}
-
-message ConfigureStandardWaveformResponse {
-  int32 status = 1;
-}
-
-message ConfigureSynchronizationRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 synchronization_source = 3;
-}
-
-message ConfigureSynchronizationResponse {
-  int32 status = 1;
-}
-
-message ConfigureTriggerModeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  oneof trigger_mode_enum {
-    TriggerMode trigger_mode = 3;
-    sint32 trigger_mode_raw = 4;
-  }
-}
-
-message ConfigureTriggerModeResponse {
-  int32 status = 1;
-}
-
-message CreateAdvancedArbSequenceRequest {
-  nidevice_grpc.Session vi = 1;
-  repeated sint32 waveform_handles_array = 2;
-  repeated sint32 loop_counts_array = 3;
-  repeated sint32 sample_counts_array = 4;
-  repeated sint32 marker_location_array = 5;
-}
-
-message CreateAdvancedArbSequenceResponse {
-  int32 status = 1;
-  repeated sint32 coerced_markers_array = 2;
-  sint32 sequence_handle = 3;
-}
-
-message CreateArbSequenceRequest {
-  nidevice_grpc.Session vi = 1;
-  repeated sint32 waveform_handles_array = 2;
-  repeated sint32 loop_counts_array = 3;
-}
-
-message CreateArbSequenceResponse {
-  int32 status = 1;
-  sint32 sequence_handle = 2;
-}
-
-message CreateFreqListRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof waveform_enum {
-    Waveform waveform = 2;
-    sint32 waveform_raw = 3;
-  }
-  repeated double frequency_array = 4;
-  repeated double duration_array = 5;
-}
-
-message CreateFreqListResponse {
-  int32 status = 1;
-  sint32 frequency_list_handle = 2;
-}
-
-message CreateWaveformComplexF64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated nidevice_grpc.NIComplexNumber waveform_data_array = 3;
-}
-
-message CreateWaveformComplexF64Response {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message CreateWaveformF64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated double waveform_data_array = 3;
-}
-
-message CreateWaveformF64Response {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message CreateWaveformFromFileF64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string file_name = 3;
-  oneof byte_order_enum {
-    ByteOrder byte_order = 4;
-    sint32 byte_order_raw = 5;
-  }
-}
-
-message CreateWaveformFromFileF64Response {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message CreateWaveformFromFileHWSRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string file_name = 3;
-  bool use_rate_from_waveform = 4;
-  bool use_gain_and_offset_from_waveform = 5;
-}
-
-message CreateWaveformFromFileHWSResponse {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message CreateWaveformFromFileI16Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string file_name = 3;
-  oneof byte_order_enum {
-    ByteOrder byte_order = 4;
-    sint32 byte_order_raw = 5;
-  }
-}
-
-message CreateWaveformFromFileI16Response {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message CreateWaveformI16Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated sint32 waveform_data_array = 3;
-}
-
-message CreateWaveformI16Response {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message DefineUserStandardWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated double waveform_data_array = 3;
-}
-
-message DefineUserStandardWaveformResponse {
-  int32 status = 1;
-}
-
-message DeleteNamedWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string waveform_name = 3;
-}
-
-message DeleteNamedWaveformResponse {
-  int32 status = 1;
-}
-
-message DeleteScriptRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string script_name = 3;
-}
-
-message DeleteScriptResponse {
-  int32 status = 1;
-}
-
-message DisableRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message DisableResponse {
-  int32 status = 1;
-}
-
-message DisableAnalogFilterRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message DisableAnalogFilterResponse {
-  int32 status = 1;
-}
-
-message DisableDigitalFilterRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message DisableDigitalFilterResponse {
-  int32 status = 1;
-}
-
-message DisableDigitalPatterningRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message DisableDigitalPatterningResponse {
-  int32 status = 1;
-}
-
-message DisableScriptTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string trigger_id = 2;
-}
-
-message DisableScriptTriggerResponse {
-  int32 status = 1;
-}
-
-message DisableStartTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message DisableStartTriggerResponse {
-  int32 status = 1;
-}
-
-message EnableAnalogFilterRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double filter_correction_frequency = 3;
-}
-
-message EnableAnalogFilterResponse {
-  int32 status = 1;
-}
-
-message EnableDigitalFilterRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message EnableDigitalFilterResponse {
-  int32 status = 1;
-}
-
-message EnableDigitalPatterningRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message EnableDigitalPatterningResponse {
-  int32 status = 1;
-}
-
-message ErrorHandlerRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 error_code = 2;
-}
-
-message ErrorHandlerResponse {
-  int32 status = 1;
-  string error_message = 2;
-}
-
-message ErrorMessageRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 error_code = 2;
-}
-
-message ErrorMessageResponse {
-  int32 status = 1;
-  string error_message = 2;
-}
-
-message ErrorQueryRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ErrorQueryResponse {
-  int32 status = 1;
-  sint32 error_code = 2;
-  string error_message = 3;
-}
-
-message ExportAttributeConfigurationBufferRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ExportAttributeConfigurationBufferResponse {
-  int32 status = 1;
-  bytes configuration = 2;
-}
-
-message ExportAttributeConfigurationFileRequest {
-  nidevice_grpc.Session vi = 1;
-  string file_path = 2;
-}
-
-message ExportAttributeConfigurationFileResponse {
-  int32 status = 1;
-}
-
-message ExportSignalRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof signal_enum {
-    Signal signal = 2;
-    sint32 signal_raw = 3;
-  }
-  string signal_identifier = 4;
-  string output_terminal = 5;
-}
-
-message ExportSignalResponse {
-  int32 status = 1;
-}
-
-message GetAttributeViBooleanRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViBooleanResponse {
-  int32 status = 1;
-  bool attribute_value = 2;
-}
-
-message GetAttributeViInt32Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViInt32Response {
-  int32 status = 1;
-  sint32 attribute_value = 2;
-}
-
-message GetAttributeViInt64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViInt64Response {
-  int32 status = 1;
-  int64 attribute_value = 2;
-}
-
-message GetAttributeViReal64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViReal64Response {
-  int32 status = 1;
-  double attribute_value = 2;
-}
-
-message GetAttributeViSessionRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViSessionResponse {
-  int32 status = 1;
-  nidevice_grpc.Session attribute_value = 2;
-}
-
-message GetAttributeViStringRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViStringResponse {
-  int32 status = 1;
-  string attribute_value = 2;
-}
-
-message GetChannelNameRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 index = 2;
-}
-
-message GetChannelNameResponse {
-  int32 status = 1;
-  string channel_string = 2;
-}
-
-message GetErrorRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetErrorResponse {
-  int32 status = 1;
-  sint32 error_code = 2;
-  string error_description = 3;
-}
-
-message GetExtCalLastDateAndTimeRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetExtCalLastDateAndTimeResponse {
-  int32 status = 1;
-  sint32 year = 2;
-  sint32 month = 3;
-  sint32 day = 4;
-  sint32 hour = 5;
-  sint32 minute = 6;
-}
-
-message GetExtCalLastTempRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetExtCalLastTempResponse {
-  int32 status = 1;
-  double temperature = 2;
-}
-
-message GetExtCalRecommendedIntervalRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetExtCalRecommendedIntervalResponse {
-  int32 status = 1;
-  sint32 months = 2;
-}
-
-message GetFIRFilterCoefficientsRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message GetFIRFilterCoefficientsResponse {
-  int32 status = 1;
-  repeated double coefficients_array = 2;
-  sint32 number_of_coefficients_read = 3;
-}
-
-message GetHardwareStateRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetHardwareStateResponse {
-  int32 status = 1;
-  HardwareState state = 2;
-  sint32 state_raw = 3;
-}
-
-message GetNextCoercionRecordRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetNextCoercionRecordResponse {
-  int32 status = 1;
-  string coercion_record = 2;
-}
-
-message GetNextInterchangeWarningRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetNextInterchangeWarningResponse {
-  int32 status = 1;
-  string interchange_warning = 2;
-}
-
-message GetSelfCalLastDateAndTimeRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetSelfCalLastDateAndTimeResponse {
-  int32 status = 1;
-  sint32 year = 2;
-  sint32 month = 3;
-  sint32 day = 4;
-  sint32 hour = 5;
-  sint32 minute = 6;
-}
-
-message GetSelfCalLastTempRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetSelfCalLastTempResponse {
-  int32 status = 1;
-  double temperature = 2;
-}
-
-message GetSelfCalSupportedRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetSelfCalSupportedResponse {
-  int32 status = 1;
-  bool self_cal_supported = 2;
-}
-
-message GetStreamEndpointHandleRequest {
-  nidevice_grpc.Session vi = 1;
-  string stream_endpoint = 2;
-}
-
-message GetStreamEndpointHandleResponse {
-  int32 status = 1;
-  uint32 reader_handle = 2;
-}
-
-message ImportAttributeConfigurationBufferRequest {
-  nidevice_grpc.Session vi = 1;
-  bytes configuration = 2;
-}
-
-message ImportAttributeConfigurationBufferResponse {
-  int32 status = 1;
-}
-
-message ImportAttributeConfigurationFileRequest {
-  nidevice_grpc.Session vi = 1;
-  string file_path = 2;
-}
-
-message ImportAttributeConfigurationFileResponse {
-  int32 status = 1;
-}
-
 message InitRequest {
   string session_name = 1;
   string resource_name = 2;
@@ -1745,11 +794,113 @@ message InitializeWithChannelsResponse {
   bool new_session_initialized = 4;
 }
 
-message InitiateGenerationRequest {
+message CloseRequest {
   nidevice_grpc.Session vi = 1;
 }
 
-message InitiateGenerationResponse {
+message CloseResponse {
+  int32 status = 1;
+}
+
+message ResetRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ResetResponse {
+  int32 status = 1;
+}
+
+message SelfTestRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message SelfTestResponse {
+  int32 status = 1;
+  sint32 self_test_result = 2;
+  string self_test_message = 3;
+}
+
+message ErrorQueryRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ErrorQueryResponse {
+  int32 status = 1;
+  sint32 error_code = 2;
+  string error_message = 3;
+}
+
+message ErrorMessageRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 error_code = 2;
+}
+
+message ErrorMessageResponse {
+  int32 status = 1;
+  string error_message = 2;
+}
+
+message RevisionQueryRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message RevisionQueryResponse {
+  int32 status = 1;
+  string instrument_driver_revision = 2;
+  string firmware_revision = 3;
+}
+
+message GetErrorRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetErrorResponse {
+  int32 status = 1;
+  sint32 error_code = 2;
+  string error_description = 3;
+}
+
+message ClearErrorRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ClearErrorResponse {
+  int32 status = 1;
+}
+
+message ErrorHandlerRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 error_code = 2;
+}
+
+message ErrorHandlerResponse {
+  int32 status = 1;
+  string error_message = 2;
+}
+
+message GetChannelNameRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 index = 2;
+}
+
+message GetChannelNameResponse {
+  int32 status = 1;
+  string channel_string = 2;
+}
+
+message ResetInterchangeCheckRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ResetInterchangeCheckResponse {
+  int32 status = 1;
+}
+
+message ClearInterchangeWarningsRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ClearInterchangeWarningsResponse {
   int32 status = 1;
 }
 
@@ -1758,6 +909,49 @@ message InvalidateAllAttributesRequest {
 }
 
 message InvalidateAllAttributesResponse {
+  int32 status = 1;
+}
+
+message ResetWithDefaultsRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ResetWithDefaultsResponse {
+  int32 status = 1;
+}
+
+message DisableRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message DisableResponse {
+  int32 status = 1;
+}
+
+message CommitRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message CommitResponse {
+  int32 status = 1;
+}
+
+message GetHardwareStateRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetHardwareStateResponse {
+  int32 status = 1;
+  HardwareState state = 2;
+  sint32 state_raw = 3;
+}
+
+message WaitUntilDoneRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 max_time = 2;
+}
+
+message WaitUntilDoneResponse {
   int32 status = 1;
 }
 
@@ -1770,25 +964,145 @@ message IsDoneResponse {
   bool done = 2;
 }
 
-message ManualEnableP2PStreamRequest {
-  nidevice_grpc.Session vi = 1;
-  string endpoint_name = 2;
-}
-
-message ManualEnableP2PStreamResponse {
-  int32 status = 1;
-}
-
-message QueryArbSeqCapabilitiesRequest {
+message ResetDeviceRequest {
   nidevice_grpc.Session vi = 1;
 }
 
-message QueryArbSeqCapabilitiesResponse {
+message ResetDeviceResponse {
   int32 status = 1;
-  sint32 maximum_number_of_sequences = 2;
-  sint32 minimum_sequence_length = 3;
-  sint32 maximum_sequence_length = 4;
-  sint32 maximum_loop_count = 5;
+}
+
+message ConfigureOperationModeRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 operation_mode = 3;
+}
+
+message ConfigureOperationModeResponse {
+  int32 status = 1;
+}
+
+message ConfigureOutputModeRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof output_mode_enum {
+    OutputMode output_mode = 2;
+    sint32 output_mode_raw = 3;
+  }
+}
+
+message ConfigureOutputModeResponse {
+  int32 status = 1;
+}
+
+message ConfigureReferenceClockRequest {
+  nidevice_grpc.Session vi = 1;
+  string reference_clock_source = 2;
+  double reference_clock_frequency = 3;
+}
+
+message ConfigureReferenceClockResponse {
+  int32 status = 1;
+}
+
+message ConfigureOutputImpedanceRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  double impedance = 3;
+}
+
+message ConfigureOutputImpedanceResponse {
+  int32 status = 1;
+}
+
+message ConfigureOutputEnabledRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  bool enabled = 3;
+}
+
+message ConfigureOutputEnabledResponse {
+  int32 status = 1;
+}
+
+message ConfigureChannelsRequest {
+  nidevice_grpc.Session vi = 1;
+  string channels = 2;
+}
+
+message ConfigureChannelsResponse {
+  int32 status = 1;
+}
+
+message InitiateGenerationRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message InitiateGenerationResponse {
+  int32 status = 1;
+}
+
+message AbortGenerationRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message AbortGenerationResponse {
+  int32 status = 1;
+}
+
+message ConfigureStandardWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  oneof waveform_enum {
+    Waveform waveform = 3;
+    sint32 waveform_raw = 4;
+  }
+  double amplitude = 5;
+  double dc_offset = 6;
+  double frequency = 7;
+  double start_phase = 8;
+}
+
+message ConfigureStandardWaveformResponse {
+  int32 status = 1;
+}
+
+message DefineUserStandardWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  repeated double waveform_data_array = 3;
+}
+
+message DefineUserStandardWaveformResponse {
+  int32 status = 1;
+}
+
+message ClearUserStandardWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message ClearUserStandardWaveformResponse {
+  int32 status = 1;
+}
+
+message ConfigureFrequencyRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  double frequency = 3;
+}
+
+message ConfigureFrequencyResponse {
+  int32 status = 1;
+}
+
+message ConfigureAmplitudeRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  double amplitude = 3;
+}
+
+message ConfigureAmplitudeResponse {
+  int32 status = 1;
 }
 
 message QueryArbWfmCapabilitiesRequest {
@@ -1803,201 +1117,110 @@ message QueryArbWfmCapabilitiesResponse {
   sint32 maximum_waveform_size = 5;
 }
 
-message QueryFreqListCapabilitiesRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message QueryFreqListCapabilitiesResponse {
-  int32 status = 1;
-  sint32 maximum_number_of_freq_lists = 2;
-  sint32 minimum_frequency_list_length = 3;
-  sint32 maximum_frequency_list_length = 4;
-  double minimum_frequency_list_duration = 5;
-  double maximum_frequency_list_duration = 6;
-  double frequency_list_duration_quantum = 7;
-}
-
-message ReadCurrentTemperatureRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ReadCurrentTemperatureResponse {
-  int32 status = 1;
-  double temperature = 2;
-}
-
-message ResetRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ResetResponse {
-  int32 status = 1;
-}
-
-message ResetAttributeRequest {
+message CreateWaveformF64Request {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
+  repeated double waveform_data_array = 3;
 }
 
-message ResetAttributeResponse {
+message CreateWaveformF64Response {
   int32 status = 1;
+  sint32 waveform_handle = 2;
 }
 
-message ResetDeviceRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ResetDeviceResponse {
-  int32 status = 1;
-}
-
-message ResetInterchangeCheckRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ResetInterchangeCheckResponse {
-  int32 status = 1;
-}
-
-message ResetWithDefaultsRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ResetWithDefaultsResponse {
-  int32 status = 1;
-}
-
-message RevisionQueryRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message RevisionQueryResponse {
-  int32 status = 1;
-  string instrument_driver_revision = 2;
-  string firmware_revision = 3;
-}
-
-message RouteSignalOutRequest {
+message CreateWaveformI16Request {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  oneof route_signal_from_enum {
-    RouteSignalFrom route_signal_from = 3;
-    sint32 route_signal_from_raw = 4;
-  }
-  oneof route_signal_to_enum {
-    RouteSignalTo route_signal_to = 5;
-    sint32 route_signal_to_raw = 6;
+  repeated sint32 waveform_data_array = 3;
+}
+
+message CreateWaveformI16Response {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message CreateWaveformComplexF64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  repeated nidevice_grpc.NIComplexNumber waveform_data_array = 3;
+}
+
+message CreateWaveformComplexF64Response {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message CreateWaveformFromFileI16Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string file_name = 3;
+  oneof byte_order_enum {
+    ByteOrder byte_order = 4;
+    sint32 byte_order_raw = 5;
   }
 }
 
-message RouteSignalOutResponse {
+message CreateWaveformFromFileI16Response {
   int32 status = 1;
+  sint32 waveform_handle = 2;
 }
 
-message SelfCalRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message SelfCalResponse {
-  int32 status = 1;
-}
-
-message SelfTestRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message SelfTestResponse {
-  int32 status = 1;
-  sint32 self_test_result = 2;
-  string self_test_message = 3;
-}
-
-message SendSoftwareEdgeTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof trigger_enum {
-    Trigger trigger = 2;
-    sint32 trigger_raw = 3;
-  }
-  string trigger_id = 4;
-}
-
-message SendSoftwareEdgeTriggerResponse {
-  int32 status = 1;
-}
-
-message SetAttributeViBooleanRequest {
+message CreateWaveformFromFileF64Request {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  bool attribute_value = 4;
-}
-
-message SetAttributeViBooleanResponse {
-  int32 status = 1;
-}
-
-message SetAttributeViInt32Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    NiFgenInt32AttributeValues attribute_value = 4;
-    sint32 attribute_value_raw = 5;
+  string file_name = 3;
+  oneof byte_order_enum {
+    ByteOrder byte_order = 4;
+    sint32 byte_order_raw = 5;
   }
 }
 
-message SetAttributeViInt32Response {
+message CreateWaveformFromFileF64Response {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message ConfigureSampleRateRequest {
+  nidevice_grpc.Session vi = 1;
+  double sample_rate = 2;
+}
+
+message ConfigureSampleRateResponse {
   int32 status = 1;
 }
 
-message SetAttributeViInt64Request {
+message ConfigureArbWaveformRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  int64 attribute_value_raw = 4;
+  sint32 waveform_handle = 3;
+  double gain = 4;
+  double offset = 5;
 }
 
-message SetAttributeViInt64Response {
+message ConfigureArbWaveformResponse {
   int32 status = 1;
 }
 
-message SetAttributeViReal64Request {
+message ClearArbWaveformRequest {
   nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    NiFgenReal64AttributeValues attribute_value = 4;
-    double attribute_value_raw = 5;
+  oneof waveform_handle_enum {
+    WaveformHandle waveform_handle = 2;
+    sint32 waveform_handle_raw = 3;
   }
 }
 
-message SetAttributeViReal64Response {
+message ClearArbWaveformResponse {
   int32 status = 1;
 }
 
-message SetAttributeViSessionRequest {
+message AllocateNamedWaveformRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  nidevice_grpc.Session attribute_value = 4;
+  string waveform_name = 3;
+  sint32 waveform_size = 4;
 }
 
-message SetAttributeViSessionResponse {
-  int32 status = 1;
-}
-
-message SetAttributeViStringRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    string attribute_value_raw = 4;
-    NiFgenStringAttributeValuesMapped attribute_value_mapped = 5;
-  }
-}
-
-message SetAttributeViStringResponse {
+message AllocateNamedWaveformResponse {
   int32 status = 1;
 }
 
@@ -2013,74 +1236,6 @@ message SetNamedWaveformNextWritePositionRequest {
 }
 
 message SetNamedWaveformNextWritePositionResponse {
-  int32 status = 1;
-}
-
-message SetWaveformNextWritePositionRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_handle = 3;
-  oneof relative_to_enum {
-    RelativeTo relative_to = 4;
-    sint32 relative_to_raw = 5;
-  }
-  sint32 offset = 6;
-}
-
-message SetWaveformNextWritePositionResponse {
-  int32 status = 1;
-}
-
-message WaitUntilDoneRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 max_time = 2;
-}
-
-message WaitUntilDoneResponse {
-  int32 status = 1;
-}
-
-message WriteBinary16WaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_handle = 3;
-  repeated sint32 data = 4;
-}
-
-message WriteBinary16WaveformResponse {
-  int32 status = 1;
-}
-
-message WriteComplexBinary16WaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_handle = 3;
-  repeated nidevice_grpc.NIComplexI16 data = 4;
-}
-
-message WriteComplexBinary16WaveformResponse {
-  int32 status = 1;
-}
-
-message WriteNamedWaveformComplexF64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string waveform_name = 3;
-  repeated nidevice_grpc.NIComplexNumber data = 4;
-}
-
-message WriteNamedWaveformComplexF64Response {
-  int32 status = 1;
-}
-
-message WriteNamedWaveformComplexI16Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string waveform_name = 3;
-  repeated nidevice_grpc.NIComplexI16 data = 4;
-}
-
-message WriteNamedWaveformComplexI16Response {
   int32 status = 1;
 }
 
@@ -2106,13 +1261,158 @@ message WriteNamedWaveformI16Response {
   int32 status = 1;
 }
 
-message WriteP2PEndpointI16Request {
+message WriteNamedWaveformComplexF64Request {
   nidevice_grpc.Session vi = 1;
-  string endpoint_name = 2;
-  repeated sint32 endpoint_data = 3;
+  string channel_name = 2;
+  string waveform_name = 3;
+  repeated nidevice_grpc.NIComplexNumber data = 4;
 }
 
-message WriteP2PEndpointI16Response {
+message WriteNamedWaveformComplexF64Response {
+  int32 status = 1;
+}
+
+message WriteNamedWaveformComplexI16Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string waveform_name = 3;
+  repeated nidevice_grpc.NIComplexI16 data = 4;
+}
+
+message WriteNamedWaveformComplexI16Response {
+  int32 status = 1;
+}
+
+message DeleteNamedWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string waveform_name = 3;
+}
+
+message DeleteNamedWaveformResponse {
+  int32 status = 1;
+}
+
+message QueryArbSeqCapabilitiesRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message QueryArbSeqCapabilitiesResponse {
+  int32 status = 1;
+  sint32 maximum_number_of_sequences = 2;
+  sint32 minimum_sequence_length = 3;
+  sint32 maximum_sequence_length = 4;
+  sint32 maximum_loop_count = 5;
+}
+
+message CreateArbSequenceRequest {
+  nidevice_grpc.Session vi = 1;
+  repeated sint32 waveform_handles_array = 2;
+  repeated sint32 loop_counts_array = 3;
+}
+
+message CreateArbSequenceResponse {
+  int32 status = 1;
+  sint32 sequence_handle = 2;
+}
+
+message CreateAdvancedArbSequenceRequest {
+  nidevice_grpc.Session vi = 1;
+  repeated sint32 waveform_handles_array = 2;
+  repeated sint32 loop_counts_array = 3;
+  repeated sint32 sample_counts_array = 4;
+  repeated sint32 marker_location_array = 5;
+}
+
+message CreateAdvancedArbSequenceResponse {
+  int32 status = 1;
+  repeated sint32 coerced_markers_array = 2;
+  sint32 sequence_handle = 3;
+}
+
+message ConfigureArbSequenceRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 sequence_handle = 3;
+  double gain = 4;
+  double offset = 5;
+}
+
+message ConfigureArbSequenceResponse {
+  int32 status = 1;
+}
+
+message ClearArbSequenceRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof sequence_handle_enum {
+    SequenceHandle sequence_handle = 2;
+    sint32 sequence_handle_raw = 3;
+  }
+}
+
+message ClearArbSequenceResponse {
+  int32 status = 1;
+}
+
+message ClearArbMemoryRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ClearArbMemoryResponse {
+  int32 status = 1;
+}
+
+message QueryFreqListCapabilitiesRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message QueryFreqListCapabilitiesResponse {
+  int32 status = 1;
+  sint32 maximum_number_of_freq_lists = 2;
+  sint32 minimum_frequency_list_length = 3;
+  sint32 maximum_frequency_list_length = 4;
+  double minimum_frequency_list_duration = 5;
+  double maximum_frequency_list_duration = 6;
+  double frequency_list_duration_quantum = 7;
+}
+
+message CreateFreqListRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof waveform_enum {
+    Waveform waveform = 2;
+    sint32 waveform_raw = 3;
+  }
+  repeated double frequency_array = 4;
+  repeated double duration_array = 5;
+}
+
+message CreateFreqListResponse {
+  int32 status = 1;
+  sint32 frequency_list_handle = 2;
+}
+
+message ConfigureFreqListRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 frequency_list_handle = 3;
+  double amplitude = 4;
+  double dc_offset = 5;
+  double start_phase = 6;
+}
+
+message ConfigureFreqListResponse {
+  int32 status = 1;
+}
+
+message ClearFreqListRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof frequency_list_handle_enum {
+    FrequencyListOptions frequency_list_handle = 2;
+    sint32 frequency_list_handle_raw = 3;
+  }
+}
+
+message ClearFreqListResponse {
   int32 status = 1;
 }
 
@@ -2123,6 +1423,191 @@ message WriteScriptRequest {
 }
 
 message WriteScriptResponse {
+  int32 status = 1;
+}
+
+message DeleteScriptRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string script_name = 3;
+}
+
+message DeleteScriptResponse {
+  int32 status = 1;
+}
+
+message ExportSignalRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof signal_enum {
+    Signal signal = 2;
+    sint32 signal_raw = 3;
+  }
+  string signal_identifier = 4;
+  string output_terminal = 5;
+}
+
+message ExportSignalResponse {
+  int32 status = 1;
+}
+
+message RouteSignalOutRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  oneof route_signal_from_enum {
+    RouteSignalFrom route_signal_from = 3;
+    sint32 route_signal_from_raw = 4;
+  }
+  oneof route_signal_to_enum {
+    RouteSignalTo route_signal_to = 5;
+    sint32 route_signal_to_raw = 6;
+  }
+}
+
+message RouteSignalOutResponse {
+  int32 status = 1;
+}
+
+message SendSoftwareEdgeTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof trigger_enum {
+    Trigger trigger = 2;
+    sint32 trigger_raw = 3;
+  }
+  string trigger_id = 4;
+}
+
+message SendSoftwareEdgeTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureDigitalEdgeStartTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string source = 2;
+  oneof edge_enum {
+    StartTriggerDigitalEdgeEdge edge = 3;
+    sint32 edge_raw = 4;
+  }
+}
+
+message ConfigureDigitalEdgeStartTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureSoftwareEdgeStartTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ConfigureSoftwareEdgeStartTriggerResponse {
+  int32 status = 1;
+}
+
+message DisableStartTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message DisableStartTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureP2PEndpointFullnessStartTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 p2p_endpoint_fullness_level = 2;
+}
+
+message ConfigureP2PEndpointFullnessStartTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureDigitalEdgeScriptTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string trigger_id = 2;
+  string source = 3;
+  oneof edge_enum {
+    ScriptTriggerDigitalEdgeEdge edge = 4;
+    sint32 edge_raw = 5;
+  }
+}
+
+message ConfigureDigitalEdgeScriptTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureDigitalLevelScriptTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string trigger_id = 2;
+  string source = 3;
+  oneof trigger_when_enum {
+    TriggerWhen trigger_when = 4;
+    sint32 trigger_when_raw = 5;
+  }
+}
+
+message ConfigureDigitalLevelScriptTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureSoftwareEdgeScriptTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string trigger_id = 2;
+}
+
+message ConfigureSoftwareEdgeScriptTriggerResponse {
+  int32 status = 1;
+}
+
+message DisableScriptTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string trigger_id = 2;
+}
+
+message DisableScriptTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureClockModeRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof clock_mode_enum {
+    ClockMode clock_mode = 2;
+    sint32 clock_mode_raw = 3;
+  }
+}
+
+message ConfigureClockModeResponse {
+  int32 status = 1;
+}
+
+message AdjustSampleClockRelativeDelayRequest {
+  nidevice_grpc.Session vi = 1;
+  double adjustment_time = 2;
+}
+
+message AdjustSampleClockRelativeDelayResponse {
+  int32 status = 1;
+}
+
+message AllocateWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 waveform_size = 3;
+}
+
+message AllocateWaveformResponse {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message SetWaveformNextWritePositionRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 waveform_handle = 3;
+  oneof relative_to_enum {
+    RelativeTo relative_to = 4;
+    sint32 relative_to_raw = 5;
+  }
+  sint32 offset = 6;
+}
+
+message SetWaveformNextWritePositionResponse {
   int32 status = 1;
 }
 
@@ -2137,6 +1622,17 @@ message WriteWaveformResponse {
   int32 status = 1;
 }
 
+message WriteBinary16WaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 waveform_handle = 3;
+  repeated sint32 data = 4;
+}
+
+message WriteBinary16WaveformResponse {
+  int32 status = 1;
+}
+
 message WriteWaveformComplexF64Request {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
@@ -2146,5 +1642,507 @@ message WriteWaveformComplexF64Request {
 
 message WriteWaveformComplexF64Response {
   int32 status = 1;
+}
+
+message WriteComplexBinary16WaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 waveform_handle = 3;
+  repeated nidevice_grpc.NIComplexI16 data = 4;
+}
+
+message WriteComplexBinary16WaveformResponse {
+  int32 status = 1;
+}
+
+message SelfCalRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message SelfCalResponse {
+  int32 status = 1;
+}
+
+message GetSelfCalSupportedRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetSelfCalSupportedResponse {
+  int32 status = 1;
+  bool self_cal_supported = 2;
+}
+
+message GetSelfCalLastDateAndTimeRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetSelfCalLastDateAndTimeResponse {
+  int32 status = 1;
+  sint32 year = 2;
+  sint32 month = 3;
+  sint32 day = 4;
+  sint32 hour = 5;
+  sint32 minute = 6;
+}
+
+message GetExtCalLastDateAndTimeRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetExtCalLastDateAndTimeResponse {
+  int32 status = 1;
+  sint32 year = 2;
+  sint32 month = 3;
+  sint32 day = 4;
+  sint32 hour = 5;
+  sint32 minute = 6;
+}
+
+message GetSelfCalLastTempRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetSelfCalLastTempResponse {
+  int32 status = 1;
+  double temperature = 2;
+}
+
+message GetExtCalLastTempRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetExtCalLastTempResponse {
+  int32 status = 1;
+  double temperature = 2;
+}
+
+message GetExtCalRecommendedIntervalRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetExtCalRecommendedIntervalResponse {
+  int32 status = 1;
+  sint32 months = 2;
+}
+
+message ReadCurrentTemperatureRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ReadCurrentTemperatureResponse {
+  int32 status = 1;
+  double temperature = 2;
+}
+
+message ConfigureCustomFIRFilterCoefficientsRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  repeated double coefficients_array = 3;
+}
+
+message ConfigureCustomFIRFilterCoefficientsResponse {
+  int32 status = 1;
+}
+
+message GetFIRFilterCoefficientsRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message GetFIRFilterCoefficientsResponse {
+  int32 status = 1;
+  repeated double coefficients_array = 2;
+  sint32 number_of_coefficients_read = 3;
+}
+
+message GetStreamEndpointHandleRequest {
+  nidevice_grpc.Session vi = 1;
+  string stream_endpoint = 2;
+}
+
+message GetStreamEndpointHandleResponse {
+  int32 status = 1;
+  uint32 reader_handle = 2;
+}
+
+message WriteP2PEndpointI16Request {
+  nidevice_grpc.Session vi = 1;
+  string endpoint_name = 2;
+  repeated sint32 endpoint_data = 3;
+}
+
+message WriteP2PEndpointI16Response {
+  int32 status = 1;
+}
+
+message ConfigureSynchronizationRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 synchronization_source = 3;
+}
+
+message ConfigureSynchronizationResponse {
+  int32 status = 1;
+}
+
+message EnableDigitalPatterningRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message EnableDigitalPatterningResponse {
+  int32 status = 1;
+}
+
+message DisableDigitalPatterningRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message DisableDigitalPatterningResponse {
+  int32 status = 1;
+}
+
+message EnableDigitalFilterRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message EnableDigitalFilterResponse {
+  int32 status = 1;
+}
+
+message DisableDigitalFilterRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message DisableDigitalFilterResponse {
+  int32 status = 1;
+}
+
+message EnableAnalogFilterRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  double filter_correction_frequency = 3;
+}
+
+message EnableAnalogFilterResponse {
+  int32 status = 1;
+}
+
+message DisableAnalogFilterRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message DisableAnalogFilterResponse {
+  int32 status = 1;
+}
+
+message ConfigureSampleClockSourceRequest {
+  nidevice_grpc.Session vi = 1;
+  string sample_clock_source = 2;
+}
+
+message ConfigureSampleClockSourceResponse {
+  int32 status = 1;
+}
+
+message ConfigureTriggerModeRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  oneof trigger_mode_enum {
+    TriggerMode trigger_mode = 3;
+    sint32 trigger_mode_raw = 4;
+  }
+}
+
+message ConfigureTriggerModeResponse {
+  int32 status = 1;
+}
+
+message ImportAttributeConfigurationFileRequest {
+  nidevice_grpc.Session vi = 1;
+  string file_path = 2;
+}
+
+message ImportAttributeConfigurationFileResponse {
+  int32 status = 1;
+}
+
+message ExportAttributeConfigurationFileRequest {
+  nidevice_grpc.Session vi = 1;
+  string file_path = 2;
+}
+
+message ExportAttributeConfigurationFileResponse {
+  int32 status = 1;
+}
+
+message ImportAttributeConfigurationBufferRequest {
+  nidevice_grpc.Session vi = 1;
+  bytes configuration = 2;
+}
+
+message ImportAttributeConfigurationBufferResponse {
+  int32 status = 1;
+}
+
+message ExportAttributeConfigurationBufferRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ExportAttributeConfigurationBufferResponse {
+  int32 status = 1;
+  bytes configuration = 2;
+}
+
+message SetAttributeViInt64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  int64 attribute_value_raw = 4;
+}
+
+message SetAttributeViInt64Response {
+  int32 status = 1;
+}
+
+message CheckAttributeViInt64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  int64 attribute_value_raw = 4;
+}
+
+message CheckAttributeViInt64Response {
+  int32 status = 1;
+}
+
+message GetAttributeViInt64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViInt64Response {
+  int32 status = 1;
+  int64 attribute_value = 2;
+}
+
+message SetAttributeViInt32Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFgenInt32AttributeValues attribute_value = 4;
+    sint32 attribute_value_raw = 5;
+  }
+}
+
+message SetAttributeViInt32Response {
+  int32 status = 1;
+}
+
+message SetAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFgenReal64AttributeValues attribute_value = 4;
+    double attribute_value_raw = 5;
+  }
+}
+
+message SetAttributeViReal64Response {
+  int32 status = 1;
+}
+
+message SetAttributeViStringRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    string attribute_value_raw = 4;
+    NiFgenStringAttributeValuesMapped attribute_value_mapped = 5;
+  }
+}
+
+message SetAttributeViStringResponse {
+  int32 status = 1;
+}
+
+message SetAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  bool attribute_value = 4;
+}
+
+message SetAttributeViBooleanResponse {
+  int32 status = 1;
+}
+
+message SetAttributeViSessionRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  nidevice_grpc.Session attribute_value = 4;
+}
+
+message SetAttributeViSessionResponse {
+  int32 status = 1;
+}
+
+message CheckAttributeViInt32Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFgenInt32AttributeValues attribute_value = 4;
+    sint32 attribute_value_raw = 5;
+  }
+}
+
+message CheckAttributeViInt32Response {
+  int32 status = 1;
+}
+
+message CheckAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFgenReal64AttributeValues attribute_value = 4;
+    double attribute_value_raw = 5;
+  }
+}
+
+message CheckAttributeViReal64Response {
+  int32 status = 1;
+}
+
+message CheckAttributeViStringRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    string attribute_value_raw = 4;
+    NiFgenStringAttributeValuesMapped attribute_value_mapped = 5;
+  }
+}
+
+message CheckAttributeViStringResponse {
+  int32 status = 1;
+}
+
+message CheckAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  bool attribute_value = 4;
+}
+
+message CheckAttributeViBooleanResponse {
+  int32 status = 1;
+}
+
+message CheckAttributeViSessionRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  nidevice_grpc.Session attribute_value = 4;
+}
+
+message CheckAttributeViSessionResponse {
+  int32 status = 1;
+}
+
+message GetAttributeViInt32Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViInt32Response {
+  int32 status = 1;
+  sint32 attribute_value = 2;
+}
+
+message GetAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViReal64Response {
+  int32 status = 1;
+  double attribute_value = 2;
+}
+
+message GetAttributeViStringRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViStringResponse {
+  int32 status = 1;
+  string attribute_value = 2;
+}
+
+message GetAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViBooleanResponse {
+  int32 status = 1;
+  bool attribute_value = 2;
+}
+
+message GetAttributeViSessionRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViSessionResponse {
+  int32 status = 1;
+  nidevice_grpc.Session attribute_value = 2;
+}
+
+message ResetAttributeRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message ResetAttributeResponse {
+  int32 status = 1;
+}
+
+message ManualEnableP2PStreamRequest {
+  nidevice_grpc.Session vi = 1;
+  string endpoint_name = 2;
+}
+
+message ManualEnableP2PStreamResponse {
+  int32 status = 1;
+}
+
+message CreateWaveformFromFileHWSRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string file_name = 3;
+  bool use_rate_from_waveform = 4;
+  bool use_gain_and_offset_from_waveform = 5;
+}
+
+message CreateWaveformFromFileHWSResponse {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
 }
 

--- a/source/codegen/metadata/nifgen/nifgen.proto
+++ b/source/codegen/metadata/nifgen/nifgen.proto
@@ -17,202 +17,218 @@ import "nidevice.proto";
 import "session.proto";
 
 service NiFgen {
+  rpc AbortGeneration(AbortGenerationRequest) returns (AbortGenerationResponse);
+  rpc AdjustSampleClockRelativeDelay(AdjustSampleClockRelativeDelayRequest) returns (AdjustSampleClockRelativeDelayResponse);
+  rpc AllocateNamedWaveform(AllocateNamedWaveformRequest) returns (AllocateNamedWaveformResponse);
+  rpc AllocateWaveform(AllocateWaveformRequest) returns (AllocateWaveformResponse);
+  rpc CheckAttributeViBoolean(CheckAttributeViBooleanRequest) returns (CheckAttributeViBooleanResponse);
+  rpc CheckAttributeViInt32(CheckAttributeViInt32Request) returns (CheckAttributeViInt32Response);
+  rpc CheckAttributeViInt64(CheckAttributeViInt64Request) returns (CheckAttributeViInt64Response);
+  rpc CheckAttributeViReal64(CheckAttributeViReal64Request) returns (CheckAttributeViReal64Response);
+  rpc CheckAttributeViSession(CheckAttributeViSessionRequest) returns (CheckAttributeViSessionResponse);
+  rpc CheckAttributeViString(CheckAttributeViStringRequest) returns (CheckAttributeViStringResponse);
+  rpc ClearArbMemory(ClearArbMemoryRequest) returns (ClearArbMemoryResponse);
+  rpc ClearArbSequence(ClearArbSequenceRequest) returns (ClearArbSequenceResponse);
+  rpc ClearArbWaveform(ClearArbWaveformRequest) returns (ClearArbWaveformResponse);
+  rpc ClearError(ClearErrorRequest) returns (ClearErrorResponse);
+  rpc ClearFreqList(ClearFreqListRequest) returns (ClearFreqListResponse);
+  rpc ClearInterchangeWarnings(ClearInterchangeWarningsRequest) returns (ClearInterchangeWarningsResponse);
+  rpc ClearUserStandardWaveform(ClearUserStandardWaveformRequest) returns (ClearUserStandardWaveformResponse);
+  rpc Close(CloseRequest) returns (CloseResponse);
+  rpc Commit(CommitRequest) returns (CommitResponse);
+  rpc ConfigureAmplitude(ConfigureAmplitudeRequest) returns (ConfigureAmplitudeResponse);
+  rpc ConfigureArbSequence(ConfigureArbSequenceRequest) returns (ConfigureArbSequenceResponse);
+  rpc ConfigureArbWaveform(ConfigureArbWaveformRequest) returns (ConfigureArbWaveformResponse);
+  rpc ConfigureChannels(ConfigureChannelsRequest) returns (ConfigureChannelsResponse);
+  rpc ConfigureClockMode(ConfigureClockModeRequest) returns (ConfigureClockModeResponse);
+  rpc ConfigureCustomFIRFilterCoefficients(ConfigureCustomFIRFilterCoefficientsRequest) returns (ConfigureCustomFIRFilterCoefficientsResponse);
+  rpc ConfigureDigitalEdgeScriptTrigger(ConfigureDigitalEdgeScriptTriggerRequest) returns (ConfigureDigitalEdgeScriptTriggerResponse);
+  rpc ConfigureDigitalEdgeStartTrigger(ConfigureDigitalEdgeStartTriggerRequest) returns (ConfigureDigitalEdgeStartTriggerResponse);
+  rpc ConfigureDigitalLevelScriptTrigger(ConfigureDigitalLevelScriptTriggerRequest) returns (ConfigureDigitalLevelScriptTriggerResponse);
+  rpc ConfigureFreqList(ConfigureFreqListRequest) returns (ConfigureFreqListResponse);
+  rpc ConfigureFrequency(ConfigureFrequencyRequest) returns (ConfigureFrequencyResponse);
+  rpc ConfigureOperationMode(ConfigureOperationModeRequest) returns (ConfigureOperationModeResponse);
+  rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
+  rpc ConfigureOutputImpedance(ConfigureOutputImpedanceRequest) returns (ConfigureOutputImpedanceResponse);
+  rpc ConfigureOutputMode(ConfigureOutputModeRequest) returns (ConfigureOutputModeResponse);
+  rpc ConfigureP2PEndpointFullnessStartTrigger(ConfigureP2PEndpointFullnessStartTriggerRequest) returns (ConfigureP2PEndpointFullnessStartTriggerResponse);
+  rpc ConfigureReferenceClock(ConfigureReferenceClockRequest) returns (ConfigureReferenceClockResponse);
+  rpc ConfigureSampleClockSource(ConfigureSampleClockSourceRequest) returns (ConfigureSampleClockSourceResponse);
+  rpc ConfigureSampleRate(ConfigureSampleRateRequest) returns (ConfigureSampleRateResponse);
+  rpc ConfigureSoftwareEdgeScriptTrigger(ConfigureSoftwareEdgeScriptTriggerRequest) returns (ConfigureSoftwareEdgeScriptTriggerResponse);
+  rpc ConfigureSoftwareEdgeStartTrigger(ConfigureSoftwareEdgeStartTriggerRequest) returns (ConfigureSoftwareEdgeStartTriggerResponse);
+  rpc ConfigureStandardWaveform(ConfigureStandardWaveformRequest) returns (ConfigureStandardWaveformResponse);
+  rpc ConfigureSynchronization(ConfigureSynchronizationRequest) returns (ConfigureSynchronizationResponse);
+  rpc ConfigureTriggerMode(ConfigureTriggerModeRequest) returns (ConfigureTriggerModeResponse);
+  rpc CreateAdvancedArbSequence(CreateAdvancedArbSequenceRequest) returns (CreateAdvancedArbSequenceResponse);
+  rpc CreateArbSequence(CreateArbSequenceRequest) returns (CreateArbSequenceResponse);
+  rpc CreateFreqList(CreateFreqListRequest) returns (CreateFreqListResponse);
+  rpc CreateWaveformComplexF64(CreateWaveformComplexF64Request) returns (CreateWaveformComplexF64Response);
+  rpc CreateWaveformF64(CreateWaveformF64Request) returns (CreateWaveformF64Response);
+  rpc CreateWaveformFromFileF64(CreateWaveformFromFileF64Request) returns (CreateWaveformFromFileF64Response);
+  rpc CreateWaveformFromFileHWS(CreateWaveformFromFileHWSRequest) returns (CreateWaveformFromFileHWSResponse);
+  rpc CreateWaveformFromFileI16(CreateWaveformFromFileI16Request) returns (CreateWaveformFromFileI16Response);
+  rpc CreateWaveformI16(CreateWaveformI16Request) returns (CreateWaveformI16Response);
+  rpc DefineUserStandardWaveform(DefineUserStandardWaveformRequest) returns (DefineUserStandardWaveformResponse);
+  rpc DeleteNamedWaveform(DeleteNamedWaveformRequest) returns (DeleteNamedWaveformResponse);
+  rpc DeleteScript(DeleteScriptRequest) returns (DeleteScriptResponse);
+  rpc Disable(DisableRequest) returns (DisableResponse);
+  rpc DisableAnalogFilter(DisableAnalogFilterRequest) returns (DisableAnalogFilterResponse);
+  rpc DisableDigitalFilter(DisableDigitalFilterRequest) returns (DisableDigitalFilterResponse);
+  rpc DisableDigitalPatterning(DisableDigitalPatterningRequest) returns (DisableDigitalPatterningResponse);
+  rpc DisableScriptTrigger(DisableScriptTriggerRequest) returns (DisableScriptTriggerResponse);
+  rpc DisableStartTrigger(DisableStartTriggerRequest) returns (DisableStartTriggerResponse);
+  rpc EnableAnalogFilter(EnableAnalogFilterRequest) returns (EnableAnalogFilterResponse);
+  rpc EnableDigitalFilter(EnableDigitalFilterRequest) returns (EnableDigitalFilterResponse);
+  rpc EnableDigitalPatterning(EnableDigitalPatterningRequest) returns (EnableDigitalPatterningResponse);
+  rpc ErrorHandler(ErrorHandlerRequest) returns (ErrorHandlerResponse);
+  rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
+  rpc ErrorQuery(ErrorQueryRequest) returns (ErrorQueryResponse);
+  rpc ExportAttributeConfigurationBuffer(ExportAttributeConfigurationBufferRequest) returns (ExportAttributeConfigurationBufferResponse);
+  rpc ExportAttributeConfigurationFile(ExportAttributeConfigurationFileRequest) returns (ExportAttributeConfigurationFileResponse);
+  rpc ExportSignal(ExportSignalRequest) returns (ExportSignalResponse);
+  rpc GetAttributeViBoolean(GetAttributeViBooleanRequest) returns (GetAttributeViBooleanResponse);
+  rpc GetAttributeViInt32(GetAttributeViInt32Request) returns (GetAttributeViInt32Response);
+  rpc GetAttributeViInt64(GetAttributeViInt64Request) returns (GetAttributeViInt64Response);
+  rpc GetAttributeViReal64(GetAttributeViReal64Request) returns (GetAttributeViReal64Response);
+  rpc GetAttributeViSession(GetAttributeViSessionRequest) returns (GetAttributeViSessionResponse);
+  rpc GetAttributeViString(GetAttributeViStringRequest) returns (GetAttributeViStringResponse);
+  rpc GetChannelName(GetChannelNameRequest) returns (GetChannelNameResponse);
+  rpc GetError(GetErrorRequest) returns (GetErrorResponse);
+  rpc GetExtCalLastDateAndTime(GetExtCalLastDateAndTimeRequest) returns (GetExtCalLastDateAndTimeResponse);
+  rpc GetExtCalLastTemp(GetExtCalLastTempRequest) returns (GetExtCalLastTempResponse);
+  rpc GetExtCalRecommendedInterval(GetExtCalRecommendedIntervalRequest) returns (GetExtCalRecommendedIntervalResponse);
+  rpc GetFIRFilterCoefficients(GetFIRFilterCoefficientsRequest) returns (GetFIRFilterCoefficientsResponse);
+  rpc GetHardwareState(GetHardwareStateRequest) returns (GetHardwareStateResponse);
+  rpc GetSelfCalLastDateAndTime(GetSelfCalLastDateAndTimeRequest) returns (GetSelfCalLastDateAndTimeResponse);
+  rpc GetSelfCalLastTemp(GetSelfCalLastTempRequest) returns (GetSelfCalLastTempResponse);
+  rpc GetSelfCalSupported(GetSelfCalSupportedRequest) returns (GetSelfCalSupportedResponse);
+  rpc GetStreamEndpointHandle(GetStreamEndpointHandleRequest) returns (GetStreamEndpointHandleResponse);
+  rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
+  rpc ImportAttributeConfigurationFile(ImportAttributeConfigurationFileRequest) returns (ImportAttributeConfigurationFileResponse);
   rpc Init(InitRequest) returns (InitResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
   rpc InitializeWithChannels(InitializeWithChannelsRequest) returns (InitializeWithChannelsResponse);
-  rpc Close(CloseRequest) returns (CloseResponse);
-  rpc Reset(ResetRequest) returns (ResetResponse);
-  rpc SelfTest(SelfTestRequest) returns (SelfTestResponse);
-  rpc ErrorQuery(ErrorQueryRequest) returns (ErrorQueryResponse);
-  rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
-  rpc RevisionQuery(RevisionQueryRequest) returns (RevisionQueryResponse);
-  rpc GetError(GetErrorRequest) returns (GetErrorResponse);
-  rpc ClearError(ClearErrorRequest) returns (ClearErrorResponse);
-  rpc ErrorHandler(ErrorHandlerRequest) returns (ErrorHandlerResponse);
-  rpc GetChannelName(GetChannelNameRequest) returns (GetChannelNameResponse);
-  rpc ResetInterchangeCheck(ResetInterchangeCheckRequest) returns (ResetInterchangeCheckResponse);
-  rpc ClearInterchangeWarnings(ClearInterchangeWarningsRequest) returns (ClearInterchangeWarningsResponse);
-  rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
-  rpc ResetWithDefaults(ResetWithDefaultsRequest) returns (ResetWithDefaultsResponse);
-  rpc Disable(DisableRequest) returns (DisableResponse);
-  rpc Commit(CommitRequest) returns (CommitResponse);
-  rpc GetHardwareState(GetHardwareStateRequest) returns (GetHardwareStateResponse);
-  rpc WaitUntilDone(WaitUntilDoneRequest) returns (WaitUntilDoneResponse);
-  rpc IsDone(IsDoneRequest) returns (IsDoneResponse);
-  rpc ResetDevice(ResetDeviceRequest) returns (ResetDeviceResponse);
-  rpc ConfigureOperationMode(ConfigureOperationModeRequest) returns (ConfigureOperationModeResponse);
-  rpc ConfigureOutputMode(ConfigureOutputModeRequest) returns (ConfigureOutputModeResponse);
-  rpc ConfigureReferenceClock(ConfigureReferenceClockRequest) returns (ConfigureReferenceClockResponse);
-  rpc ConfigureOutputImpedance(ConfigureOutputImpedanceRequest) returns (ConfigureOutputImpedanceResponse);
-  rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
-  rpc ConfigureChannels(ConfigureChannelsRequest) returns (ConfigureChannelsResponse);
   rpc InitiateGeneration(InitiateGenerationRequest) returns (InitiateGenerationResponse);
-  rpc AbortGeneration(AbortGenerationRequest) returns (AbortGenerationResponse);
-  rpc ConfigureStandardWaveform(ConfigureStandardWaveformRequest) returns (ConfigureStandardWaveformResponse);
-  rpc DefineUserStandardWaveform(DefineUserStandardWaveformRequest) returns (DefineUserStandardWaveformResponse);
-  rpc ClearUserStandardWaveform(ClearUserStandardWaveformRequest) returns (ClearUserStandardWaveformResponse);
-  rpc ConfigureFrequency(ConfigureFrequencyRequest) returns (ConfigureFrequencyResponse);
-  rpc ConfigureAmplitude(ConfigureAmplitudeRequest) returns (ConfigureAmplitudeResponse);
+  rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
+  rpc IsDone(IsDoneRequest) returns (IsDoneResponse);
+  rpc ManualEnableP2PStream(ManualEnableP2PStreamRequest) returns (ManualEnableP2PStreamResponse);
+  rpc QueryArbSeqCapabilities(QueryArbSeqCapabilitiesRequest) returns (QueryArbSeqCapabilitiesResponse);
   rpc QueryArbWfmCapabilities(QueryArbWfmCapabilitiesRequest) returns (QueryArbWfmCapabilitiesResponse);
-  rpc CreateWaveformF64(CreateWaveformF64Request) returns (CreateWaveformF64Response);
-  rpc CreateWaveformI16(CreateWaveformI16Request) returns (CreateWaveformI16Response);
-  rpc CreateWaveformComplexF64(CreateWaveformComplexF64Request) returns (CreateWaveformComplexF64Response);
-  rpc CreateWaveformFromFileI16(CreateWaveformFromFileI16Request) returns (CreateWaveformFromFileI16Response);
-  rpc CreateWaveformFromFileF64(CreateWaveformFromFileF64Request) returns (CreateWaveformFromFileF64Response);
-  rpc ConfigureSampleRate(ConfigureSampleRateRequest) returns (ConfigureSampleRateResponse);
-  rpc ConfigureArbWaveform(ConfigureArbWaveformRequest) returns (ConfigureArbWaveformResponse);
-  rpc ClearArbWaveform(ClearArbWaveformRequest) returns (ClearArbWaveformResponse);
-  rpc AllocateNamedWaveform(AllocateNamedWaveformRequest) returns (AllocateNamedWaveformResponse);
+  rpc QueryFreqListCapabilities(QueryFreqListCapabilitiesRequest) returns (QueryFreqListCapabilitiesResponse);
+  rpc ReadCurrentTemperature(ReadCurrentTemperatureRequest) returns (ReadCurrentTemperatureResponse);
+  rpc Reset(ResetRequest) returns (ResetResponse);
+  rpc ResetAttribute(ResetAttributeRequest) returns (ResetAttributeResponse);
+  rpc ResetDevice(ResetDeviceRequest) returns (ResetDeviceResponse);
+  rpc ResetInterchangeCheck(ResetInterchangeCheckRequest) returns (ResetInterchangeCheckResponse);
+  rpc ResetWithDefaults(ResetWithDefaultsRequest) returns (ResetWithDefaultsResponse);
+  rpc RevisionQuery(RevisionQueryRequest) returns (RevisionQueryResponse);
+  rpc RouteSignalOut(RouteSignalOutRequest) returns (RouteSignalOutResponse);
+  rpc SelfCal(SelfCalRequest) returns (SelfCalResponse);
+  rpc SelfTest(SelfTestRequest) returns (SelfTestResponse);
+  rpc SendSoftwareEdgeTrigger(SendSoftwareEdgeTriggerRequest) returns (SendSoftwareEdgeTriggerResponse);
+  rpc SetAttributeViBoolean(SetAttributeViBooleanRequest) returns (SetAttributeViBooleanResponse);
+  rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
+  rpc SetAttributeViInt64(SetAttributeViInt64Request) returns (SetAttributeViInt64Response);
+  rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
+  rpc SetAttributeViSession(SetAttributeViSessionRequest) returns (SetAttributeViSessionResponse);
+  rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
   rpc SetNamedWaveformNextWritePosition(SetNamedWaveformNextWritePositionRequest) returns (SetNamedWaveformNextWritePositionResponse);
-  rpc WriteNamedWaveformF64(WriteNamedWaveformF64Request) returns (WriteNamedWaveformF64Response);
-  rpc WriteNamedWaveformI16(WriteNamedWaveformI16Request) returns (WriteNamedWaveformI16Response);
+  rpc SetWaveformNextWritePosition(SetWaveformNextWritePositionRequest) returns (SetWaveformNextWritePositionResponse);
+  rpc WaitUntilDone(WaitUntilDoneRequest) returns (WaitUntilDoneResponse);
+  rpc WriteBinary16Waveform(WriteBinary16WaveformRequest) returns (WriteBinary16WaveformResponse);
+  rpc WriteComplexBinary16Waveform(WriteComplexBinary16WaveformRequest) returns (WriteComplexBinary16WaveformResponse);
   rpc WriteNamedWaveformComplexF64(WriteNamedWaveformComplexF64Request) returns (WriteNamedWaveformComplexF64Response);
   rpc WriteNamedWaveformComplexI16(WriteNamedWaveformComplexI16Request) returns (WriteNamedWaveformComplexI16Response);
-  rpc DeleteNamedWaveform(DeleteNamedWaveformRequest) returns (DeleteNamedWaveformResponse);
-  rpc QueryArbSeqCapabilities(QueryArbSeqCapabilitiesRequest) returns (QueryArbSeqCapabilitiesResponse);
-  rpc CreateArbSequence(CreateArbSequenceRequest) returns (CreateArbSequenceResponse);
-  rpc CreateAdvancedArbSequence(CreateAdvancedArbSequenceRequest) returns (CreateAdvancedArbSequenceResponse);
-  rpc ConfigureArbSequence(ConfigureArbSequenceRequest) returns (ConfigureArbSequenceResponse);
-  rpc ClearArbSequence(ClearArbSequenceRequest) returns (ClearArbSequenceResponse);
-  rpc ClearArbMemory(ClearArbMemoryRequest) returns (ClearArbMemoryResponse);
-  rpc QueryFreqListCapabilities(QueryFreqListCapabilitiesRequest) returns (QueryFreqListCapabilitiesResponse);
-  rpc CreateFreqList(CreateFreqListRequest) returns (CreateFreqListResponse);
-  rpc ConfigureFreqList(ConfigureFreqListRequest) returns (ConfigureFreqListResponse);
-  rpc ClearFreqList(ClearFreqListRequest) returns (ClearFreqListResponse);
-  rpc WriteScript(WriteScriptRequest) returns (WriteScriptResponse);
-  rpc DeleteScript(DeleteScriptRequest) returns (DeleteScriptResponse);
-  rpc ExportSignal(ExportSignalRequest) returns (ExportSignalResponse);
-  rpc RouteSignalOut(RouteSignalOutRequest) returns (RouteSignalOutResponse);
-  rpc SendSoftwareEdgeTrigger(SendSoftwareEdgeTriggerRequest) returns (SendSoftwareEdgeTriggerResponse);
-  rpc ConfigureDigitalEdgeStartTrigger(ConfigureDigitalEdgeStartTriggerRequest) returns (ConfigureDigitalEdgeStartTriggerResponse);
-  rpc ConfigureSoftwareEdgeStartTrigger(ConfigureSoftwareEdgeStartTriggerRequest) returns (ConfigureSoftwareEdgeStartTriggerResponse);
-  rpc DisableStartTrigger(DisableStartTriggerRequest) returns (DisableStartTriggerResponse);
-  rpc ConfigureP2PEndpointFullnessStartTrigger(ConfigureP2PEndpointFullnessStartTriggerRequest) returns (ConfigureP2PEndpointFullnessStartTriggerResponse);
-  rpc ConfigureDigitalEdgeScriptTrigger(ConfigureDigitalEdgeScriptTriggerRequest) returns (ConfigureDigitalEdgeScriptTriggerResponse);
-  rpc ConfigureDigitalLevelScriptTrigger(ConfigureDigitalLevelScriptTriggerRequest) returns (ConfigureDigitalLevelScriptTriggerResponse);
-  rpc ConfigureSoftwareEdgeScriptTrigger(ConfigureSoftwareEdgeScriptTriggerRequest) returns (ConfigureSoftwareEdgeScriptTriggerResponse);
-  rpc DisableScriptTrigger(DisableScriptTriggerRequest) returns (DisableScriptTriggerResponse);
-  rpc ConfigureClockMode(ConfigureClockModeRequest) returns (ConfigureClockModeResponse);
-  rpc AdjustSampleClockRelativeDelay(AdjustSampleClockRelativeDelayRequest) returns (AdjustSampleClockRelativeDelayResponse);
-  rpc AllocateWaveform(AllocateWaveformRequest) returns (AllocateWaveformResponse);
-  rpc SetWaveformNextWritePosition(SetWaveformNextWritePositionRequest) returns (SetWaveformNextWritePositionResponse);
-  rpc WriteWaveform(WriteWaveformRequest) returns (WriteWaveformResponse);
-  rpc WriteBinary16Waveform(WriteBinary16WaveformRequest) returns (WriteBinary16WaveformResponse);
-  rpc WriteWaveformComplexF64(WriteWaveformComplexF64Request) returns (WriteWaveformComplexF64Response);
-  rpc WriteComplexBinary16Waveform(WriteComplexBinary16WaveformRequest) returns (WriteComplexBinary16WaveformResponse);
-  rpc SelfCal(SelfCalRequest) returns (SelfCalResponse);
-  rpc GetSelfCalSupported(GetSelfCalSupportedRequest) returns (GetSelfCalSupportedResponse);
-  rpc GetSelfCalLastDateAndTime(GetSelfCalLastDateAndTimeRequest) returns (GetSelfCalLastDateAndTimeResponse);
-  rpc GetExtCalLastDateAndTime(GetExtCalLastDateAndTimeRequest) returns (GetExtCalLastDateAndTimeResponse);
-  rpc GetSelfCalLastTemp(GetSelfCalLastTempRequest) returns (GetSelfCalLastTempResponse);
-  rpc GetExtCalLastTemp(GetExtCalLastTempRequest) returns (GetExtCalLastTempResponse);
-  rpc GetExtCalRecommendedInterval(GetExtCalRecommendedIntervalRequest) returns (GetExtCalRecommendedIntervalResponse);
-  rpc ReadCurrentTemperature(ReadCurrentTemperatureRequest) returns (ReadCurrentTemperatureResponse);
-  rpc ConfigureCustomFIRFilterCoefficients(ConfigureCustomFIRFilterCoefficientsRequest) returns (ConfigureCustomFIRFilterCoefficientsResponse);
-  rpc GetFIRFilterCoefficients(GetFIRFilterCoefficientsRequest) returns (GetFIRFilterCoefficientsResponse);
-  rpc GetStreamEndpointHandle(GetStreamEndpointHandleRequest) returns (GetStreamEndpointHandleResponse);
+  rpc WriteNamedWaveformF64(WriteNamedWaveformF64Request) returns (WriteNamedWaveformF64Response);
+  rpc WriteNamedWaveformI16(WriteNamedWaveformI16Request) returns (WriteNamedWaveformI16Response);
   rpc WriteP2PEndpointI16(WriteP2PEndpointI16Request) returns (WriteP2PEndpointI16Response);
-  rpc ConfigureSynchronization(ConfigureSynchronizationRequest) returns (ConfigureSynchronizationResponse);
-  rpc EnableDigitalPatterning(EnableDigitalPatterningRequest) returns (EnableDigitalPatterningResponse);
-  rpc DisableDigitalPatterning(DisableDigitalPatterningRequest) returns (DisableDigitalPatterningResponse);
-  rpc EnableDigitalFilter(EnableDigitalFilterRequest) returns (EnableDigitalFilterResponse);
-  rpc DisableDigitalFilter(DisableDigitalFilterRequest) returns (DisableDigitalFilterResponse);
-  rpc EnableAnalogFilter(EnableAnalogFilterRequest) returns (EnableAnalogFilterResponse);
-  rpc DisableAnalogFilter(DisableAnalogFilterRequest) returns (DisableAnalogFilterResponse);
-  rpc ConfigureSampleClockSource(ConfigureSampleClockSourceRequest) returns (ConfigureSampleClockSourceResponse);
-  rpc ConfigureTriggerMode(ConfigureTriggerModeRequest) returns (ConfigureTriggerModeResponse);
-  rpc ImportAttributeConfigurationFile(ImportAttributeConfigurationFileRequest) returns (ImportAttributeConfigurationFileResponse);
-  rpc ExportAttributeConfigurationFile(ExportAttributeConfigurationFileRequest) returns (ExportAttributeConfigurationFileResponse);
-  rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
-  rpc ExportAttributeConfigurationBuffer(ExportAttributeConfigurationBufferRequest) returns (ExportAttributeConfigurationBufferResponse);
-  rpc SetAttributeViInt64(SetAttributeViInt64Request) returns (SetAttributeViInt64Response);
-  rpc CheckAttributeViInt64(CheckAttributeViInt64Request) returns (CheckAttributeViInt64Response);
-  rpc GetAttributeViInt64(GetAttributeViInt64Request) returns (GetAttributeViInt64Response);
-  rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
-  rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
-  rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
-  rpc SetAttributeViBoolean(SetAttributeViBooleanRequest) returns (SetAttributeViBooleanResponse);
-  rpc SetAttributeViSession(SetAttributeViSessionRequest) returns (SetAttributeViSessionResponse);
-  rpc CheckAttributeViInt32(CheckAttributeViInt32Request) returns (CheckAttributeViInt32Response);
-  rpc CheckAttributeViReal64(CheckAttributeViReal64Request) returns (CheckAttributeViReal64Response);
-  rpc CheckAttributeViString(CheckAttributeViStringRequest) returns (CheckAttributeViStringResponse);
-  rpc CheckAttributeViBoolean(CheckAttributeViBooleanRequest) returns (CheckAttributeViBooleanResponse);
-  rpc CheckAttributeViSession(CheckAttributeViSessionRequest) returns (CheckAttributeViSessionResponse);
-  rpc GetAttributeViInt32(GetAttributeViInt32Request) returns (GetAttributeViInt32Response);
-  rpc GetAttributeViReal64(GetAttributeViReal64Request) returns (GetAttributeViReal64Response);
-  rpc GetAttributeViString(GetAttributeViStringRequest) returns (GetAttributeViStringResponse);
-  rpc GetAttributeViBoolean(GetAttributeViBooleanRequest) returns (GetAttributeViBooleanResponse);
-  rpc GetAttributeViSession(GetAttributeViSessionRequest) returns (GetAttributeViSessionResponse);
-  rpc ResetAttribute(ResetAttributeRequest) returns (ResetAttributeResponse);
-  rpc ManualEnableP2PStream(ManualEnableP2PStreamRequest) returns (ManualEnableP2PStreamResponse);
-  rpc CreateWaveformFromFileHWS(CreateWaveformFromFileHWSRequest) returns (CreateWaveformFromFileHWSResponse);
+  rpc WriteScript(WriteScriptRequest) returns (WriteScriptResponse);
+  rpc WriteWaveform(WriteWaveformRequest) returns (WriteWaveformResponse);
+  rpc WriteWaveformComplexF64(WriteWaveformComplexF64Request) returns (WriteWaveformComplexF64Response);
 }
 
 enum NiFgenAttribute {
   NIFGEN_ATTRIBUTE_UNSPECIFIED = 0;
-  NIFGEN_ATTRIBUTE_OUTPUT_MODE = 1250001;
-  NIFGEN_ATTRIBUTE_OUTPUT_ENABLED = 1250003;
-  NIFGEN_ATTRIBUTE_DIGITAL_GAIN = 1150254;
-  NIFGEN_ATTRIBUTE_ANALOG_PATH = 1150222;
-  NIFGEN_ATTRIBUTE_LOAD_IMPEDANCE = 1150220;
-  NIFGEN_ATTRIBUTE_OUTPUT_IMPEDANCE = 1250004;
-  NIFGEN_ATTRIBUTE_TERMINAL_CONFIGURATION = 1150365;
-  NIFGEN_ATTRIBUTE_COMMON_MODE_OFFSET = 1150366;
-  NIFGEN_ATTRIBUTE_CHANNEL_DELAY = 1150369;
-  NIFGEN_ATTRIBUTE_ABSOLUTE_DELAY = 1150413;
-  NIFGEN_ATTRIBUTE_ANALOG_FILTER_ENABLED = 1150103;
+  NIFGEN_ATTRIBUTE_RANGE_CHECK = 1050002;
+  NIFGEN_ATTRIBUTE_QUERY_INSTRUMENT_STATUS = 1050003;
+  NIFGEN_ATTRIBUTE_CACHE = 1050004;
+  NIFGEN_ATTRIBUTE_SIMULATE = 1050005;
+  NIFGEN_ATTRIBUTE_RECORD_COERCIONS = 1050006;
+  NIFGEN_ATTRIBUTE_DRIVER_SETUP = 1050007;
+  NIFGEN_ATTRIBUTE_INTERCHANGE_CHECK = 1050021;
+  NIFGEN_ATTRIBUTE_CHANNEL_COUNT = 1050203;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_PREFIX = 1050302;
+  NIFGEN_ATTRIBUTE_IO_RESOURCE_DESCRIPTOR = 1050304;
+  NIFGEN_ATTRIBUTE_LOGICAL_NAME = 1050305;
+  NIFGEN_ATTRIBUTE_SUPPORTED_INSTRUMENT_MODELS = 1050327;
+  NIFGEN_ATTRIBUTE_GROUP_CAPABILITIES = 1050401;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_MAJOR_VERSION = 1050503;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_MINOR_VERSION = 1050504;
+  NIFGEN_ATTRIBUTE_INSTRUMENT_FIRMWARE_REVISION = 1050510;
+  NIFGEN_ATTRIBUTE_INSTRUMENT_MANUFACTURER = 1050511;
+  NIFGEN_ATTRIBUTE_INSTRUMENT_MODEL = 1050512;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_VENDOR = 1050513;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_DESCRIPTION = 1050514;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_CLASS_SPEC_MAJOR_VERSION = 1050515;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_CLASS_SPEC_MINOR_VERSION = 1050516;
+  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_REVISION = 1050551;
+  NIFGEN_ATTRIBUTE_ID_QUERY_RESPONSE = 1150001;
+  NIFGEN_ATTRIBUTE_DIGITAL_PATTERN_ENABLED = 1150101;
   NIFGEN_ATTRIBUTE_DIGITAL_FILTER_ENABLED = 1150102;
+  NIFGEN_ATTRIBUTE_ANALOG_FILTER_ENABLED = 1150103;
+  NIFGEN_ATTRIBUTE_FILTER_CORRECTION_FREQUENCY = 1150104;
+  NIFGEN_ATTRIBUTE_SYNC_DUTY_CYCLE_HIGH = 1150105;
+  NIFGEN_ATTRIBUTE_UPDATE_CLOCK_SOURCE = 1150106;
+  NIFGEN_ATTRIBUTE_REF_CLOCK_FREQUENCY = 1150107;
+  NIFGEN_ATTRIBUTE_TRIGGER_MODE = 1150108;
+  NIFGEN_ATTRIBUTE_CLOCK_MODE = 1150110;
+  NIFGEN_ATTRIBUTE_SYNCHRONIZATION = 1150111;
+  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_SOURCE = 1150112;
+  NIFGEN_ATTRIBUTE_REFERENCE_CLOCK_SOURCE = 1150113;
+  NIFGEN_ATTRIBUTE_FREQ_LIST_HANDLE = 1150208;
+  NIFGEN_ATTRIBUTE_MAX_NUM_FREQ_LISTS = 1150209;
+  NIFGEN_ATTRIBUTE_MIN_FREQ_LIST_LENGTH = 1150210;
+  NIFGEN_ATTRIBUTE_MAX_FREQ_LIST_LENGTH = 1150211;
+  NIFGEN_ATTRIBUTE_MIN_FREQ_LIST_DURATION = 1150212;
+  NIFGEN_ATTRIBUTE_MAX_FREQ_LIST_DURATION = 1150213;
+  NIFGEN_ATTRIBUTE_FREQ_LIST_DURATION_QUANTUM = 1150214;
+  NIFGEN_ATTRIBUTE_BUS_TYPE = 1150215;
+  NIFGEN_ATTRIBUTE_VIDEO_WAVEFORM_TYPE = 1150216;
   NIFGEN_ATTRIBUTE_DIGITAL_FILTER_INTERPOLATION_FACTOR = 1150218;
-  NIFGEN_ATTRIBUTE_FLATNESS_CORRECTION_ENABLED = 1150323;
+  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_DIVISOR = 1150219;
+  NIFGEN_ATTRIBUTE_LOAD_IMPEDANCE = 1150220;
+  NIFGEN_ATTRIBUTE_ANALOG_PATH = 1150222;
+  NIFGEN_ATTRIBUTE_GAIN_DAC_VALUE = 1150223;
+  NIFGEN_ATTRIBUTE_OFFSET_DAC_VALUE = 1150224;
+  NIFGEN_ATTRIBUTE_OSCILLATOR_FREQ_DAC_VALUE = 1150225;
+  NIFGEN_ATTRIBUTE_PRE_AMPLIFIER_ATTENUATION = 1150228;
+  NIFGEN_ATTRIBUTE_POST_AMPLIFIER_ATTENUATION = 1150229;
+  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_TIMEBASE_DIVISOR = 1150230;
+  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_ABSOLUTE_DELAY = 1150231;
+  NIFGEN_ATTRIBUTE_OSCILLATOR_PHASE_DAC_VALUE = 1150232;
+  NIFGEN_ATTRIBUTE_EXTERNAL_CLOCK_DELAY_BINARY_VALUE = 1150233;
   NIFGEN_ATTRIBUTE_ANALOG_DATA_MASK = 1150234;
   NIFGEN_ATTRIBUTE_ANALOG_STATIC_VALUE = 1150235;
   NIFGEN_ATTRIBUTE_DIGITAL_DATA_MASK = 1150236;
   NIFGEN_ATTRIBUTE_DIGITAL_STATIC_VALUE = 1150237;
-  NIFGEN_ATTRIBUTE_DIGITAL_PATTERN_ENABLED = 1150101;
-  NIFGEN_ATTRIBUTE_AUX_POWER_ENABLED = 1150411;
-  NIFGEN_ATTRIBUTE_IDLE_BEHAVIOR = 1150377;
-  NIFGEN_ATTRIBUTE_IDLE_VALUE = 1150378;
-  NIFGEN_ATTRIBUTE_WAIT_BEHAVIOR = 1150379;
-  NIFGEN_ATTRIBUTE_WAIT_VALUE = 1150380;
-  NIFGEN_ATTRIBUTE_ARB_GAIN = 1250202;
-  NIFGEN_ATTRIBUTE_ARB_OFFSET = 1250203;
-  NIFGEN_ATTRIBUTE_WAVEFORM_QUANTUM = 1250206;
-  NIFGEN_ATTRIBUTE_MAX_NUM_WAVEFORMS = 1250205;
-  NIFGEN_ATTRIBUTE_MIN_WAVEFORM_SIZE = 1250207;
-  NIFGEN_ATTRIBUTE_MAX_WAVEFORM_SIZE = 1250208;
-  NIFGEN_ATTRIBUTE_ARB_WAVEFORM_HANDLE = 1250201;
-  NIFGEN_ATTRIBUTE_ARB_MARKER_POSITION = 1150327;
-  NIFGEN_ATTRIBUTE_ARB_REPEAT_COUNT = 1150328;
-  NIFGEN_ATTRIBUTE_ARB_SEQUENCE_HANDLE = 1250211;
-  NIFGEN_ATTRIBUTE_MAX_NUM_SEQUENCES = 1250212;
-  NIFGEN_ATTRIBUTE_MIN_SEQUENCE_LENGTH = 1250213;
-  NIFGEN_ATTRIBUTE_MAX_SEQUENCE_LENGTH = 1250214;
-  NIFGEN_ATTRIBUTE_MAX_LOOP_COUNT = 1250215;
-  NIFGEN_ATTRIBUTE_SCRIPT_TO_GENERATE = 1150270;
+  NIFGEN_ATTRIBUTE_FUNC_BUFFER_SIZE = 1150238;
+  NIFGEN_ATTRIBUTE_FUNC_MAX_BUFFER_SIZE = 1150239;
   NIFGEN_ATTRIBUTE_FILE_TRANSFER_BLOCK_SIZE = 1150240;
   NIFGEN_ATTRIBUTE_DATA_TRANSFER_BLOCK_SIZE = 1150241;
-  NIFGEN_ATTRIBUTE_DATA_TRANSFER_MAXIMUM_BANDWIDTH = 1150373;
+  NIFGEN_ATTRIBUTE_MEMORY_SIZE = 1150242;
+  NIFGEN_ATTRIBUTE_SERIAL_NUMBER = 1150243;
   NIFGEN_ATTRIBUTE_DIRECT_DMA_ENABLED = 1150244;
   NIFGEN_ATTRIBUTE_DIRECT_DMA_WINDOW_SIZE = 1150245;
-  NIFGEN_ATTRIBUTE_DIRECT_DMA_WINDOW_ADDRESS = 1150274;
-  NIFGEN_ATTRIBUTE_STREAMING_WAVEFORM_NAME = 1150326;
-  NIFGEN_ATTRIBUTE_STREAMING_WAVEFORM_HANDLE = 1150324;
-  NIFGEN_ATTRIBUTE_STREAMING_SPACE_AVAILABLE_IN_WAVEFORM = 1150325;
-  NIFGEN_ATTRIBUTE_STREAMING_WRITE_TIMEOUT = 1150409;
-  NIFGEN_ATTRIBUTE_DATA_TRANSFER_PREFERRED_PACKET_SIZE = 1150374;
-  NIFGEN_ATTRIBUTE_DATA_TRANSFER_MAXIMUM_IN_FLIGHT_READS = 1150375;
-  NIFGEN_ATTRIBUTE_PCI_DMA_OPTIMIZATIONS_ENABLED = 1150362;
   NIFGEN_ATTRIBUTE_OSP_ENABLED = 1150246;
-  NIFGEN_ATTRIBUTE_OSP_IQ_RATE = 1150248;
   NIFGEN_ATTRIBUTE_OSP_DATA_PROCESSING_MODE = 1150247;
-  NIFGEN_ATTRIBUTE_OSP_MODE = 1150370;
-  NIFGEN_ATTRIBUTE_OSP_FREQUENCY_SHIFT = 1150371;
+  NIFGEN_ATTRIBUTE_OSP_IQ_RATE = 1150248;
   NIFGEN_ATTRIBUTE_OSP_CARRIER_ENABLED = 1150249;
   NIFGEN_ATTRIBUTE_OSP_CARRIER_FREQUENCY = 1150250;
   NIFGEN_ATTRIBUTE_OSP_CARRIER_PHASE_I = 1150251;
   NIFGEN_ATTRIBUTE_OSP_CARRIER_PHASE_Q = 1150252;
-  NIFGEN_ATTRIBUTE_OSP_COMPENSATE_FOR_FILTER_GROUP_DELAY = 1150389;
   NIFGEN_ATTRIBUTE_OSP_FIR_FILTER_TYPE = 1150253;
+  NIFGEN_ATTRIBUTE_DIGITAL_GAIN = 1150254;
   NIFGEN_ATTRIBUTE_OSP_FIR_FILTER_ENABLED = 1150255;
   NIFGEN_ATTRIBUTE_OSP_FIR_FILTER_INTERPOLATION = 1150256;
   NIFGEN_ATTRIBUTE_OSP_CIC_FILTER_ENABLED = 1150257;
@@ -228,96 +244,11 @@ enum NiFgenAttribute {
   NIFGEN_ATTRIBUTE_OSP_PRE_FILTER_OFFSET_Q = 1150267;
   NIFGEN_ATTRIBUTE_OSP_OVERFLOW_ERROR_REPORTING = 1150268;
   NIFGEN_ATTRIBUTE_OSP_OVERFLOW_STATUS = 1150269;
-  NIFGEN_ATTRIBUTE_P2P_ENABLED = 1150391;
-  NIFGEN_ATTRIBUTE_P2P_DESTINATION_CHANNELS = 1150392;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_SIZE = 1150393;
-  NIFGEN_ATTRIBUTE_P2P_SPACE_AVAILABLE_IN_ENDPOINT = 1150394;
-  NIFGEN_ATTRIBUTE_P2P_MOST_SPACE_AVAILABLE_IN_ENDPOINT = 1150395;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_COUNT = 1150396;
-  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_INTERVAL = 1150400;
-  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_INITIAL_CREDITS = 1150408;
-  NIFGEN_ATTRIBUTE_P2P_MANUAL_CONFIGURATION_ENABLED = 1150397;
-  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_ADDRESS = 1150398;
-  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_ADDRESS_TYPE = 1150399;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_ADDRESS = 1150401;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_ADDRESS_TYPE = 1150402;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_SIZE = 1150403;
-  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL = 1150410;
-  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_ADDRESS = 1150405;
-  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_ADDRESS_TYPE = 1150406;
-  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_VALUE = 1150407;
-  NIFGEN_ATTRIBUTE_FUNC_WAVEFORM = 1250101;
-  NIFGEN_ATTRIBUTE_FUNC_AMPLITUDE = 1250102;
-  NIFGEN_ATTRIBUTE_FUNC_DC_OFFSET = 1250103;
-  NIFGEN_ATTRIBUTE_FUNC_START_PHASE = 1250105;
-  NIFGEN_ATTRIBUTE_FUNC_DUTY_CYCLE_HIGH = 1250106;
-  NIFGEN_ATTRIBUTE_SYNC_DUTY_CYCLE_HIGH = 1150105;
-  NIFGEN_ATTRIBUTE_SYNC_OUT_OUTPUT_TERMINAL = 1150330;
-  NIFGEN_ATTRIBUTE_FUNC_FREQUENCY = 1250104;
-  NIFGEN_ATTRIBUTE_FUNC_BUFFER_SIZE = 1150238;
-  NIFGEN_ATTRIBUTE_FUNC_MAX_BUFFER_SIZE = 1150239;
-  NIFGEN_ATTRIBUTE_FREQ_LIST_HANDLE = 1150208;
-  NIFGEN_ATTRIBUTE_MAX_NUM_FREQ_LISTS = 1150209;
-  NIFGEN_ATTRIBUTE_MIN_FREQ_LIST_LENGTH = 1150210;
-  NIFGEN_ATTRIBUTE_MAX_FREQ_LIST_LENGTH = 1150211;
-  NIFGEN_ATTRIBUTE_MIN_FREQ_LIST_DURATION = 1150212;
-  NIFGEN_ATTRIBUTE_MAX_FREQ_LIST_DURATION = 1150213;
-  NIFGEN_ATTRIBUTE_FREQ_LIST_DURATION_QUANTUM = 1150214;
-  NIFGEN_ATTRIBUTE_REFERENCE_CLOCK_SOURCE = 1150113;
-  NIFGEN_ATTRIBUTE_REF_CLOCK_FREQUENCY = 1150107;
-  NIFGEN_ATTRIBUTE_EXPORTED_REFERENCE_CLOCK_OUTPUT_TERMINAL = 1150321;
-  NIFGEN_ATTRIBUTE_EXPORTED_ONBOARD_REFERENCE_CLOCK_OUTPUT_TERMINAL = 1150322;
-  NIFGEN_ATTRIBUTE_ARB_SAMPLE_RATE = 1250204;
-  NIFGEN_ATTRIBUTE_CLOCK_MODE = 1150110;
-  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_SOURCE = 1150112;
-  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_OUTPUT_TERMINAL = 1150320;
-  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_DIVISOR = 1150219;
-  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_TIMEBASE_SOURCE = 1150367;
-  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_TIMEBASE_RATE = 1150368;
-  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_TIMEBASE_OUTPUT_TERMINAL = 1150329;
-  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_TIMEBASE_DIVISOR = 1150230;
-  NIFGEN_ATTRIBUTE_EXTERNAL_SAMPLE_CLOCK_MULTIPLIER = 1150376;
-  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_ABSOLUTE_DELAY = 1150231;
-  NIFGEN_ATTRIBUTE_OSCILLATOR_PHASE_DAC_VALUE = 1150232;
-  NIFGEN_ATTRIBUTE_EXTERNAL_CLOCK_DELAY_BINARY_VALUE = 1150233;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_TERMINAL = 1150312;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_BEHAVIOR = 1150342;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_POLARITY = 1150313;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_WIDTH = 1150340;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_WIDTH_UNITS = 1150341;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_TOGGLE_INITIAL_STATE = 1150343;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_DELAY = 1150354;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_DELAY_UNITS = 1150355;
-  NIFGEN_ATTRIBUTE_ALL_MARKER_EVENTS_LIVE_STATUS = 1150344;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_LIVE_STATUS = 1150345;
-  NIFGEN_ATTRIBUTE_ALL_MARKER_EVENTS_LATCHED_STATUS = 1150349;
-  NIFGEN_ATTRIBUTE_MARKER_EVENT_LATCHED_STATUS = 1150350;
-  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_DATA_BIT_NUMBER = 1150337;
-  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_LEVEL_POLARITY = 1150338;
-  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_OUTPUT_TERMINAL = 1150339;
-  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_OUTPUT_TERMINAL = 1150310;
-  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_LEVEL_ACTIVE_LEVEL = 1150311;
-  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_LIVE_STATUS = 1150348;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_OUTPUT_TERMINAL = 1150314;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_OUTPUT_BEHAVIOR = 1150331;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_LEVEL_ACTIVE_LEVEL = 1150316;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_POLARITY = 1150318;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_WIDTH_UNITS = 1150333;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_WIDTH = 1150335;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_DELAY = 1150356;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_DELAY_UNITS = 1150357;
-  NIFGEN_ATTRIBUTE_STARTED_EVENT_LATCHED_STATUS = 1150352;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_OUTPUT_TERMINAL = 1150315;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_OUTPUT_BEHAVIOR = 1150332;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_LEVEL_ACTIVE_LEVEL = 1150317;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_POLARITY = 1150319;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_WIDTH_UNITS = 1150334;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_WIDTH = 1150336;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_DELAY = 1150358;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_DELAY_UNITS = 1150359;
-  NIFGEN_ATTRIBUTE_DONE_EVENT_LATCHED_STATUS = 1150351;
-  NIFGEN_ATTRIBUTE_TRIGGER_MODE = 1150108;
-  NIFGEN_ATTRIBUTE_BURST_COUNT = 1250350;
+  NIFGEN_ATTRIBUTE_SCRIPT_TO_GENERATE = 1150270;
+  NIFGEN_ATTRIBUTE_MARKER_EVENTS_COUNT = 1150271;
+  NIFGEN_ATTRIBUTE_SCRIPT_TRIGGERS_COUNT = 1150272;
+  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENTS_COUNT = 1150273;
+  NIFGEN_ATTRIBUTE_DIRECT_DMA_WINDOW_ADDRESS = 1150274;
   NIFGEN_ATTRIBUTE_START_TRIGGER_TYPE = 1150280;
   NIFGEN_ATTRIBUTE_DIGITAL_EDGE_START_TRIGGER_SOURCE = 1150281;
   NIFGEN_ATTRIBUTE_DIGITAL_EDGE_START_TRIGGER_EDGE = 1150282;
@@ -328,99 +259,122 @@ enum NiFgenAttribute {
   NIFGEN_ATTRIBUTE_DIGITAL_LEVEL_SCRIPT_TRIGGER_SOURCE = 1150293;
   NIFGEN_ATTRIBUTE_DIGITAL_LEVEL_SCRIPT_TRIGGER_ACTIVE_LEVEL = 1150294;
   NIFGEN_ATTRIBUTE_EXPORTED_SCRIPT_TRIGGER_OUTPUT_TERMINAL = 1150295;
-  NIFGEN_ATTRIBUTE_BUS_TYPE = 1150215;
-  NIFGEN_ATTRIBUTE_MEMORY_SIZE = 1150242;
-  NIFGEN_ATTRIBUTE_SERIAL_NUMBER = 1150243;
-  NIFGEN_ATTRIBUTE_MARKER_EVENTS_COUNT = 1150271;
-  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENTS_COUNT = 1150273;
-  NIFGEN_ATTRIBUTE_SCRIPT_TRIGGERS_COUNT = 1150272;
-  NIFGEN_ATTRIBUTE_VIDEO_WAVEFORM_TYPE = 1150216;
-  NIFGEN_ATTRIBUTE_FPGA_BITFILE_PATH = 1150412;
-  NIFGEN_ATTRIBUTE_FILTER_CORRECTION_FREQUENCY = 1150104;
-  NIFGEN_ATTRIBUTE_TRIGGER_SOURCE = 1250302;
-  NIFGEN_ATTRIBUTE_SYNCHRONIZATION = 1150111;
-  NIFGEN_ATTRIBUTE_ID_QUERY_RESPONSE = 1150001;
-  NIFGEN_ATTRIBUTE_GAIN_DAC_VALUE = 1150223;
-  NIFGEN_ATTRIBUTE_OFFSET_DAC_VALUE = 1150224;
-  NIFGEN_ATTRIBUTE_OSCILLATOR_FREQ_DAC_VALUE = 1150225;
-  NIFGEN_ATTRIBUTE_PRE_AMPLIFIER_ATTENUATION = 1150228;
-  NIFGEN_ATTRIBUTE_POST_AMPLIFIER_ATTENUATION = 1150229;
-  NIFGEN_ATTRIBUTE_CACHE = 1050004;
-  NIFGEN_ATTRIBUTE_RANGE_CHECK = 1050002;
-  NIFGEN_ATTRIBUTE_QUERY_INSTRUMENT_STATUS = 1050003;
-  NIFGEN_ATTRIBUTE_RECORD_COERCIONS = 1050006;
-  NIFGEN_ATTRIBUTE_SIMULATE = 1050005;
-  NIFGEN_ATTRIBUTE_INTERCHANGE_CHECK = 1050021;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_DESCRIPTION = 1050514;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_PREFIX = 1050302;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_VENDOR = 1050513;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_REVISION = 1050551;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_CLASS_SPEC_MAJOR_VERSION = 1050515;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_CLASS_SPEC_MINOR_VERSION = 1050516;
-  NIFGEN_ATTRIBUTE_SUPPORTED_INSTRUMENT_MODELS = 1050327;
-  NIFGEN_ATTRIBUTE_GROUP_CAPABILITIES = 1050401;
-  NIFGEN_ATTRIBUTE_CHANNEL_COUNT = 1050203;
-  NIFGEN_ATTRIBUTE_INSTRUMENT_MANUFACTURER = 1050511;
-  NIFGEN_ATTRIBUTE_INSTRUMENT_MODEL = 1050512;
-  NIFGEN_ATTRIBUTE_INSTRUMENT_FIRMWARE_REVISION = 1050510;
+  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_OUTPUT_TERMINAL = 1150310;
+  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_LEVEL_ACTIVE_LEVEL = 1150311;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_TERMINAL = 1150312;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_POLARITY = 1150313;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_OUTPUT_TERMINAL = 1150314;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_OUTPUT_TERMINAL = 1150315;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_LEVEL_ACTIVE_LEVEL = 1150316;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_LEVEL_ACTIVE_LEVEL = 1150317;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_POLARITY = 1150318;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_POLARITY = 1150319;
+  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_OUTPUT_TERMINAL = 1150320;
+  NIFGEN_ATTRIBUTE_EXPORTED_REFERENCE_CLOCK_OUTPUT_TERMINAL = 1150321;
+  NIFGEN_ATTRIBUTE_EXPORTED_ONBOARD_REFERENCE_CLOCK_OUTPUT_TERMINAL = 1150322;
+  NIFGEN_ATTRIBUTE_FLATNESS_CORRECTION_ENABLED = 1150323;
+  NIFGEN_ATTRIBUTE_STREAMING_WAVEFORM_HANDLE = 1150324;
+  NIFGEN_ATTRIBUTE_STREAMING_SPACE_AVAILABLE_IN_WAVEFORM = 1150325;
+  NIFGEN_ATTRIBUTE_STREAMING_WAVEFORM_NAME = 1150326;
+  NIFGEN_ATTRIBUTE_ARB_MARKER_POSITION = 1150327;
+  NIFGEN_ATTRIBUTE_ARB_REPEAT_COUNT = 1150328;
+  NIFGEN_ATTRIBUTE_EXPORTED_SAMPLE_CLOCK_TIMEBASE_OUTPUT_TERMINAL = 1150329;
+  NIFGEN_ATTRIBUTE_SYNC_OUT_OUTPUT_TERMINAL = 1150330;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_OUTPUT_BEHAVIOR = 1150331;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_OUTPUT_BEHAVIOR = 1150332;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_WIDTH_UNITS = 1150333;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_WIDTH_UNITS = 1150334;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_PULSE_WIDTH = 1150335;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_PULSE_WIDTH = 1150336;
+  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_DATA_BIT_NUMBER = 1150337;
+  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_LEVEL_POLARITY = 1150338;
+  NIFGEN_ATTRIBUTE_DATA_MARKER_EVENT_OUTPUT_TERMINAL = 1150339;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_WIDTH = 1150340;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_PULSE_WIDTH_UNITS = 1150341;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_BEHAVIOR = 1150342;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_TOGGLE_INITIAL_STATE = 1150343;
+  NIFGEN_ATTRIBUTE_ALL_MARKER_EVENTS_LIVE_STATUS = 1150344;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_LIVE_STATUS = 1150345;
+  NIFGEN_ATTRIBUTE_READY_FOR_START_EVENT_LIVE_STATUS = 1150348;
+  NIFGEN_ATTRIBUTE_ALL_MARKER_EVENTS_LATCHED_STATUS = 1150349;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_LATCHED_STATUS = 1150350;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_LATCHED_STATUS = 1150351;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_LATCHED_STATUS = 1150352;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_DELAY = 1150354;
+  NIFGEN_ATTRIBUTE_MARKER_EVENT_DELAY_UNITS = 1150355;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_DELAY = 1150356;
+  NIFGEN_ATTRIBUTE_STARTED_EVENT_DELAY_UNITS = 1150357;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_DELAY = 1150358;
+  NIFGEN_ATTRIBUTE_DONE_EVENT_DELAY_UNITS = 1150359;
+  NIFGEN_ATTRIBUTE_PCI_DMA_OPTIMIZATIONS_ENABLED = 1150362;
+  NIFGEN_ATTRIBUTE_TERMINAL_CONFIGURATION = 1150365;
+  NIFGEN_ATTRIBUTE_COMMON_MODE_OFFSET = 1150366;
+  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_TIMEBASE_SOURCE = 1150367;
+  NIFGEN_ATTRIBUTE_SAMPLE_CLOCK_TIMEBASE_RATE = 1150368;
+  NIFGEN_ATTRIBUTE_CHANNEL_DELAY = 1150369;
+  NIFGEN_ATTRIBUTE_OSP_MODE = 1150370;
+  NIFGEN_ATTRIBUTE_OSP_FREQUENCY_SHIFT = 1150371;
+  NIFGEN_ATTRIBUTE_DATA_TRANSFER_MAXIMUM_BANDWIDTH = 1150373;
+  NIFGEN_ATTRIBUTE_DATA_TRANSFER_PREFERRED_PACKET_SIZE = 1150374;
+  NIFGEN_ATTRIBUTE_DATA_TRANSFER_MAXIMUM_IN_FLIGHT_READS = 1150375;
+  NIFGEN_ATTRIBUTE_EXTERNAL_SAMPLE_CLOCK_MULTIPLIER = 1150376;
+  NIFGEN_ATTRIBUTE_IDLE_BEHAVIOR = 1150377;
+  NIFGEN_ATTRIBUTE_IDLE_VALUE = 1150378;
+  NIFGEN_ATTRIBUTE_WAIT_BEHAVIOR = 1150379;
+  NIFGEN_ATTRIBUTE_WAIT_VALUE = 1150380;
+  NIFGEN_ATTRIBUTE_OSP_COMPENSATE_FOR_FILTER_GROUP_DELAY = 1150389;
   NIFGEN_ATTRIBUTE_MODULE_REVISION = 1150390;
-  NIFGEN_ATTRIBUTE_IO_RESOURCE_DESCRIPTOR = 1050304;
-  NIFGEN_ATTRIBUTE_LOGICAL_NAME = 1050305;
-  NIFGEN_ATTRIBUTE_DRIVER_SETUP = 1050007;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_MAJOR_VERSION = 1050503;
-  NIFGEN_ATTRIBUTE_SPECIFIC_DRIVER_MINOR_VERSION = 1050504;
-  NIFGEN_ATTRIBUTE_UPDATE_CLOCK_SOURCE = 1150106;
+  NIFGEN_ATTRIBUTE_P2P_ENABLED = 1150391;
+  NIFGEN_ATTRIBUTE_P2P_DESTINATION_CHANNELS = 1150392;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_SIZE = 1150393;
+  NIFGEN_ATTRIBUTE_P2P_SPACE_AVAILABLE_IN_ENDPOINT = 1150394;
+  NIFGEN_ATTRIBUTE_P2P_MOST_SPACE_AVAILABLE_IN_ENDPOINT = 1150395;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_COUNT = 1150396;
+  NIFGEN_ATTRIBUTE_P2P_MANUAL_CONFIGURATION_ENABLED = 1150397;
+  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_ADDRESS = 1150398;
+  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_ADDRESS_TYPE = 1150399;
+  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_INTERVAL = 1150400;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_ADDRESS = 1150401;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_ADDRESS_TYPE = 1150402;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_WINDOW_SIZE = 1150403;
+  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_ADDRESS = 1150405;
+  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_ADDRESS_TYPE = 1150406;
+  NIFGEN_ATTRIBUTE_P2P_DONE_NOTIFICATION_VALUE = 1150407;
+  NIFGEN_ATTRIBUTE_P2P_DATA_TRANSFER_PERMISSION_INITIAL_CREDITS = 1150408;
+  NIFGEN_ATTRIBUTE_STREAMING_WRITE_TIMEOUT = 1150409;
+  NIFGEN_ATTRIBUTE_P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL = 1150410;
+  NIFGEN_ATTRIBUTE_AUX_POWER_ENABLED = 1150411;
+  NIFGEN_ATTRIBUTE_FPGA_BITFILE_PATH = 1150412;
+  NIFGEN_ATTRIBUTE_ABSOLUTE_DELAY = 1150413;
+  NIFGEN_ATTRIBUTE_OUTPUT_MODE = 1250001;
+  NIFGEN_ATTRIBUTE_OUTPUT_ENABLED = 1250003;
+  NIFGEN_ATTRIBUTE_OUTPUT_IMPEDANCE = 1250004;
+  NIFGEN_ATTRIBUTE_FUNC_WAVEFORM = 1250101;
+  NIFGEN_ATTRIBUTE_FUNC_AMPLITUDE = 1250102;
+  NIFGEN_ATTRIBUTE_FUNC_DC_OFFSET = 1250103;
+  NIFGEN_ATTRIBUTE_FUNC_FREQUENCY = 1250104;
+  NIFGEN_ATTRIBUTE_FUNC_START_PHASE = 1250105;
+  NIFGEN_ATTRIBUTE_FUNC_DUTY_CYCLE_HIGH = 1250106;
+  NIFGEN_ATTRIBUTE_ARB_WAVEFORM_HANDLE = 1250201;
+  NIFGEN_ATTRIBUTE_ARB_GAIN = 1250202;
+  NIFGEN_ATTRIBUTE_ARB_OFFSET = 1250203;
+  NIFGEN_ATTRIBUTE_ARB_SAMPLE_RATE = 1250204;
+  NIFGEN_ATTRIBUTE_MAX_NUM_WAVEFORMS = 1250205;
+  NIFGEN_ATTRIBUTE_WAVEFORM_QUANTUM = 1250206;
+  NIFGEN_ATTRIBUTE_MIN_WAVEFORM_SIZE = 1250207;
+  NIFGEN_ATTRIBUTE_MAX_WAVEFORM_SIZE = 1250208;
+  NIFGEN_ATTRIBUTE_ARB_SEQUENCE_HANDLE = 1250211;
+  NIFGEN_ATTRIBUTE_MAX_NUM_SEQUENCES = 1250212;
+  NIFGEN_ATTRIBUTE_MIN_SEQUENCE_LENGTH = 1250213;
+  NIFGEN_ATTRIBUTE_MAX_SEQUENCE_LENGTH = 1250214;
+  NIFGEN_ATTRIBUTE_MAX_LOOP_COUNT = 1250215;
+  NIFGEN_ATTRIBUTE_TRIGGER_SOURCE = 1250302;
+  NIFGEN_ATTRIBUTE_BURST_COUNT = 1250350;
 }
 
-enum OutputMode {
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_FUNC = 0;
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB = 1;
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SEQ = 2;
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_FREQ_LIST = 101;
-  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SCRIPT = 102;
-}
-
-enum Waveform {
-  WAVEFORM_UNSPECIFIED = 0;
-  WAVEFORM_NIFGEN_VAL_WFM_SINE = 1;
-  WAVEFORM_NIFGEN_VAL_WFM_SQUARE = 2;
-  WAVEFORM_NIFGEN_VAL_WFM_TRIANGLE = 3;
-  WAVEFORM_NIFGEN_VAL_WFM_RAMP_UP = 4;
-  WAVEFORM_NIFGEN_VAL_WFM_RAMP_DOWN = 5;
-  WAVEFORM_NIFGEN_VAL_WFM_DC = 6;
-  WAVEFORM_NIFGEN_VAL_WFM_NOISE = 101;
-  WAVEFORM_NIFGEN_VAL_WFM_USER = 102;
-}
-
-enum Signal {
-  SIGNAL_UNSPECIFIED = 0;
-  SIGNAL_NIFGEN_VAL_ONBOARD_REFERENCE_CLOCK = 1019;
-  SIGNAL_NIFGEN_VAL_SYNC_OUT = 1002;
-  SIGNAL_NIFGEN_VAL_START_TRIGGER = 1004;
-  SIGNAL_NIFGEN_VAL_MARKER_EVENT = 1001;
-  SIGNAL_NIFGEN_VAL_SAMPLE_CLOCK_TIMEBASE = 1006;
-  SIGNAL_NIFGEN_VAL_SYNCHRONIZATION = 1007;
-  SIGNAL_NIFGEN_VAL_SAMPLE_CLOCK = 101;
-  SIGNAL_NIFGEN_VAL_REFERENCE_CLOCK = 102;
-  SIGNAL_NIFGEN_VAL_SCRIPT_TRIGGER = 103;
-  SIGNAL_NIFGEN_VAL_READY_FOR_START_EVENT = 105;
-  SIGNAL_NIFGEN_VAL_STARTED_EVENT = 106;
-  SIGNAL_NIFGEN_VAL_DONE_EVENT = 107;
-  SIGNAL_NIFGEN_VAL_DATA_MARKER_EVENT = 108;
-}
-
-enum StartTriggerDigitalEdgeEdge {
-  START_TRIGGER_DIGITAL_EDGE_EDGE_UNSPECIFIED = 0;
-  START_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_RISING_EDGE = 101;
-  START_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_FALLING_EDGE = 102;
-}
-
-enum TriggerMode {
-  TRIGGER_MODE_UNSPECIFIED = 0;
-  TRIGGER_MODE_NIFGEN_VAL_SINGLE = 1;
-  TRIGGER_MODE_NIFGEN_VAL_CONTINUOUS = 2;
-  TRIGGER_MODE_NIFGEN_VAL_STEPPED = 3;
-  TRIGGER_MODE_NIFGEN_VAL_BURST = 4;
+enum ByteOrder {
+  BYTE_ORDER_NIFGEN_VAL_LITTLE_ENDIAN = 0;
+  BYTE_ORDER_NIFGEN_VAL_BIG_ENDIAN = 1;
 }
 
 enum ClockMode {
@@ -429,9 +383,9 @@ enum ClockMode {
   CLOCK_MODE_NIFGEN_VAL_AUTOMATIC = 2;
 }
 
-enum RelativeTo {
-  RELATIVE_TO_NIFGEN_VAL_WAVEFORM_POSITION_START = 0;
-  RELATIVE_TO_NIFGEN_VAL_WAVEFORM_POSITION_CURRENT = 1;
+enum FrequencyListOptions {
+  FREQUENCY_LIST_OPTIONS_UNSPECIFIED = 0;
+  FREQUENCY_LIST_OPTIONS_NIFGEN_VAL_ALL_FLISTS = -1;
 }
 
 enum HardwareState {
@@ -440,83 +394,6 @@ enum HardwareState {
   HARDWARE_STATE_NIFGEN_VAL_RUNNING = 200;
   HARDWARE_STATE_NIFGEN_VAL_DONE = 600;
   HARDWARE_STATE_NIFGEN_VAL_HARDWARE_ERROR = 1000;
-}
-
-enum ByteOrder {
-  BYTE_ORDER_NIFGEN_VAL_LITTLE_ENDIAN = 0;
-  BYTE_ORDER_NIFGEN_VAL_BIG_ENDIAN = 1;
-}
-
-enum TriggerWhen {
-  TRIGGER_WHEN_UNSPECIFIED = 0;
-  TRIGGER_WHEN_NIFGEN_VAL_ACTIVE_HIGH = 101;
-  TRIGGER_WHEN_NIFGEN_VAL_ACTIVE_LOW = 102;
-}
-
-enum ScriptTriggerDigitalEdgeEdge {
-  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_UNSPECIFIED = 0;
-  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_RISING_EDGE = 101;
-  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_FALLING_EDGE = 102;
-}
-
-enum Trigger {
-  TRIGGER_UNSPECIFIED = 0;
-  TRIGGER_NIFGEN_VAL_START_TRIGGER = 1004;
-  TRIGGER_NIFGEN_VAL_SCRIPT_TRIGGER = 103;
-}
-
-enum FrequencyListOptions {
-  FREQUENCY_LIST_OPTIONS_UNSPECIFIED = 0;
-  FREQUENCY_LIST_OPTIONS_NIFGEN_VAL_ALL_FLISTS = -1;
-}
-
-enum RouteSignalFrom {
-  ROUTE_SIGNAL_FROM_UNSPECIFIED = 0;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_MARKER = 1001;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SYNC_OUT = 1002;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_OUT_START_TRIGGER = 1004;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_BOARD_CLOCK = 1006;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SYNCHRONIZATION = 1007;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SOFTWARE_TRIG = 2;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_REF_OUT = 1008;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_CLOCK_OUT = 1009;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_PXI_STAR = 131;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_PFI_0 = 1011;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_0 = 141;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_1 = 142;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_2 = 143;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_3 = 144;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_4 = 145;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_5 = 146;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_6 = 147;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_7 = 1010;
-  ROUTE_SIGNAL_FROM_NIFGEN_VAL_ONBOARD_REFERENCE_CLOCK = 1019;
-}
-
-enum RouteSignalTo {
-  ROUTE_SIGNAL_TO_UNSPECIFIED = 0;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_0 = 141;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_1 = 142;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_2 = 143;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_3 = 144;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_4 = 145;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_5 = 146;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_6 = 147;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_7 = 1010;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_REF_OUT = 1008;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_PFI_0 = 1011;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_PFI_1 = 1012;
-  ROUTE_SIGNAL_TO_NIFGEN_VAL_PXI_STAR = 131;
-}
-
-enum SequenceHandle {
-  SEQUENCE_HANDLE_UNSPECIFIED = 0;
-  SEQUENCE_HANDLE_NIFGEN_VAL_ALL_SEQUENCES = -1;
-}
-
-enum WaveformHandle {
-  WAVEFORM_HANDLE_UNSPECIFIED = 0;
-  WAVEFORM_HANDLE_NIFGEN_VAL_ALL_WAVEFORMS = -1;
 }
 
 enum NiFgenInt32AttributeValues {
@@ -747,6 +624,1078 @@ enum NiFgenStringAttributeValuesMapped {
   NIFGEN_STRING_SAMPLE_CLOCK_TIMEBASE_SOURCE_VAL_ONBOARD_CLOCK = 19;
 }
 
+enum OutputMode {
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_FUNC = 0;
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB = 1;
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SEQ = 2;
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_FREQ_LIST = 101;
+  OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SCRIPT = 102;
+}
+
+enum RelativeTo {
+  RELATIVE_TO_NIFGEN_VAL_WAVEFORM_POSITION_START = 0;
+  RELATIVE_TO_NIFGEN_VAL_WAVEFORM_POSITION_CURRENT = 1;
+}
+
+enum RouteSignalFrom {
+  ROUTE_SIGNAL_FROM_UNSPECIFIED = 0;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_MARKER = 1001;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SYNC_OUT = 1002;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_OUT_START_TRIGGER = 1004;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_BOARD_CLOCK = 1006;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SYNCHRONIZATION = 1007;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_SOFTWARE_TRIG = 2;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_REF_OUT = 1008;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_CLOCK_OUT = 1009;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_PXI_STAR = 131;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_PFI_0 = 1011;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_0 = 141;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_1 = 142;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_2 = 143;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_3 = 144;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_4 = 145;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_5 = 146;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_6 = 147;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_RTSI_7 = 1010;
+  ROUTE_SIGNAL_FROM_NIFGEN_VAL_ONBOARD_REFERENCE_CLOCK = 1019;
+}
+
+enum RouteSignalTo {
+  ROUTE_SIGNAL_TO_UNSPECIFIED = 0;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_0 = 141;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_1 = 142;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_2 = 143;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_3 = 144;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_4 = 145;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_5 = 146;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_6 = 147;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_RTSI_7 = 1010;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_REF_OUT = 1008;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_PFI_0 = 1011;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_PFI_1 = 1012;
+  ROUTE_SIGNAL_TO_NIFGEN_VAL_PXI_STAR = 131;
+}
+
+enum ScriptTriggerDigitalEdgeEdge {
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_UNSPECIFIED = 0;
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_RISING_EDGE = 101;
+  SCRIPT_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_FALLING_EDGE = 102;
+}
+
+enum SequenceHandle {
+  SEQUENCE_HANDLE_UNSPECIFIED = 0;
+  SEQUENCE_HANDLE_NIFGEN_VAL_ALL_SEQUENCES = -1;
+}
+
+enum Signal {
+  SIGNAL_UNSPECIFIED = 0;
+  SIGNAL_NIFGEN_VAL_ONBOARD_REFERENCE_CLOCK = 1019;
+  SIGNAL_NIFGEN_VAL_SYNC_OUT = 1002;
+  SIGNAL_NIFGEN_VAL_START_TRIGGER = 1004;
+  SIGNAL_NIFGEN_VAL_MARKER_EVENT = 1001;
+  SIGNAL_NIFGEN_VAL_SAMPLE_CLOCK_TIMEBASE = 1006;
+  SIGNAL_NIFGEN_VAL_SYNCHRONIZATION = 1007;
+  SIGNAL_NIFGEN_VAL_SAMPLE_CLOCK = 101;
+  SIGNAL_NIFGEN_VAL_REFERENCE_CLOCK = 102;
+  SIGNAL_NIFGEN_VAL_SCRIPT_TRIGGER = 103;
+  SIGNAL_NIFGEN_VAL_READY_FOR_START_EVENT = 105;
+  SIGNAL_NIFGEN_VAL_STARTED_EVENT = 106;
+  SIGNAL_NIFGEN_VAL_DONE_EVENT = 107;
+  SIGNAL_NIFGEN_VAL_DATA_MARKER_EVENT = 108;
+}
+
+enum StartTriggerDigitalEdgeEdge {
+  START_TRIGGER_DIGITAL_EDGE_EDGE_UNSPECIFIED = 0;
+  START_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_RISING_EDGE = 101;
+  START_TRIGGER_DIGITAL_EDGE_EDGE_NIFGEN_VAL_FALLING_EDGE = 102;
+}
+
+enum Trigger {
+  TRIGGER_UNSPECIFIED = 0;
+  TRIGGER_NIFGEN_VAL_START_TRIGGER = 1004;
+  TRIGGER_NIFGEN_VAL_SCRIPT_TRIGGER = 103;
+}
+
+enum TriggerMode {
+  TRIGGER_MODE_UNSPECIFIED = 0;
+  TRIGGER_MODE_NIFGEN_VAL_SINGLE = 1;
+  TRIGGER_MODE_NIFGEN_VAL_CONTINUOUS = 2;
+  TRIGGER_MODE_NIFGEN_VAL_STEPPED = 3;
+  TRIGGER_MODE_NIFGEN_VAL_BURST = 4;
+}
+
+enum TriggerWhen {
+  TRIGGER_WHEN_UNSPECIFIED = 0;
+  TRIGGER_WHEN_NIFGEN_VAL_ACTIVE_HIGH = 101;
+  TRIGGER_WHEN_NIFGEN_VAL_ACTIVE_LOW = 102;
+}
+
+enum Waveform {
+  WAVEFORM_UNSPECIFIED = 0;
+  WAVEFORM_NIFGEN_VAL_WFM_SINE = 1;
+  WAVEFORM_NIFGEN_VAL_WFM_SQUARE = 2;
+  WAVEFORM_NIFGEN_VAL_WFM_TRIANGLE = 3;
+  WAVEFORM_NIFGEN_VAL_WFM_RAMP_UP = 4;
+  WAVEFORM_NIFGEN_VAL_WFM_RAMP_DOWN = 5;
+  WAVEFORM_NIFGEN_VAL_WFM_DC = 6;
+  WAVEFORM_NIFGEN_VAL_WFM_NOISE = 101;
+  WAVEFORM_NIFGEN_VAL_WFM_USER = 102;
+}
+
+enum WaveformHandle {
+  WAVEFORM_HANDLE_UNSPECIFIED = 0;
+  WAVEFORM_HANDLE_NIFGEN_VAL_ALL_WAVEFORMS = -1;
+}
+
+message AbortGenerationRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message AbortGenerationResponse {
+  int32 status = 1;
+}
+
+message AdjustSampleClockRelativeDelayRequest {
+  nidevice_grpc.Session vi = 1;
+  double adjustment_time = 2;
+}
+
+message AdjustSampleClockRelativeDelayResponse {
+  int32 status = 1;
+}
+
+message AllocateNamedWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string waveform_name = 3;
+  sint32 waveform_size = 4;
+}
+
+message AllocateNamedWaveformResponse {
+  int32 status = 1;
+}
+
+message AllocateWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 waveform_size = 3;
+}
+
+message AllocateWaveformResponse {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message CheckAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  bool attribute_value = 4;
+}
+
+message CheckAttributeViBooleanResponse {
+  int32 status = 1;
+}
+
+message CheckAttributeViInt32Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFgenInt32AttributeValues attribute_value = 4;
+    sint32 attribute_value_raw = 5;
+  }
+}
+
+message CheckAttributeViInt32Response {
+  int32 status = 1;
+}
+
+message CheckAttributeViInt64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  int64 attribute_value_raw = 4;
+}
+
+message CheckAttributeViInt64Response {
+  int32 status = 1;
+}
+
+message CheckAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFgenReal64AttributeValues attribute_value = 4;
+    double attribute_value_raw = 5;
+  }
+}
+
+message CheckAttributeViReal64Response {
+  int32 status = 1;
+}
+
+message CheckAttributeViSessionRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  nidevice_grpc.Session attribute_value = 4;
+}
+
+message CheckAttributeViSessionResponse {
+  int32 status = 1;
+}
+
+message CheckAttributeViStringRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    string attribute_value_raw = 4;
+    NiFgenStringAttributeValuesMapped attribute_value_mapped = 5;
+  }
+}
+
+message CheckAttributeViStringResponse {
+  int32 status = 1;
+}
+
+message ClearArbMemoryRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ClearArbMemoryResponse {
+  int32 status = 1;
+}
+
+message ClearArbSequenceRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof sequence_handle_enum {
+    SequenceHandle sequence_handle = 2;
+    sint32 sequence_handle_raw = 3;
+  }
+}
+
+message ClearArbSequenceResponse {
+  int32 status = 1;
+}
+
+message ClearArbWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof waveform_handle_enum {
+    WaveformHandle waveform_handle = 2;
+    sint32 waveform_handle_raw = 3;
+  }
+}
+
+message ClearArbWaveformResponse {
+  int32 status = 1;
+}
+
+message ClearErrorRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ClearErrorResponse {
+  int32 status = 1;
+}
+
+message ClearFreqListRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof frequency_list_handle_enum {
+    FrequencyListOptions frequency_list_handle = 2;
+    sint32 frequency_list_handle_raw = 3;
+  }
+}
+
+message ClearFreqListResponse {
+  int32 status = 1;
+}
+
+message ClearInterchangeWarningsRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ClearInterchangeWarningsResponse {
+  int32 status = 1;
+}
+
+message ClearUserStandardWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message ClearUserStandardWaveformResponse {
+  int32 status = 1;
+}
+
+message CloseRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message CloseResponse {
+  int32 status = 1;
+}
+
+message CommitRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message CommitResponse {
+  int32 status = 1;
+}
+
+message ConfigureAmplitudeRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  double amplitude = 3;
+}
+
+message ConfigureAmplitudeResponse {
+  int32 status = 1;
+}
+
+message ConfigureArbSequenceRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 sequence_handle = 3;
+  double gain = 4;
+  double offset = 5;
+}
+
+message ConfigureArbSequenceResponse {
+  int32 status = 1;
+}
+
+message ConfigureArbWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 waveform_handle = 3;
+  double gain = 4;
+  double offset = 5;
+}
+
+message ConfigureArbWaveformResponse {
+  int32 status = 1;
+}
+
+message ConfigureChannelsRequest {
+  nidevice_grpc.Session vi = 1;
+  string channels = 2;
+}
+
+message ConfigureChannelsResponse {
+  int32 status = 1;
+}
+
+message ConfigureClockModeRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof clock_mode_enum {
+    ClockMode clock_mode = 2;
+    sint32 clock_mode_raw = 3;
+  }
+}
+
+message ConfigureClockModeResponse {
+  int32 status = 1;
+}
+
+message ConfigureCustomFIRFilterCoefficientsRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  repeated double coefficients_array = 3;
+}
+
+message ConfigureCustomFIRFilterCoefficientsResponse {
+  int32 status = 1;
+}
+
+message ConfigureDigitalEdgeScriptTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string trigger_id = 2;
+  string source = 3;
+  oneof edge_enum {
+    ScriptTriggerDigitalEdgeEdge edge = 4;
+    sint32 edge_raw = 5;
+  }
+}
+
+message ConfigureDigitalEdgeScriptTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureDigitalEdgeStartTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string source = 2;
+  oneof edge_enum {
+    StartTriggerDigitalEdgeEdge edge = 3;
+    sint32 edge_raw = 4;
+  }
+}
+
+message ConfigureDigitalEdgeStartTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureDigitalLevelScriptTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string trigger_id = 2;
+  string source = 3;
+  oneof trigger_when_enum {
+    TriggerWhen trigger_when = 4;
+    sint32 trigger_when_raw = 5;
+  }
+}
+
+message ConfigureDigitalLevelScriptTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureFreqListRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 frequency_list_handle = 3;
+  double amplitude = 4;
+  double dc_offset = 5;
+  double start_phase = 6;
+}
+
+message ConfigureFreqListResponse {
+  int32 status = 1;
+}
+
+message ConfigureFrequencyRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  double frequency = 3;
+}
+
+message ConfigureFrequencyResponse {
+  int32 status = 1;
+}
+
+message ConfigureOperationModeRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 operation_mode = 3;
+}
+
+message ConfigureOperationModeResponse {
+  int32 status = 1;
+}
+
+message ConfigureOutputEnabledRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  bool enabled = 3;
+}
+
+message ConfigureOutputEnabledResponse {
+  int32 status = 1;
+}
+
+message ConfigureOutputImpedanceRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  double impedance = 3;
+}
+
+message ConfigureOutputImpedanceResponse {
+  int32 status = 1;
+}
+
+message ConfigureOutputModeRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof output_mode_enum {
+    OutputMode output_mode = 2;
+    sint32 output_mode_raw = 3;
+  }
+}
+
+message ConfigureOutputModeResponse {
+  int32 status = 1;
+}
+
+message ConfigureP2PEndpointFullnessStartTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 p2p_endpoint_fullness_level = 2;
+}
+
+message ConfigureP2PEndpointFullnessStartTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureReferenceClockRequest {
+  nidevice_grpc.Session vi = 1;
+  string reference_clock_source = 2;
+  double reference_clock_frequency = 3;
+}
+
+message ConfigureReferenceClockResponse {
+  int32 status = 1;
+}
+
+message ConfigureSampleClockSourceRequest {
+  nidevice_grpc.Session vi = 1;
+  string sample_clock_source = 2;
+}
+
+message ConfigureSampleClockSourceResponse {
+  int32 status = 1;
+}
+
+message ConfigureSampleRateRequest {
+  nidevice_grpc.Session vi = 1;
+  double sample_rate = 2;
+}
+
+message ConfigureSampleRateResponse {
+  int32 status = 1;
+}
+
+message ConfigureSoftwareEdgeScriptTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string trigger_id = 2;
+}
+
+message ConfigureSoftwareEdgeScriptTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureSoftwareEdgeStartTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ConfigureSoftwareEdgeStartTriggerResponse {
+  int32 status = 1;
+}
+
+message ConfigureStandardWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  oneof waveform_enum {
+    Waveform waveform = 3;
+    sint32 waveform_raw = 4;
+  }
+  double amplitude = 5;
+  double dc_offset = 6;
+  double frequency = 7;
+  double start_phase = 8;
+}
+
+message ConfigureStandardWaveformResponse {
+  int32 status = 1;
+}
+
+message ConfigureSynchronizationRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 synchronization_source = 3;
+}
+
+message ConfigureSynchronizationResponse {
+  int32 status = 1;
+}
+
+message ConfigureTriggerModeRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  oneof trigger_mode_enum {
+    TriggerMode trigger_mode = 3;
+    sint32 trigger_mode_raw = 4;
+  }
+}
+
+message ConfigureTriggerModeResponse {
+  int32 status = 1;
+}
+
+message CreateAdvancedArbSequenceRequest {
+  nidevice_grpc.Session vi = 1;
+  repeated sint32 waveform_handles_array = 2;
+  repeated sint32 loop_counts_array = 3;
+  repeated sint32 sample_counts_array = 4;
+  repeated sint32 marker_location_array = 5;
+}
+
+message CreateAdvancedArbSequenceResponse {
+  int32 status = 1;
+  repeated sint32 coerced_markers_array = 2;
+  sint32 sequence_handle = 3;
+}
+
+message CreateArbSequenceRequest {
+  nidevice_grpc.Session vi = 1;
+  repeated sint32 waveform_handles_array = 2;
+  repeated sint32 loop_counts_array = 3;
+}
+
+message CreateArbSequenceResponse {
+  int32 status = 1;
+  sint32 sequence_handle = 2;
+}
+
+message CreateFreqListRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof waveform_enum {
+    Waveform waveform = 2;
+    sint32 waveform_raw = 3;
+  }
+  repeated double frequency_array = 4;
+  repeated double duration_array = 5;
+}
+
+message CreateFreqListResponse {
+  int32 status = 1;
+  sint32 frequency_list_handle = 2;
+}
+
+message CreateWaveformComplexF64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  repeated nidevice_grpc.NIComplexNumber waveform_data_array = 3;
+}
+
+message CreateWaveformComplexF64Response {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message CreateWaveformF64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  repeated double waveform_data_array = 3;
+}
+
+message CreateWaveformF64Response {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message CreateWaveformFromFileF64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string file_name = 3;
+  oneof byte_order_enum {
+    ByteOrder byte_order = 4;
+    sint32 byte_order_raw = 5;
+  }
+}
+
+message CreateWaveformFromFileF64Response {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message CreateWaveformFromFileHWSRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string file_name = 3;
+  bool use_rate_from_waveform = 4;
+  bool use_gain_and_offset_from_waveform = 5;
+}
+
+message CreateWaveformFromFileHWSResponse {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message CreateWaveformFromFileI16Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string file_name = 3;
+  oneof byte_order_enum {
+    ByteOrder byte_order = 4;
+    sint32 byte_order_raw = 5;
+  }
+}
+
+message CreateWaveformFromFileI16Response {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message CreateWaveformI16Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  repeated sint32 waveform_data_array = 3;
+}
+
+message CreateWaveformI16Response {
+  int32 status = 1;
+  sint32 waveform_handle = 2;
+}
+
+message DefineUserStandardWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  repeated double waveform_data_array = 3;
+}
+
+message DefineUserStandardWaveformResponse {
+  int32 status = 1;
+}
+
+message DeleteNamedWaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string waveform_name = 3;
+}
+
+message DeleteNamedWaveformResponse {
+  int32 status = 1;
+}
+
+message DeleteScriptRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string script_name = 3;
+}
+
+message DeleteScriptResponse {
+  int32 status = 1;
+}
+
+message DisableRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message DisableResponse {
+  int32 status = 1;
+}
+
+message DisableAnalogFilterRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message DisableAnalogFilterResponse {
+  int32 status = 1;
+}
+
+message DisableDigitalFilterRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message DisableDigitalFilterResponse {
+  int32 status = 1;
+}
+
+message DisableDigitalPatterningRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message DisableDigitalPatterningResponse {
+  int32 status = 1;
+}
+
+message DisableScriptTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  string trigger_id = 2;
+}
+
+message DisableScriptTriggerResponse {
+  int32 status = 1;
+}
+
+message DisableStartTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message DisableStartTriggerResponse {
+  int32 status = 1;
+}
+
+message EnableAnalogFilterRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  double filter_correction_frequency = 3;
+}
+
+message EnableAnalogFilterResponse {
+  int32 status = 1;
+}
+
+message EnableDigitalFilterRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message EnableDigitalFilterResponse {
+  int32 status = 1;
+}
+
+message EnableDigitalPatterningRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message EnableDigitalPatterningResponse {
+  int32 status = 1;
+}
+
+message ErrorHandlerRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 error_code = 2;
+}
+
+message ErrorHandlerResponse {
+  int32 status = 1;
+  string error_message = 2;
+}
+
+message ErrorMessageRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 error_code = 2;
+}
+
+message ErrorMessageResponse {
+  int32 status = 1;
+  string error_message = 2;
+}
+
+message ErrorQueryRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ErrorQueryResponse {
+  int32 status = 1;
+  sint32 error_code = 2;
+  string error_message = 3;
+}
+
+message ExportAttributeConfigurationBufferRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ExportAttributeConfigurationBufferResponse {
+  int32 status = 1;
+  bytes configuration = 2;
+}
+
+message ExportAttributeConfigurationFileRequest {
+  nidevice_grpc.Session vi = 1;
+  string file_path = 2;
+}
+
+message ExportAttributeConfigurationFileResponse {
+  int32 status = 1;
+}
+
+message ExportSignalRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof signal_enum {
+    Signal signal = 2;
+    sint32 signal_raw = 3;
+  }
+  string signal_identifier = 4;
+  string output_terminal = 5;
+}
+
+message ExportSignalResponse {
+  int32 status = 1;
+}
+
+message GetAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViBooleanResponse {
+  int32 status = 1;
+  bool attribute_value = 2;
+}
+
+message GetAttributeViInt32Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViInt32Response {
+  int32 status = 1;
+  sint32 attribute_value = 2;
+}
+
+message GetAttributeViInt64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViInt64Response {
+  int32 status = 1;
+  int64 attribute_value = 2;
+}
+
+message GetAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViReal64Response {
+  int32 status = 1;
+  double attribute_value = 2;
+}
+
+message GetAttributeViSessionRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViSessionResponse {
+  int32 status = 1;
+  nidevice_grpc.Session attribute_value = 2;
+}
+
+message GetAttributeViStringRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message GetAttributeViStringResponse {
+  int32 status = 1;
+  string attribute_value = 2;
+}
+
+message GetChannelNameRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 index = 2;
+}
+
+message GetChannelNameResponse {
+  int32 status = 1;
+  string channel_string = 2;
+}
+
+message GetErrorRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetErrorResponse {
+  int32 status = 1;
+  sint32 error_code = 2;
+  string error_description = 3;
+}
+
+message GetExtCalLastDateAndTimeRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetExtCalLastDateAndTimeResponse {
+  int32 status = 1;
+  sint32 year = 2;
+  sint32 month = 3;
+  sint32 day = 4;
+  sint32 hour = 5;
+  sint32 minute = 6;
+}
+
+message GetExtCalLastTempRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetExtCalLastTempResponse {
+  int32 status = 1;
+  double temperature = 2;
+}
+
+message GetExtCalRecommendedIntervalRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetExtCalRecommendedIntervalResponse {
+  int32 status = 1;
+  sint32 months = 2;
+}
+
+message GetFIRFilterCoefficientsRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message GetFIRFilterCoefficientsResponse {
+  int32 status = 1;
+  repeated double coefficients_array = 2;
+  sint32 number_of_coefficients_read = 3;
+}
+
+message GetHardwareStateRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetHardwareStateResponse {
+  int32 status = 1;
+  HardwareState state = 2;
+  sint32 state_raw = 3;
+}
+
+message GetSelfCalLastDateAndTimeRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetSelfCalLastDateAndTimeResponse {
+  int32 status = 1;
+  sint32 year = 2;
+  sint32 month = 3;
+  sint32 day = 4;
+  sint32 hour = 5;
+  sint32 minute = 6;
+}
+
+message GetSelfCalLastTempRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetSelfCalLastTempResponse {
+  int32 status = 1;
+  double temperature = 2;
+}
+
+message GetSelfCalSupportedRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetSelfCalSupportedResponse {
+  int32 status = 1;
+  bool self_cal_supported = 2;
+}
+
+message GetStreamEndpointHandleRequest {
+  nidevice_grpc.Session vi = 1;
+  string stream_endpoint = 2;
+}
+
+message GetStreamEndpointHandleResponse {
+  int32 status = 1;
+  uint32 reader_handle = 2;
+}
+
+message ImportAttributeConfigurationBufferRequest {
+  nidevice_grpc.Session vi = 1;
+  bytes configuration = 2;
+}
+
+message ImportAttributeConfigurationBufferResponse {
+  int32 status = 1;
+}
+
+message ImportAttributeConfigurationFileRequest {
+  nidevice_grpc.Session vi = 1;
+  string file_path = 2;
+}
+
+message ImportAttributeConfigurationFileResponse {
+  int32 status = 1;
+}
+
 message InitRequest {
   string session_name = 1;
   string resource_name = 2;
@@ -794,113 +1743,11 @@ message InitializeWithChannelsResponse {
   bool new_session_initialized = 4;
 }
 
-message CloseRequest {
+message InitiateGenerationRequest {
   nidevice_grpc.Session vi = 1;
 }
 
-message CloseResponse {
-  int32 status = 1;
-}
-
-message ResetRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ResetResponse {
-  int32 status = 1;
-}
-
-message SelfTestRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message SelfTestResponse {
-  int32 status = 1;
-  sint32 self_test_result = 2;
-  string self_test_message = 3;
-}
-
-message ErrorQueryRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ErrorQueryResponse {
-  int32 status = 1;
-  sint32 error_code = 2;
-  string error_message = 3;
-}
-
-message ErrorMessageRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 error_code = 2;
-}
-
-message ErrorMessageResponse {
-  int32 status = 1;
-  string error_message = 2;
-}
-
-message RevisionQueryRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message RevisionQueryResponse {
-  int32 status = 1;
-  string instrument_driver_revision = 2;
-  string firmware_revision = 3;
-}
-
-message GetErrorRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetErrorResponse {
-  int32 status = 1;
-  sint32 error_code = 2;
-  string error_description = 3;
-}
-
-message ClearErrorRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ClearErrorResponse {
-  int32 status = 1;
-}
-
-message ErrorHandlerRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 error_code = 2;
-}
-
-message ErrorHandlerResponse {
-  int32 status = 1;
-  string error_message = 2;
-}
-
-message GetChannelNameRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 index = 2;
-}
-
-message GetChannelNameResponse {
-  int32 status = 1;
-  string channel_string = 2;
-}
-
-message ResetInterchangeCheckRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ResetInterchangeCheckResponse {
-  int32 status = 1;
-}
-
-message ClearInterchangeWarningsRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ClearInterchangeWarningsResponse {
+message InitiateGenerationResponse {
   int32 status = 1;
 }
 
@@ -909,49 +1756,6 @@ message InvalidateAllAttributesRequest {
 }
 
 message InvalidateAllAttributesResponse {
-  int32 status = 1;
-}
-
-message ResetWithDefaultsRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ResetWithDefaultsResponse {
-  int32 status = 1;
-}
-
-message DisableRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message DisableResponse {
-  int32 status = 1;
-}
-
-message CommitRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message CommitResponse {
-  int32 status = 1;
-}
-
-message GetHardwareStateRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetHardwareStateResponse {
-  int32 status = 1;
-  HardwareState state = 2;
-  sint32 state_raw = 3;
-}
-
-message WaitUntilDoneRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 max_time = 2;
-}
-
-message WaitUntilDoneResponse {
   int32 status = 1;
 }
 
@@ -964,145 +1768,25 @@ message IsDoneResponse {
   bool done = 2;
 }
 
-message ResetDeviceRequest {
+message ManualEnableP2PStreamRequest {
   nidevice_grpc.Session vi = 1;
+  string endpoint_name = 2;
 }
 
-message ResetDeviceResponse {
+message ManualEnableP2PStreamResponse {
   int32 status = 1;
 }
 
-message ConfigureOperationModeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 operation_mode = 3;
-}
-
-message ConfigureOperationModeResponse {
-  int32 status = 1;
-}
-
-message ConfigureOutputModeRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof output_mode_enum {
-    OutputMode output_mode = 2;
-    sint32 output_mode_raw = 3;
-  }
-}
-
-message ConfigureOutputModeResponse {
-  int32 status = 1;
-}
-
-message ConfigureReferenceClockRequest {
-  nidevice_grpc.Session vi = 1;
-  string reference_clock_source = 2;
-  double reference_clock_frequency = 3;
-}
-
-message ConfigureReferenceClockResponse {
-  int32 status = 1;
-}
-
-message ConfigureOutputImpedanceRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double impedance = 3;
-}
-
-message ConfigureOutputImpedanceResponse {
-  int32 status = 1;
-}
-
-message ConfigureOutputEnabledRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  bool enabled = 3;
-}
-
-message ConfigureOutputEnabledResponse {
-  int32 status = 1;
-}
-
-message ConfigureChannelsRequest {
-  nidevice_grpc.Session vi = 1;
-  string channels = 2;
-}
-
-message ConfigureChannelsResponse {
-  int32 status = 1;
-}
-
-message InitiateGenerationRequest {
+message QueryArbSeqCapabilitiesRequest {
   nidevice_grpc.Session vi = 1;
 }
 
-message InitiateGenerationResponse {
+message QueryArbSeqCapabilitiesResponse {
   int32 status = 1;
-}
-
-message AbortGenerationRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message AbortGenerationResponse {
-  int32 status = 1;
-}
-
-message ConfigureStandardWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  oneof waveform_enum {
-    Waveform waveform = 3;
-    sint32 waveform_raw = 4;
-  }
-  double amplitude = 5;
-  double dc_offset = 6;
-  double frequency = 7;
-  double start_phase = 8;
-}
-
-message ConfigureStandardWaveformResponse {
-  int32 status = 1;
-}
-
-message DefineUserStandardWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated double waveform_data_array = 3;
-}
-
-message DefineUserStandardWaveformResponse {
-  int32 status = 1;
-}
-
-message ClearUserStandardWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message ClearUserStandardWaveformResponse {
-  int32 status = 1;
-}
-
-message ConfigureFrequencyRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double frequency = 3;
-}
-
-message ConfigureFrequencyResponse {
-  int32 status = 1;
-}
-
-message ConfigureAmplitudeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double amplitude = 3;
-}
-
-message ConfigureAmplitudeResponse {
-  int32 status = 1;
+  sint32 maximum_number_of_sequences = 2;
+  sint32 minimum_sequence_length = 3;
+  sint32 maximum_sequence_length = 4;
+  sint32 maximum_loop_count = 5;
 }
 
 message QueryArbWfmCapabilitiesRequest {
@@ -1117,110 +1801,201 @@ message QueryArbWfmCapabilitiesResponse {
   sint32 maximum_waveform_size = 5;
 }
 
-message CreateWaveformF64Request {
+message QueryFreqListCapabilitiesRequest {
   nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated double waveform_data_array = 3;
 }
 
-message CreateWaveformF64Response {
+message QueryFreqListCapabilitiesResponse {
   int32 status = 1;
-  sint32 waveform_handle = 2;
+  sint32 maximum_number_of_freq_lists = 2;
+  sint32 minimum_frequency_list_length = 3;
+  sint32 maximum_frequency_list_length = 4;
+  double minimum_frequency_list_duration = 5;
+  double maximum_frequency_list_duration = 6;
+  double frequency_list_duration_quantum = 7;
 }
 
-message CreateWaveformI16Request {
+message ReadCurrentTemperatureRequest {
   nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated sint32 waveform_data_array = 3;
 }
 
-message CreateWaveformI16Response {
+message ReadCurrentTemperatureResponse {
   int32 status = 1;
-  sint32 waveform_handle = 2;
+  double temperature = 2;
 }
 
-message CreateWaveformComplexF64Request {
+message ResetRequest {
   nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated nidevice_grpc.NIComplexNumber waveform_data_array = 3;
 }
 
-message CreateWaveformComplexF64Response {
+message ResetResponse {
   int32 status = 1;
-  sint32 waveform_handle = 2;
 }
 
-message CreateWaveformFromFileI16Request {
+message ResetAttributeRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  string file_name = 3;
-  oneof byte_order_enum {
-    ByteOrder byte_order = 4;
-    sint32 byte_order_raw = 5;
+  NiFgenAttribute attribute_id = 3;
+}
+
+message ResetAttributeResponse {
+  int32 status = 1;
+}
+
+message ResetDeviceRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ResetDeviceResponse {
+  int32 status = 1;
+}
+
+message ResetInterchangeCheckRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ResetInterchangeCheckResponse {
+  int32 status = 1;
+}
+
+message ResetWithDefaultsRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ResetWithDefaultsResponse {
+  int32 status = 1;
+}
+
+message RevisionQueryRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message RevisionQueryResponse {
+  int32 status = 1;
+  string instrument_driver_revision = 2;
+  string firmware_revision = 3;
+}
+
+message RouteSignalOutRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  oneof route_signal_from_enum {
+    RouteSignalFrom route_signal_from = 3;
+    sint32 route_signal_from_raw = 4;
+  }
+  oneof route_signal_to_enum {
+    RouteSignalTo route_signal_to = 5;
+    sint32 route_signal_to_raw = 6;
   }
 }
 
-message CreateWaveformFromFileI16Response {
+message RouteSignalOutResponse {
   int32 status = 1;
-  sint32 waveform_handle = 2;
 }
 
-message CreateWaveformFromFileF64Request {
+message SelfCalRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message SelfCalResponse {
+  int32 status = 1;
+}
+
+message SelfTestRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message SelfTestResponse {
+  int32 status = 1;
+  sint32 self_test_result = 2;
+  string self_test_message = 3;
+}
+
+message SendSoftwareEdgeTriggerRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof trigger_enum {
+    Trigger trigger = 2;
+    sint32 trigger_raw = 3;
+  }
+  string trigger_id = 4;
+}
+
+message SendSoftwareEdgeTriggerResponse {
+  int32 status = 1;
+}
+
+message SetAttributeViBooleanRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  string file_name = 3;
-  oneof byte_order_enum {
-    ByteOrder byte_order = 4;
-    sint32 byte_order_raw = 5;
+  NiFgenAttribute attribute_id = 3;
+  bool attribute_value = 4;
+}
+
+message SetAttributeViBooleanResponse {
+  int32 status = 1;
+}
+
+message SetAttributeViInt32Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFgenInt32AttributeValues attribute_value = 4;
+    sint32 attribute_value_raw = 5;
   }
 }
 
-message CreateWaveformFromFileF64Response {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message ConfigureSampleRateRequest {
-  nidevice_grpc.Session vi = 1;
-  double sample_rate = 2;
-}
-
-message ConfigureSampleRateResponse {
+message SetAttributeViInt32Response {
   int32 status = 1;
 }
 
-message ConfigureArbWaveformRequest {
+message SetAttributeViInt64Request {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  sint32 waveform_handle = 3;
-  double gain = 4;
-  double offset = 5;
+  NiFgenAttribute attribute_id = 3;
+  int64 attribute_value_raw = 4;
 }
 
-message ConfigureArbWaveformResponse {
+message SetAttributeViInt64Response {
   int32 status = 1;
 }
 
-message ClearArbWaveformRequest {
+message SetAttributeViReal64Request {
   nidevice_grpc.Session vi = 1;
-  oneof waveform_handle_enum {
-    WaveformHandle waveform_handle = 2;
-    sint32 waveform_handle_raw = 3;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFgenReal64AttributeValues attribute_value = 4;
+    double attribute_value_raw = 5;
   }
 }
 
-message ClearArbWaveformResponse {
+message SetAttributeViReal64Response {
   int32 status = 1;
 }
 
-message AllocateNamedWaveformRequest {
+message SetAttributeViSessionRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  string waveform_name = 3;
-  sint32 waveform_size = 4;
+  NiFgenAttribute attribute_id = 3;
+  nidevice_grpc.Session attribute_value = 4;
 }
 
-message AllocateNamedWaveformResponse {
+message SetAttributeViSessionResponse {
+  int32 status = 1;
+}
+
+message SetAttributeViStringRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFgenAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    string attribute_value_raw = 4;
+    NiFgenStringAttributeValuesMapped attribute_value_mapped = 5;
+  }
+}
+
+message SetAttributeViStringResponse {
   int32 status = 1;
 }
 
@@ -1239,25 +2014,49 @@ message SetNamedWaveformNextWritePositionResponse {
   int32 status = 1;
 }
 
-message WriteNamedWaveformF64Request {
+message SetWaveformNextWritePositionRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  string waveform_name = 3;
-  repeated double data = 4;
+  sint32 waveform_handle = 3;
+  oneof relative_to_enum {
+    RelativeTo relative_to = 4;
+    sint32 relative_to_raw = 5;
+  }
+  sint32 offset = 6;
 }
 
-message WriteNamedWaveformF64Response {
+message SetWaveformNextWritePositionResponse {
   int32 status = 1;
 }
 
-message WriteNamedWaveformI16Request {
+message WaitUntilDoneRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 max_time = 2;
+}
+
+message WaitUntilDoneResponse {
+  int32 status = 1;
+}
+
+message WriteBinary16WaveformRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  string waveform_name = 3;
+  sint32 waveform_handle = 3;
   repeated sint32 data = 4;
 }
 
-message WriteNamedWaveformI16Response {
+message WriteBinary16WaveformResponse {
+  int32 status = 1;
+}
+
+message WriteComplexBinary16WaveformRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  sint32 waveform_handle = 3;
+  repeated nidevice_grpc.NIComplexI16 data = 4;
+}
+
+message WriteComplexBinary16WaveformResponse {
   int32 status = 1;
 }
 
@@ -1283,136 +2082,35 @@ message WriteNamedWaveformComplexI16Response {
   int32 status = 1;
 }
 
-message DeleteNamedWaveformRequest {
+message WriteNamedWaveformF64Request {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
   string waveform_name = 3;
+  repeated double data = 4;
 }
 
-message DeleteNamedWaveformResponse {
+message WriteNamedWaveformF64Response {
   int32 status = 1;
 }
 
-message QueryArbSeqCapabilitiesRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message QueryArbSeqCapabilitiesResponse {
-  int32 status = 1;
-  sint32 maximum_number_of_sequences = 2;
-  sint32 minimum_sequence_length = 3;
-  sint32 maximum_sequence_length = 4;
-  sint32 maximum_loop_count = 5;
-}
-
-message CreateArbSequenceRequest {
-  nidevice_grpc.Session vi = 1;
-  repeated sint32 waveform_handles_array = 2;
-  repeated sint32 loop_counts_array = 3;
-}
-
-message CreateArbSequenceResponse {
-  int32 status = 1;
-  sint32 sequence_handle = 2;
-}
-
-message CreateAdvancedArbSequenceRequest {
-  nidevice_grpc.Session vi = 1;
-  repeated sint32 waveform_handles_array = 2;
-  repeated sint32 loop_counts_array = 3;
-  repeated sint32 sample_counts_array = 4;
-  repeated sint32 marker_location_array = 5;
-}
-
-message CreateAdvancedArbSequenceResponse {
-  int32 status = 1;
-  repeated sint32 coerced_markers_array = 2;
-  sint32 sequence_handle = 3;
-}
-
-message ConfigureArbSequenceRequest {
+message WriteNamedWaveformI16Request {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
-  sint32 sequence_handle = 3;
-  double gain = 4;
-  double offset = 5;
+  string waveform_name = 3;
+  repeated sint32 data = 4;
 }
 
-message ConfigureArbSequenceResponse {
+message WriteNamedWaveformI16Response {
   int32 status = 1;
 }
 
-message ClearArbSequenceRequest {
+message WriteP2PEndpointI16Request {
   nidevice_grpc.Session vi = 1;
-  oneof sequence_handle_enum {
-    SequenceHandle sequence_handle = 2;
-    sint32 sequence_handle_raw = 3;
-  }
+  string endpoint_name = 2;
+  repeated sint32 endpoint_data = 3;
 }
 
-message ClearArbSequenceResponse {
-  int32 status = 1;
-}
-
-message ClearArbMemoryRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ClearArbMemoryResponse {
-  int32 status = 1;
-}
-
-message QueryFreqListCapabilitiesRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message QueryFreqListCapabilitiesResponse {
-  int32 status = 1;
-  sint32 maximum_number_of_freq_lists = 2;
-  sint32 minimum_frequency_list_length = 3;
-  sint32 maximum_frequency_list_length = 4;
-  double minimum_frequency_list_duration = 5;
-  double maximum_frequency_list_duration = 6;
-  double frequency_list_duration_quantum = 7;
-}
-
-message CreateFreqListRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof waveform_enum {
-    Waveform waveform = 2;
-    sint32 waveform_raw = 3;
-  }
-  repeated double frequency_array = 4;
-  repeated double duration_array = 5;
-}
-
-message CreateFreqListResponse {
-  int32 status = 1;
-  sint32 frequency_list_handle = 2;
-}
-
-message ConfigureFreqListRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 frequency_list_handle = 3;
-  double amplitude = 4;
-  double dc_offset = 5;
-  double start_phase = 6;
-}
-
-message ConfigureFreqListResponse {
-  int32 status = 1;
-}
-
-message ClearFreqListRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof frequency_list_handle_enum {
-    FrequencyListOptions frequency_list_handle = 2;
-    sint32 frequency_list_handle_raw = 3;
-  }
-}
-
-message ClearFreqListResponse {
+message WriteP2PEndpointI16Response {
   int32 status = 1;
 }
 
@@ -1423,191 +2121,6 @@ message WriteScriptRequest {
 }
 
 message WriteScriptResponse {
-  int32 status = 1;
-}
-
-message DeleteScriptRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string script_name = 3;
-}
-
-message DeleteScriptResponse {
-  int32 status = 1;
-}
-
-message ExportSignalRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof signal_enum {
-    Signal signal = 2;
-    sint32 signal_raw = 3;
-  }
-  string signal_identifier = 4;
-  string output_terminal = 5;
-}
-
-message ExportSignalResponse {
-  int32 status = 1;
-}
-
-message RouteSignalOutRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  oneof route_signal_from_enum {
-    RouteSignalFrom route_signal_from = 3;
-    sint32 route_signal_from_raw = 4;
-  }
-  oneof route_signal_to_enum {
-    RouteSignalTo route_signal_to = 5;
-    sint32 route_signal_to_raw = 6;
-  }
-}
-
-message RouteSignalOutResponse {
-  int32 status = 1;
-}
-
-message SendSoftwareEdgeTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof trigger_enum {
-    Trigger trigger = 2;
-    sint32 trigger_raw = 3;
-  }
-  string trigger_id = 4;
-}
-
-message SendSoftwareEdgeTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureDigitalEdgeStartTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string source = 2;
-  oneof edge_enum {
-    StartTriggerDigitalEdgeEdge edge = 3;
-    sint32 edge_raw = 4;
-  }
-}
-
-message ConfigureDigitalEdgeStartTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureSoftwareEdgeStartTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ConfigureSoftwareEdgeStartTriggerResponse {
-  int32 status = 1;
-}
-
-message DisableStartTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message DisableStartTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureP2PEndpointFullnessStartTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 p2p_endpoint_fullness_level = 2;
-}
-
-message ConfigureP2PEndpointFullnessStartTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureDigitalEdgeScriptTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string trigger_id = 2;
-  string source = 3;
-  oneof edge_enum {
-    ScriptTriggerDigitalEdgeEdge edge = 4;
-    sint32 edge_raw = 5;
-  }
-}
-
-message ConfigureDigitalEdgeScriptTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureDigitalLevelScriptTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string trigger_id = 2;
-  string source = 3;
-  oneof trigger_when_enum {
-    TriggerWhen trigger_when = 4;
-    sint32 trigger_when_raw = 5;
-  }
-}
-
-message ConfigureDigitalLevelScriptTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureSoftwareEdgeScriptTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string trigger_id = 2;
-}
-
-message ConfigureSoftwareEdgeScriptTriggerResponse {
-  int32 status = 1;
-}
-
-message DisableScriptTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-  string trigger_id = 2;
-}
-
-message DisableScriptTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureClockModeRequest {
-  nidevice_grpc.Session vi = 1;
-  oneof clock_mode_enum {
-    ClockMode clock_mode = 2;
-    sint32 clock_mode_raw = 3;
-  }
-}
-
-message ConfigureClockModeResponse {
-  int32 status = 1;
-}
-
-message AdjustSampleClockRelativeDelayRequest {
-  nidevice_grpc.Session vi = 1;
-  double adjustment_time = 2;
-}
-
-message AdjustSampleClockRelativeDelayResponse {
-  int32 status = 1;
-}
-
-message AllocateWaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_size = 3;
-}
-
-message AllocateWaveformResponse {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
-}
-
-message SetWaveformNextWritePositionRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_handle = 3;
-  oneof relative_to_enum {
-    RelativeTo relative_to = 4;
-    sint32 relative_to_raw = 5;
-  }
-  sint32 offset = 6;
-}
-
-message SetWaveformNextWritePositionResponse {
   int32 status = 1;
 }
 
@@ -1622,17 +2135,6 @@ message WriteWaveformResponse {
   int32 status = 1;
 }
 
-message WriteBinary16WaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_handle = 3;
-  repeated sint32 data = 4;
-}
-
-message WriteBinary16WaveformResponse {
-  int32 status = 1;
-}
-
 message WriteWaveformComplexF64Request {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
@@ -1642,507 +2144,5 @@ message WriteWaveformComplexF64Request {
 
 message WriteWaveformComplexF64Response {
   int32 status = 1;
-}
-
-message WriteComplexBinary16WaveformRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 waveform_handle = 3;
-  repeated nidevice_grpc.NIComplexI16 data = 4;
-}
-
-message WriteComplexBinary16WaveformResponse {
-  int32 status = 1;
-}
-
-message SelfCalRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message SelfCalResponse {
-  int32 status = 1;
-}
-
-message GetSelfCalSupportedRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetSelfCalSupportedResponse {
-  int32 status = 1;
-  bool self_cal_supported = 2;
-}
-
-message GetSelfCalLastDateAndTimeRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetSelfCalLastDateAndTimeResponse {
-  int32 status = 1;
-  sint32 year = 2;
-  sint32 month = 3;
-  sint32 day = 4;
-  sint32 hour = 5;
-  sint32 minute = 6;
-}
-
-message GetExtCalLastDateAndTimeRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetExtCalLastDateAndTimeResponse {
-  int32 status = 1;
-  sint32 year = 2;
-  sint32 month = 3;
-  sint32 day = 4;
-  sint32 hour = 5;
-  sint32 minute = 6;
-}
-
-message GetSelfCalLastTempRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetSelfCalLastTempResponse {
-  int32 status = 1;
-  double temperature = 2;
-}
-
-message GetExtCalLastTempRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetExtCalLastTempResponse {
-  int32 status = 1;
-  double temperature = 2;
-}
-
-message GetExtCalRecommendedIntervalRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message GetExtCalRecommendedIntervalResponse {
-  int32 status = 1;
-  sint32 months = 2;
-}
-
-message ReadCurrentTemperatureRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ReadCurrentTemperatureResponse {
-  int32 status = 1;
-  double temperature = 2;
-}
-
-message ConfigureCustomFIRFilterCoefficientsRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  repeated double coefficients_array = 3;
-}
-
-message ConfigureCustomFIRFilterCoefficientsResponse {
-  int32 status = 1;
-}
-
-message GetFIRFilterCoefficientsRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message GetFIRFilterCoefficientsResponse {
-  int32 status = 1;
-  repeated double coefficients_array = 2;
-  sint32 number_of_coefficients_read = 3;
-}
-
-message GetStreamEndpointHandleRequest {
-  nidevice_grpc.Session vi = 1;
-  string stream_endpoint = 2;
-}
-
-message GetStreamEndpointHandleResponse {
-  int32 status = 1;
-  uint32 reader_handle = 2;
-}
-
-message WriteP2PEndpointI16Request {
-  nidevice_grpc.Session vi = 1;
-  string endpoint_name = 2;
-  repeated sint32 endpoint_data = 3;
-}
-
-message WriteP2PEndpointI16Response {
-  int32 status = 1;
-}
-
-message ConfigureSynchronizationRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 synchronization_source = 3;
-}
-
-message ConfigureSynchronizationResponse {
-  int32 status = 1;
-}
-
-message EnableDigitalPatterningRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message EnableDigitalPatterningResponse {
-  int32 status = 1;
-}
-
-message DisableDigitalPatterningRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message DisableDigitalPatterningResponse {
-  int32 status = 1;
-}
-
-message EnableDigitalFilterRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message EnableDigitalFilterResponse {
-  int32 status = 1;
-}
-
-message DisableDigitalFilterRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message DisableDigitalFilterResponse {
-  int32 status = 1;
-}
-
-message EnableAnalogFilterRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double filter_correction_frequency = 3;
-}
-
-message EnableAnalogFilterResponse {
-  int32 status = 1;
-}
-
-message DisableAnalogFilterRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message DisableAnalogFilterResponse {
-  int32 status = 1;
-}
-
-message ConfigureSampleClockSourceRequest {
-  nidevice_grpc.Session vi = 1;
-  string sample_clock_source = 2;
-}
-
-message ConfigureSampleClockSourceResponse {
-  int32 status = 1;
-}
-
-message ConfigureTriggerModeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  oneof trigger_mode_enum {
-    TriggerMode trigger_mode = 3;
-    sint32 trigger_mode_raw = 4;
-  }
-}
-
-message ConfigureTriggerModeResponse {
-  int32 status = 1;
-}
-
-message ImportAttributeConfigurationFileRequest {
-  nidevice_grpc.Session vi = 1;
-  string file_path = 2;
-}
-
-message ImportAttributeConfigurationFileResponse {
-  int32 status = 1;
-}
-
-message ExportAttributeConfigurationFileRequest {
-  nidevice_grpc.Session vi = 1;
-  string file_path = 2;
-}
-
-message ExportAttributeConfigurationFileResponse {
-  int32 status = 1;
-}
-
-message ImportAttributeConfigurationBufferRequest {
-  nidevice_grpc.Session vi = 1;
-  bytes configuration = 2;
-}
-
-message ImportAttributeConfigurationBufferResponse {
-  int32 status = 1;
-}
-
-message ExportAttributeConfigurationBufferRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message ExportAttributeConfigurationBufferResponse {
-  int32 status = 1;
-  bytes configuration = 2;
-}
-
-message SetAttributeViInt64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  int64 attribute_value_raw = 4;
-}
-
-message SetAttributeViInt64Response {
-  int32 status = 1;
-}
-
-message CheckAttributeViInt64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  int64 attribute_value_raw = 4;
-}
-
-message CheckAttributeViInt64Response {
-  int32 status = 1;
-}
-
-message GetAttributeViInt64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViInt64Response {
-  int32 status = 1;
-  int64 attribute_value = 2;
-}
-
-message SetAttributeViInt32Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    NiFgenInt32AttributeValues attribute_value = 4;
-    sint32 attribute_value_raw = 5;
-  }
-}
-
-message SetAttributeViInt32Response {
-  int32 status = 1;
-}
-
-message SetAttributeViReal64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    NiFgenReal64AttributeValues attribute_value = 4;
-    double attribute_value_raw = 5;
-  }
-}
-
-message SetAttributeViReal64Response {
-  int32 status = 1;
-}
-
-message SetAttributeViStringRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    string attribute_value_raw = 4;
-    NiFgenStringAttributeValuesMapped attribute_value_mapped = 5;
-  }
-}
-
-message SetAttributeViStringResponse {
-  int32 status = 1;
-}
-
-message SetAttributeViBooleanRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  bool attribute_value = 4;
-}
-
-message SetAttributeViBooleanResponse {
-  int32 status = 1;
-}
-
-message SetAttributeViSessionRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  nidevice_grpc.Session attribute_value = 4;
-}
-
-message SetAttributeViSessionResponse {
-  int32 status = 1;
-}
-
-message CheckAttributeViInt32Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    NiFgenInt32AttributeValues attribute_value = 4;
-    sint32 attribute_value_raw = 5;
-  }
-}
-
-message CheckAttributeViInt32Response {
-  int32 status = 1;
-}
-
-message CheckAttributeViReal64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    NiFgenReal64AttributeValues attribute_value = 4;
-    double attribute_value_raw = 5;
-  }
-}
-
-message CheckAttributeViReal64Response {
-  int32 status = 1;
-}
-
-message CheckAttributeViStringRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  oneof attribute_value_enum {
-    string attribute_value_raw = 4;
-    NiFgenStringAttributeValuesMapped attribute_value_mapped = 5;
-  }
-}
-
-message CheckAttributeViStringResponse {
-  int32 status = 1;
-}
-
-message CheckAttributeViBooleanRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  bool attribute_value = 4;
-}
-
-message CheckAttributeViBooleanResponse {
-  int32 status = 1;
-}
-
-message CheckAttributeViSessionRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-  nidevice_grpc.Session attribute_value = 4;
-}
-
-message CheckAttributeViSessionResponse {
-  int32 status = 1;
-}
-
-message GetAttributeViInt32Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViInt32Response {
-  int32 status = 1;
-  sint32 attribute_value = 2;
-}
-
-message GetAttributeViReal64Request {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViReal64Response {
-  int32 status = 1;
-  double attribute_value = 2;
-}
-
-message GetAttributeViStringRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViStringResponse {
-  int32 status = 1;
-  string attribute_value = 2;
-}
-
-message GetAttributeViBooleanRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViBooleanResponse {
-  int32 status = 1;
-  bool attribute_value = 2;
-}
-
-message GetAttributeViSessionRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message GetAttributeViSessionResponse {
-  int32 status = 1;
-  nidevice_grpc.Session attribute_value = 2;
-}
-
-message ResetAttributeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  NiFgenAttribute attribute_id = 3;
-}
-
-message ResetAttributeResponse {
-  int32 status = 1;
-}
-
-message ManualEnableP2PStreamRequest {
-  nidevice_grpc.Session vi = 1;
-  string endpoint_name = 2;
-}
-
-message ManualEnableP2PStreamResponse {
-  int32 status = 1;
-}
-
-message CreateWaveformFromFileHWSRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  string file_name = 3;
-  bool use_rate_from_waveform = 4;
-  bool use_gain_and_offset_from_waveform = 5;
-}
-
-message CreateWaveformFromFileHWSResponse {
-  int32 status = 1;
-  sint32 waveform_handle = 2;
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Pulls in the 26.0 final grpc-device metadata for the nifgen drivers.

### Why should this Pull Request be merged?

The nifgen.proto file was outdated, leading to a mismatch in message extraction between the gRPC client and server.

### What testing has been done?
 - Local build suceeded

### Breaking Changes / Removals

- Enum Field Update
  - In the following RPC requests, the field edge has been updated:
    - ConfigureDigitalEdgeScriptTriggerRequest
    - ConfigureDigitalEdgeStartTriggerRequest
  - Clients must now use either:
    - edge_raw (raw integer field), or
    - edge (enum-based field).

Impact: Any client code referencing the old edge field must be updated.

- RPC Removals
  - GetNextCoercionRecord
  - GetNextInterchangeWarning

Impact: Clients relying on these RPCs must remove or refactor calls, as they are no longer available.