### PR TITLE
CMakeLists: honor USE_SUBMODULE_LIBS when including

### DIFF
--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup python3
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9.x'
+        python-version: '3.11.x'
 
     - name: Install build dependencies
       run: python -m pip install -r python_build_requirements.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,11 +319,12 @@ function(GenerateGrpcSources)
   set(output_files "${GENERATE_ARGS_OUTPUT}")
   set(proto_file "${GENERATE_ARGS_PROTO}")
   if(USE_SUBMODULE_LIBS)
-    set(protobuf_includes_arg 
-      -I ${CMAKE_SOURCE_DIR}/third_party/grpc/third_party/protobuf/src/
-      -I ${CMAKE_SOURCE_DIR}/third_party/ni-apis/ni/grpcdevice/v1/ # for session.proto
-      -I ${CMAKE_SOURCE_DIR}/third_party/ni-apis/)
+    set(protobuf_includes_arg
+      -I ${CMAKE_SOURCE_DIR}/third_party/grpc/third_party/protobuf/src/)
   endif()
+  list(APPEND protobuf_includes_arg
+    -I ${CMAKE_SOURCE_DIR}/third_party/ni-apis/ni/grpcdevice/v1/ # for session.proto
+    -I ${CMAKE_SOURCE_DIR}/third_party/ni-apis/)
   get_filename_component(proto_name "${proto_file}" NAME)
   get_filename_component(proto_path "${proto_file}" PATH)
   # Asssumption: all outputs are in the same directory: use the zero-th.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,9 +137,18 @@ include_directories(
   "./generated"
   "./imports/include"
   "./source"
-  "./third_party/grpc-sideband/src"
-  "./third_party/grpc-sideband/moniker_src"
 )
+
+if(USE_SUBMODULE_LIBS)
+  include_directories(
+    "./third_party/grpc-sideband/src"
+    "./third_party/grpc-sideband/moniker_src"
+  )
+else()
+  find_path(GRPC_SIDEBAND_INCLUDE_DIR ni-grpc-sideband REQUIRED)
+  include_directories("${GRPC_SIDEBAND_INCLUDE_DIR}/ni-grpc-sideband")
+endif()
+
 if(WIN32)
   link_directories("./imports/lib/win64")
 endif()


### PR DESCRIPTION
### What does this Pull Request accomplish?

A section of the CMakeLists attempts to include protobuf headers from the third_party submodules unconditionally, even if the submodules are not supposed to be used for the build.

Branch these includes behind a check for if USE_SUBMODULE_LIBS is enabled.

**Also**. Upgrade the python runtime version used in the ``validate_python`` step of the PR build to 3.11.0. Python 3.9.0 does not support one of the functions needed by poetry 1.8.2.


### Why should this Pull Request be merged?

NILRT builds the grpc-sideband library as a dynamic lib and should import its headers from ``/usr/includes`` rather than the submodules.


### What testing has been done?

* [x] Built these changes in the NILRT OE environment and confirmed that ni-grpc-device compiles without the submodules.