### PR TITLE
Add client defaults config to artifacts

### DIFF
--- a/source/codegen/stage_client_files.py
+++ b/source/codegen/stage_client_files.py
@@ -100,6 +100,10 @@ class _ArtifactLocations:
     def metadata_dir(self) -> Path:
         return self.repo_root / "source" / "codegen" / "metadata"
 
+    @property
+    def config_dir(self) -> Path:
+        return self.repo_root / "source" / "config"
+
 
 def _get_release_proto_files(
     artifact_locations: _ArtifactLocations, readiness: _ArtifactReadiness
@@ -149,6 +153,10 @@ def stage_client_files(output_path: Path, ignore_release_readiness: bool):
 
     for dir in _get_release_example_directories(artifact_locations, readiness):
         copytree(dir, examples_path / dir.name)
+
+    config_path = output_path / "config"
+    config_path.mkdir(parents=True)
+    copy2(artifact_locations.config_dir / "ni-grpc-device.defaults.yml", config_path)
 
     copy2(artifact_locations.repo_root / "LICENSE", output_path)
     copy2(artifact_locations.repo_root / "ThirdPartyNotices.txt", output_path)

--- a/source/config/ni-grpc-device.defaults.yml
+++ b/source/config/ni-grpc-device.defaults.yml
@@ -1,0 +1,9 @@
+file_version: 1
+# TLS is disabled by default. Change certificate_mode to Unmanaged to enable
+# client authentication and provide paths to your certificate chain and private
+# key.
+certificate_mode: Disabled
+certificate_chain: File://$(UserServicesDir)/$(Service)/cert.pem
+certificate_key: File://$(UserServicesDir)/$(Service)/key.pem
+server_mode: Disabled
+trusted_certificates: SystemDefault


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds the gRPC Device client defaults TLS configuration file to the upstream repo and includes it in released client artifacts.

This change:
- adds the client defaults YAML as a source-owned config file
- updates client artifact staging so the file is exported in the client bundle under `config/`
- keeps the release workflow unchanged by using the existing client staging path that already feeds the published zip and tarball artifacts

### Why should this Pull Request be merged?

The client defaults config needs to be sourced from the `grpc-device` repo instead of being owned only downstream in `ni-central`.

Merging this change makes the GitHub repo the source of truth for the client config payload and ensures published client artifacts contain the file needed by downstream consumers and installers.

### What testing has been done?

- Ran the client staging script locally and verified the staged output contains `config/ni-grpc-device.defaults.yml`
- Built the repo locally on Windows in the Visual Studio 2022 developer environment with:
  - `cmake --build build --config RelWithDebInfo --target ni_grpc_device_server`

The local build completed successfully.