### PR TITLE
Adding RFSA gRPC support with Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Indicates the most recent driver version used to test builds of the current sour
 | NI-RFmx WCDMA             | 2025 Q1       | Not Supported | Not Supported |
 | NI-RFmx WLAN              | 2026 Q2       | Not Supported | Not Supported |
 | NI-RFmx WLANGen           | 2026 Q2       | Not Supported | Not Supported |
-| NI-RFSA                   | 21.0.0        | 21.0.0        | Not Supported |
+| NI-RFSA                   | 2026 Q2       | 2026 Q2       | 2026 Q2       |
 | NI-RFSG                   | 2025 Q3       | 2025 Q3       | 2025 Q3       |
 | NI-SCOPE                  | 2023 Q2       | 2023 Q2       | 2023 Q2       |
 | NI-SWITCH                 | 2023 Q1       | 2023 Q1       | 2023 Q1       |

--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -97,6 +97,7 @@ service NiRFSA {
   rpc Initiate(InitiateRequest) returns (InitiateResponse);
   rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
   rpc IsSelfCalValid(IsSelfCalValidRequest) returns (IsSelfCalValidResponse);
+  rpc LoadConfigurationsFromFile(LoadConfigurationsFromFileRequest) returns (LoadConfigurationsFromFileResponse);
   rpc PerformThermalCorrection(PerformThermalCorrectionRequest) returns (PerformThermalCorrectionResponse);
   rpc ReadIQSingleRecordComplexF64(ReadIQSingleRecordComplexF64Request) returns (ReadIQSingleRecordComplexF64Response);
   rpc ReadPowerSpectrumF32(ReadPowerSpectrumF32Request) returns (ReadPowerSpectrumF32Response);
@@ -107,6 +108,7 @@ service NiRFSA {
   rpc ResetWithDefaults(ResetWithDefaultsRequest) returns (ResetWithDefaultsResponse);
   rpc ResetWithOptions(ResetWithOptionsRequest) returns (ResetWithOptionsResponse);
   rpc RevisionQuery(RevisionQueryRequest) returns (RevisionQueryResponse);
+  rpc SaveConfigurationsToFile(SaveConfigurationsToFileRequest) returns (SaveConfigurationsToFileResponse);
   rpc SelfCal(SelfCalRequest) returns (SelfCalResponse);
   rpc SelfCalibrate(SelfCalibrateRequest) returns (SelfCalibrateResponse);
   rpc SelfCalibrateRange(SelfCalibrateRangeRequest) returns (SelfCalibrateRangeResponse);
@@ -375,6 +377,14 @@ enum NiRFSAAttribute {
   NIRFSA_ATTRIBUTE_USER_SOURCE_PULSE_WIDTH = 1150322;
   NIRFSA_ATTRIBUTE_FIXED_GROUP_DELAY_ACROSS_PORTS = 1150324;
   NIRFSA_ATTRIBUTE_DEEMBEDDING_COMPENSATION_GAIN = 1150325;
+  NIRFSA_ATTRIBUTE_EXPORTED_REF_CLOCK_RATE = 1150326;
+  NIRFSA_ATTRIBUTE_SELECTED_PATH = 1150331;
+  NIRFSA_ATTRIBUTE_AVAILABLE_PATHS = 1150332;
+  NIRFSA_ATTRIBUTE_CREATED_SESSION_CHANNEL = 1150333;
+  NIRFSA_ATTRIBUTE_MIN_FUNDAMENTAL_SILO_FREQUENCY = 1150334;
+  NIRFSA_ATTRIBUTE_MAX_FUNDAMENTAL_SILO_FREQUENCY = 1150335;
+  NIRFSA_ATTRIBUTE_LOAD_CONFIGURATIONS_FROM_FILE_RESET_OPTIONS = 1150337;
+  NIRFSA_ATTRIBUTE_ASSOC_AUX_SWITCH_GAIN_UID = 1150356;
 }
 
 enum AcquisitionType {
@@ -1651,6 +1661,16 @@ message IsSelfCalValidResponse {
   int64 valid_steps_raw = 4;
 }
 
+message LoadConfigurationsFromFileRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string file_path = 3;
+}
+
+message LoadConfigurationsFromFileResponse {
+  int32 status = 1;
+}
+
 message PerformThermalCorrectionRequest {
   nidevice_grpc.Session vi = 1;
 }
@@ -1752,6 +1772,16 @@ message RevisionQueryResponse {
   int32 status = 1;
   string driver_rev = 2;
   string instr_rev = 3;
+}
+
+message SaveConfigurationsToFileRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  string file_path = 3;
+}
+
+message SaveConfigurationsToFileResponse {
+  int32 status = 1;
 }
 
 message SelfCalRequest {

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -1624,6 +1624,25 @@ is_self_cal_valid(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
+LoadConfigurationsFromFileResponse
+load_configurations_from_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name, const std::string& file_path)
+{
+  ::grpc::ClientContext context;
+
+  auto request = LoadConfigurationsFromFileRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+  request.set_file_path(file_path);
+
+  auto response = LoadConfigurationsFromFileResponse{};
+
+  raise_if_error(
+      stub->LoadConfigurationsFromFile(&context, request, &response),
+      context);
+
+  return response;
+}
+
 PerformThermalCorrectionResponse
 perform_thermal_correction(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
@@ -1808,6 +1827,25 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
 
   raise_if_error(
       stub->RevisionQuery(&context, request, &response),
+      context);
+
+  return response;
+}
+
+SaveConfigurationsToFileResponse
+save_configurations_to_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name, const std::string& file_path)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SaveConfigurationsToFileRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+  request.set_file_path(file_path);
+
+  auto response = SaveConfigurationsToFileResponse{};
+
+  raise_if_error(
+      stub->SaveConfigurationsToFile(&context, request, &response),
       context);
 
   return response;

--- a/generated/nirfsa/nirfsa_client.h
+++ b/generated/nirfsa/nirfsa_client.h
@@ -102,6 +102,7 @@ InitWithOptionsResponse init_with_options(const StubPtr& stub, const std::string
 InitiateResponse initiate(const StubPtr& stub, const nidevice_grpc::Session& vi);
 InvalidateAllAttributesResponse invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi);
 IsSelfCalValidResponse is_self_cal_valid(const StubPtr& stub, const nidevice_grpc::Session& vi);
+LoadConfigurationsFromFileResponse load_configurations_from_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name, const std::string& file_path);
 PerformThermalCorrectionResponse perform_thermal_correction(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReadIQSingleRecordComplexF64Response read_iq_single_record_complex_f64(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int64& data_array_size);
 ReadPowerSpectrumF32Response read_power_spectrum_f32(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& data_array_size);
@@ -112,6 +113,7 @@ ResetDeviceResponse reset_device(const StubPtr& stub, const nidevice_grpc::Sessi
 ResetWithDefaultsResponse reset_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ResetWithOptionsResponse reset_with_options(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ResetWithOptionsStepsToOmit, pb::uint64>& steps_to_omit);
 RevisionQueryResponse revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi);
+SaveConfigurationsToFileResponse save_configurations_to_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name, const std::string& file_path);
 SelfCalResponse self_cal(const StubPtr& stub, const nidevice_grpc::Session& vi);
 SelfCalibrateResponse self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateSteps, pb::int64>& steps_to_omit);
 SelfCalibrateRangeResponse self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateSteps, pb::int64>& steps_to_omit, const double& min_frequency, const double& max_frequency, const double& min_reference_level, const double& max_reference_level);

--- a/generated/nirfsa/nirfsa_compilation_test.cpp
+++ b/generated/nirfsa/nirfsa_compilation_test.cpp
@@ -407,6 +407,11 @@ ViStatus IsSelfCalValid(ViSession vi, ViBoolean* selfCalValid, ViInt64* validSte
   return niRFSA_IsSelfCalValid(vi, selfCalValid, validSteps);
 }
 
+ViStatus LoadConfigurationsFromFile(ViSession vi, ViConstString channelName, ViConstString filePath)
+{
+  return niRFSA_LoadConfigurationsFromFile(vi, channelName, filePath);
+}
+
 ViStatus PerformThermalCorrection(ViSession vi)
 {
   return niRFSA_PerformThermalCorrection(vi);
@@ -455,6 +460,11 @@ ViStatus ResetWithOptions(ViSession vi, ViUInt64 stepsToOmit)
 ViStatus RevisionQuery(ViSession vi, ViChar driverRev[256], ViChar instrRev[256])
 {
   return niRFSA_revision_query(vi, driverRev, instrRev);
+}
+
+ViStatus SaveConfigurationsToFile(ViSession vi, ViConstString channelName, ViConstString filePath)
+{
+  return niRFSA_SaveConfigurationsToFile(vi, channelName, filePath);
 }
 
 ViStatus SelfCal(ViSession vi)

--- a/generated/nirfsa/nirfsa_library.cpp
+++ b/generated/nirfsa/nirfsa_library.cpp
@@ -107,6 +107,7 @@ NiRFSALibrary::NiRFSALibrary(std::shared_ptr<nidevice_grpc::SharedLibraryInterfa
   function_pointers_.Initiate = reinterpret_cast<InitiatePtr>(shared_library_->get_function_pointer("niRFSA_Initiate"));
   function_pointers_.InvalidateAllAttributes = reinterpret_cast<InvalidateAllAttributesPtr>(shared_library_->get_function_pointer("niRFSA_InvalidateAllAttributes"));
   function_pointers_.IsSelfCalValid = reinterpret_cast<IsSelfCalValidPtr>(shared_library_->get_function_pointer("niRFSA_IsSelfCalValid"));
+  function_pointers_.LoadConfigurationsFromFile = reinterpret_cast<LoadConfigurationsFromFilePtr>(shared_library_->get_function_pointer("niRFSA_LoadConfigurationsFromFile"));
   function_pointers_.LockSession = reinterpret_cast<LockSessionPtr>(shared_library_->get_function_pointer("niRFSA_LockSession"));
   function_pointers_.PerformThermalCorrection = reinterpret_cast<PerformThermalCorrectionPtr>(shared_library_->get_function_pointer("niRFSA_PerformThermalCorrection"));
   function_pointers_.ReadIQSingleRecordComplexF64 = reinterpret_cast<ReadIQSingleRecordComplexF64Ptr>(shared_library_->get_function_pointer("niRFSA_ReadIQSingleRecordComplexF64"));
@@ -118,6 +119,7 @@ NiRFSALibrary::NiRFSALibrary(std::shared_ptr<nidevice_grpc::SharedLibraryInterfa
   function_pointers_.ResetWithDefaults = reinterpret_cast<ResetWithDefaultsPtr>(shared_library_->get_function_pointer("niRFSA_ResetWithDefaults"));
   function_pointers_.ResetWithOptions = reinterpret_cast<ResetWithOptionsPtr>(shared_library_->get_function_pointer("niRFSA_ResetWithOptions"));
   function_pointers_.RevisionQuery = reinterpret_cast<RevisionQueryPtr>(shared_library_->get_function_pointer("niRFSA_revision_query"));
+  function_pointers_.SaveConfigurationsToFile = reinterpret_cast<SaveConfigurationsToFilePtr>(shared_library_->get_function_pointer("niRFSA_SaveConfigurationsToFile"));
   function_pointers_.SelfCal = reinterpret_cast<SelfCalPtr>(shared_library_->get_function_pointer("niRFSA_SelfCal"));
   function_pointers_.SelfCalibrate = reinterpret_cast<SelfCalibratePtr>(shared_library_->get_function_pointer("niRFSA_SelfCalibrate"));
   function_pointers_.SelfCalibrateRange = reinterpret_cast<SelfCalibrateRangePtr>(shared_library_->get_function_pointer("niRFSA_SelfCalibrateRange"));
@@ -785,6 +787,14 @@ ViStatus NiRFSALibrary::IsSelfCalValid(ViSession vi, ViBoolean* selfCalValid, Vi
   return function_pointers_.IsSelfCalValid(vi, selfCalValid, validSteps);
 }
 
+ViStatus NiRFSALibrary::LoadConfigurationsFromFile(ViSession vi, ViConstString channelName, ViConstString filePath)
+{
+  if (!function_pointers_.LoadConfigurationsFromFile) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_LoadConfigurationsFromFile.");
+  }
+  return function_pointers_.LoadConfigurationsFromFile(vi, channelName, filePath);
+}
+
 ViStatus NiRFSALibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
 {
   if (!function_pointers_.LockSession) {
@@ -871,6 +881,14 @@ ViStatus NiRFSALibrary::RevisionQuery(ViSession vi, ViChar driverRev[256], ViCha
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_revision_query.");
   }
   return function_pointers_.RevisionQuery(vi, driverRev, instrRev);
+}
+
+ViStatus NiRFSALibrary::SaveConfigurationsToFile(ViSession vi, ViConstString channelName, ViConstString filePath)
+{
+  if (!function_pointers_.SaveConfigurationsToFile) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_SaveConfigurationsToFile.");
+  }
+  return function_pointers_.SaveConfigurationsToFile(vi, channelName, filePath);
 }
 
 ViStatus NiRFSALibrary::SelfCal(ViSession vi)

--- a/generated/nirfsa/nirfsa_library.h
+++ b/generated/nirfsa/nirfsa_library.h
@@ -101,6 +101,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   ViStatus Initiate(ViSession vi) override;
   ViStatus InvalidateAllAttributes(ViSession vi) override;
   ViStatus IsSelfCalValid(ViSession vi, ViBoolean* selfCalValid, ViInt64* validSteps) override;
+  ViStatus LoadConfigurationsFromFile(ViSession vi, ViConstString channelName, ViConstString filePath) override;
   ViStatus LockSession(ViSession vi, ViBoolean* callerHasLock) override;
   ViStatus PerformThermalCorrection(ViSession vi) override;
   ViStatus ReadIQSingleRecordComplexF64(ViSession vi, ViConstString channelList, ViReal64 timeout, NIComplexNumber_struct data[], ViInt64 dataArraySize, niRFSA_wfmInfo_struct* wfmInfo) override;
@@ -112,6 +113,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   ViStatus ResetWithDefaults(ViSession vi) override;
   ViStatus ResetWithOptions(ViSession vi, ViUInt64 stepsToOmit) override;
   ViStatus RevisionQuery(ViSession vi, ViChar driverRev[256], ViChar instrRev[256]) override;
+  ViStatus SaveConfigurationsToFile(ViSession vi, ViConstString channelName, ViConstString filePath) override;
   ViStatus SelfCal(ViSession vi) override;
   ViStatus SelfCalibrate(ViSession vi, ViInt64 stepsToOmit) override;
   ViStatus SelfCalibrateRange(ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minReferenceLevel, ViReal64 maxReferenceLevel) override;
@@ -208,6 +210,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   using InitiatePtr = decltype(&niRFSA_Initiate);
   using InvalidateAllAttributesPtr = decltype(&niRFSA_InvalidateAllAttributes);
   using IsSelfCalValidPtr = decltype(&niRFSA_IsSelfCalValid);
+  using LoadConfigurationsFromFilePtr = decltype(&niRFSA_LoadConfigurationsFromFile);
   using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using PerformThermalCorrectionPtr = decltype(&niRFSA_PerformThermalCorrection);
   using ReadIQSingleRecordComplexF64Ptr = decltype(&niRFSA_ReadIQSingleRecordComplexF64);
@@ -219,6 +222,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   using ResetWithDefaultsPtr = decltype(&niRFSA_ResetWithDefaults);
   using ResetWithOptionsPtr = decltype(&niRFSA_ResetWithOptions);
   using RevisionQueryPtr = decltype(&niRFSA_revision_query);
+  using SaveConfigurationsToFilePtr = decltype(&niRFSA_SaveConfigurationsToFile);
   using SelfCalPtr = decltype(&niRFSA_SelfCal);
   using SelfCalibratePtr = decltype(&niRFSA_SelfCalibrate);
   using SelfCalibrateRangePtr = decltype(&niRFSA_SelfCalibrateRange);
@@ -315,6 +319,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
     InitiatePtr Initiate;
     InvalidateAllAttributesPtr InvalidateAllAttributes;
     IsSelfCalValidPtr IsSelfCalValid;
+    LoadConfigurationsFromFilePtr LoadConfigurationsFromFile;
     LockSessionPtr LockSession;
     PerformThermalCorrectionPtr PerformThermalCorrection;
     ReadIQSingleRecordComplexF64Ptr ReadIQSingleRecordComplexF64;
@@ -326,6 +331,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
     ResetWithDefaultsPtr ResetWithDefaults;
     ResetWithOptionsPtr ResetWithOptions;
     RevisionQueryPtr RevisionQuery;
+    SaveConfigurationsToFilePtr SaveConfigurationsToFile;
     SelfCalPtr SelfCal;
     SelfCalibratePtr SelfCalibrate;
     SelfCalibrateRangePtr SelfCalibrateRange;

--- a/generated/nirfsa/nirfsa_library_interface.h
+++ b/generated/nirfsa/nirfsa_library_interface.h
@@ -96,6 +96,7 @@ class NiRFSALibraryInterface {
   virtual ViStatus Initiate(ViSession vi) = 0;
   virtual ViStatus InvalidateAllAttributes(ViSession vi) = 0;
   virtual ViStatus IsSelfCalValid(ViSession vi, ViBoolean* selfCalValid, ViInt64* validSteps) = 0;
+  virtual ViStatus LoadConfigurationsFromFile(ViSession vi, ViConstString channelName, ViConstString filePath) = 0;
   virtual ViStatus LockSession(ViSession vi, ViBoolean* callerHasLock) = 0;
   virtual ViStatus PerformThermalCorrection(ViSession vi) = 0;
   virtual ViStatus ReadIQSingleRecordComplexF64(ViSession vi, ViConstString channelList, ViReal64 timeout, NIComplexNumber_struct data[], ViInt64 dataArraySize, niRFSA_wfmInfo_struct* wfmInfo) = 0;
@@ -107,6 +108,7 @@ class NiRFSALibraryInterface {
   virtual ViStatus ResetWithDefaults(ViSession vi) = 0;
   virtual ViStatus ResetWithOptions(ViSession vi, ViUInt64 stepsToOmit) = 0;
   virtual ViStatus RevisionQuery(ViSession vi, ViChar driverRev[256], ViChar instrRev[256]) = 0;
+  virtual ViStatus SaveConfigurationsToFile(ViSession vi, ViConstString channelName, ViConstString filePath) = 0;
   virtual ViStatus SelfCal(ViSession vi) = 0;
   virtual ViStatus SelfCalibrate(ViSession vi, ViInt64 stepsToOmit) = 0;
   virtual ViStatus SelfCalibrateRange(ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minReferenceLevel, ViReal64 maxReferenceLevel) = 0;

--- a/generated/nirfsa/nirfsa_mock_library.h
+++ b/generated/nirfsa/nirfsa_mock_library.h
@@ -97,6 +97,7 @@ class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   MOCK_METHOD(ViStatus, Initiate, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, InvalidateAllAttributes, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, IsSelfCalValid, (ViSession vi, ViBoolean* selfCalValid, ViInt64* validSteps), (override));
+  MOCK_METHOD(ViStatus, LoadConfigurationsFromFile, (ViSession vi, ViConstString channelName, ViConstString filePath), (override));
   MOCK_METHOD(ViStatus, LockSession, (ViSession vi, ViBoolean* callerHasLock), (override));
   MOCK_METHOD(ViStatus, PerformThermalCorrection, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, ReadIQSingleRecordComplexF64, (ViSession vi, ViConstString channelList, ViReal64 timeout, NIComplexNumber_struct data[], ViInt64 dataArraySize, niRFSA_wfmInfo_struct* wfmInfo), (override));
@@ -108,6 +109,7 @@ class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   MOCK_METHOD(ViStatus, ResetWithDefaults, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, ResetWithOptions, (ViSession vi, ViUInt64 stepsToOmit), (override));
   MOCK_METHOD(ViStatus, RevisionQuery, (ViSession vi, ViChar driverRev[256], ViChar instrRev[256]), (override));
+  MOCK_METHOD(ViStatus, SaveConfigurationsToFile, (ViSession vi, ViConstString channelName, ViConstString filePath), (override));
   MOCK_METHOD(ViStatus, SelfCal, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, SelfCalibrate, (ViSession vi, ViInt64 stepsToOmit), (override));
   MOCK_METHOD(ViStatus, SelfCalibrateRange, (ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minReferenceLevel, ViReal64 maxReferenceLevel), (override));

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -2635,6 +2635,32 @@ namespace nirfsa_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFSAService::LoadConfigurationsFromFile(::grpc::ServerContext* context, const LoadConfigurationsFromFileRequest* request, LoadConfigurationsFromFileResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      auto channel_name_mbcs = convert_from_grpc<std::string>(request->channel_name());
+      auto channel_name = channel_name_mbcs.c_str();
+      auto file_path_mbcs = convert_from_grpc<std::string>(request->file_path());
+      auto file_path = file_path_mbcs.c_str();
+      auto status = library_->LoadConfigurationsFromFile(vi, channel_name, file_path);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFSAService::PerformThermalCorrection(::grpc::ServerContext* context, const PerformThermalCorrectionRequest* request, PerformThermalCorrectionResponse* response)
   {
     if (context->IsCancelled()) {
@@ -2899,6 +2925,32 @@ namespace nirfsa_grpc {
       convert_to_grpc(instr_rev, &instr_rev_utf8);
       response->set_instr_rev(instr_rev_utf8);
       nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instr_rev()));
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFSAService::SaveConfigurationsToFile(::grpc::ServerContext* context, const SaveConfigurationsToFileRequest* request, SaveConfigurationsToFileResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      auto channel_name_mbcs = convert_from_grpc<std::string>(request->channel_name());
+      auto channel_name = channel_name_mbcs.c_str();
+      auto file_path_mbcs = convert_from_grpc<std::string>(request->file_path());
+      auto file_path = file_path_mbcs.c_str();
+      auto status = library_->SaveConfigurationsToFile(vi, channel_name, file_path);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {

--- a/generated/nirfsa/nirfsa_service.h
+++ b/generated/nirfsa/nirfsa_service.h
@@ -122,6 +122,7 @@ public:
   ::grpc::Status Initiate(::grpc::ServerContext* context, const InitiateRequest* request, InitiateResponse* response) override;
   ::grpc::Status InvalidateAllAttributes(::grpc::ServerContext* context, const InvalidateAllAttributesRequest* request, InvalidateAllAttributesResponse* response) override;
   ::grpc::Status IsSelfCalValid(::grpc::ServerContext* context, const IsSelfCalValidRequest* request, IsSelfCalValidResponse* response) override;
+  ::grpc::Status LoadConfigurationsFromFile(::grpc::ServerContext* context, const LoadConfigurationsFromFileRequest* request, LoadConfigurationsFromFileResponse* response) override;
   ::grpc::Status PerformThermalCorrection(::grpc::ServerContext* context, const PerformThermalCorrectionRequest* request, PerformThermalCorrectionResponse* response) override;
   ::grpc::Status ReadIQSingleRecordComplexF64(::grpc::ServerContext* context, const ReadIQSingleRecordComplexF64Request* request, ReadIQSingleRecordComplexF64Response* response) override;
   ::grpc::Status ReadPowerSpectrumF32(::grpc::ServerContext* context, const ReadPowerSpectrumF32Request* request, ReadPowerSpectrumF32Response* response) override;
@@ -132,6 +133,7 @@ public:
   ::grpc::Status ResetWithDefaults(::grpc::ServerContext* context, const ResetWithDefaultsRequest* request, ResetWithDefaultsResponse* response) override;
   ::grpc::Status ResetWithOptions(::grpc::ServerContext* context, const ResetWithOptionsRequest* request, ResetWithOptionsResponse* response) override;
   ::grpc::Status RevisionQuery(::grpc::ServerContext* context, const RevisionQueryRequest* request, RevisionQueryResponse* response) override;
+  ::grpc::Status SaveConfigurationsToFile(::grpc::ServerContext* context, const SaveConfigurationsToFileRequest* request, SaveConfigurationsToFileResponse* response) override;
   ::grpc::Status SelfCal(::grpc::ServerContext* context, const SelfCalRequest* request, SelfCalResponse* response) override;
   ::grpc::Status SelfCalibrate(::grpc::ServerContext* context, const SelfCalibrateRequest* request, SelfCalibrateResponse* response) override;
   ::grpc::Status SelfCalibrateRange(::grpc::ServerContext* context, const SelfCalibrateRangeRequest* request, SelfCalibrateRangeResponse* response) override;

--- a/imports/include/niRFSA.h
+++ b/imports/include/niRFSA.h
@@ -147,6 +147,7 @@ extern "C" {
 #define NIRFSA_ATTR_DIGITIZER_SAMPLE_CLOCK_TIMEBASE_RATE   /* ViReal64    */   (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 22L)
 #define NIRFSA_ATTR_PXI_CHASSIS_CLK10_SOURCE               /* ViString    */   (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 23L)
 #define NIRFSA_ATTR_EXPORTED_REF_CLOCK_OUTPUT_TERMINAL     /* ViString    */   (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 72L)
+#define NIRFSA_ATTR_EXPORTED_REF_CLOCK_RATE                /* ViReal64    */   (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 326L)
 #define NIRFSA_ATTR_DIGITIZER_SAMPLE_CLOCK_RATE                      /* ViReal64 */ (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 228L)
 #define NIRFSA_ATTR_EXPORTED_DIGITIZER_SAMPLE_CLOCK_OUTPUT_TERMINAL  /* ViString */ (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 229L)
 
@@ -380,6 +381,11 @@ extern "C" {
 #define NIRFSA_ATTR_DEEMBEDDING_SELECTED_TABLE                /*ViString     */     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 308L)
 #define NIRFSA_ATTR_DEEMBEDDING_COMPENSATION_GAIN             /*ViReal64     */     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 325L)
 
+#define NIRFSA_ATTR_SELECTED_PATH                             /* ViString */        (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 331L)
+#define NIRFSA_ATTR_AVAILABLE_PATHS                           /* ViString */        (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 332L)
+
+#define NIRFSA_ATTR_LOAD_CONFIGURATIONS_FROM_FILE_RESET_OPTIONS            /*ViInt32*/          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 337L)
+
 /****************************************************************************
  *------ Device-Specific Attribute Value Defines (5644R/5645R/5646R) -------*
  ****************************************************************************/
@@ -571,6 +577,15 @@ extern "C" {
 #define NIRFSA_VAL_USER_SOURCE5_STR                    "UserSource5"
 #define NIRFSA_VAL_USER_SOURCE6_STR                    "UserSource6"
 #define NIRFSA_VAL_USER_SOURCE7_STR                    "UserSource7"
+#define NIRFSA_VAL_PULSE_IN_STR                        "PulseIn"
+#define NIRFSA_VAL_DIO0_STR                            "DIO/PFI0"
+#define NIRFSA_VAL_DIO1_STR                            "DIO/PFI1"
+#define NIRFSA_VAL_DIO2_STR                            "DIO/PFI2"
+#define NIRFSA_VAL_DIO3_STR                            "DIO/PFI3"
+#define NIRFSA_VAL_DIO4_STR                            "DIO/PFI4"
+#define NIRFSA_VAL_DIO5_STR                            "DIO/PFI5"
+#define NIRFSA_VAL_DIO6_STR                            "DIO/PFI6"
+#define NIRFSA_VAL_DIO7_STR                            "DIO/PFI7"
 
 /*- Values for NIRFSA_ATTR_CONFIGURATION_LIST_STEP_TRIGGER_SOURCE -*/
 /* #define NIRFSA_VAL_TIMER_EVENT_STR                     "TimerEvent" (Defined Above) */
@@ -764,6 +779,7 @@ extern "C" {
 #define NIRFSA_VAL_DEEMBEDDING_TYPE_NONE                          3900
 #define NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR                        3901
 #define NIRFSA_VAL_DEEMBEDDING_TYPE_VECTOR                        3902
+#define NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_FLATNESS            3903
 
 /*- Values for niRFSA_ConfigureDeembeddingTableInterpolationLinear -*/
 #define NIRFSA_VAL_LINEAR_INTERPOLATION_FORMAT_REAL_AND_IMAGINARY      4000
@@ -782,6 +798,10 @@ extern "C" {
 /*- Values for NIRFSA_ATTR_USER_SOURCE_PULSE_WIDTH_UNITS -*/
 #define NIRFSA_VAL_PULSE_WIDTH_UNITS_SECONDS       6200
 #define NIRFSA_VAL_PULSE_WIDTH_UNITS_CLOCK_PERIODS 6201
+
+/*- Values for NIRFSA_ATTR_LOAD_CONFIGURATIONS_FROM_FILE_RESET_OPTIONS -*/
+#define NIRFSA_VAL_LOAD_CONFIGURATIONS_FROM_FILE_RESET_OPTIONS_SKIP_NONE                0x0ULL
+#define NIRFSA_VAL_LOAD_CONFIGURATIONS_FROM_FILE_RESET_OPTIONS_SKIP_DEEMBEDDING_TABLES  0x2ULL
 
 /*- SMT Structures -----------------------------------------------*/
 #if kRFSA_32BitPlatform
@@ -1047,6 +1067,20 @@ ViStatus _VI_FUNC niRFSA_ResetWithDefaults(
 ViStatus _VI_FUNC niRFSA_InvalidateAllAttributes(
    ViSession vi);
 
+/* Save Load Functions --------------------------------------*/
+ViStatus _VI_FUNC niRFSA_SaveConfigurationsToFile
+(
+   ViSession vi,
+   ViConstString channelName,
+   ViConstString filePath
+);
+
+ViStatus _VI_FUNC niRFSA_LoadConfigurationsFromFile
+(
+   ViSession vi,
+   ViConstString channelName,
+   ViConstString filePath
+);
 
 /*- Error Functions --------------------------------------------------------*/
 ViStatus _VI_FUNC niRFSA_GetError(
@@ -1241,28 +1275,12 @@ typedef struct niRFSA_coefficientInfo_struct
 } niRFSA_coefficientInfo;
 #pragma pack(pop)
 
-#if kRFSA_32BitPlatform
-   #pragma pack(push, 2)
-#elif kRFSA_64BitPlatform
-   // Nothing needed for 64 bit platforms
-#else
-   #error Unknown Platform
-#endif
-
 #if !defined(_NIComplexI16)
 #define _NIComplexI16
 typedef struct NIComplexI16_struct {
    ViInt16 real;
    ViInt16 imaginary;
 } NIComplexI16;
-#endif
-
-#if kRFSA_32BitPlatform
-   #pragma pack(pop)
-#elif kRFSA_64BitPlatform
-   // Nothing needed for 64 bit platforms
-#else
-   #error Unknown Platform
 #endif
 
 

--- a/source/codegen/metadata/nirfsa/attributes.py
+++ b/source/codegen/metadata/nirfsa/attributes.py
@@ -2115,5 +2115,45 @@ attributes = {
         'access': 'read-write',
         'name': 'DEEMBEDDING_COMPENSATION_GAIN',
         'type': 'ViReal64'
+    },
+    1150326: {
+        'access': 'read-write',
+        'name': 'EXPORTED_REF_CLOCK_RATE',
+        'type': 'ViReal64'
+    },
+    1150331: {
+        'access': 'read-write',
+        'name': 'SELECTED_PATH',
+        'type': 'ViString'
+    },
+    1150332: {
+        'access': 'read only',
+        'name': 'AVAILABLE_PATHS',
+        'type': 'ViString'
+    },
+    1150333: {
+        'access': 'read-write',
+        'name': 'CREATED_SESSION_CHANNEL',
+        'type': 'ViInt32'
+    },
+    1150334: {
+        'access': 'read only',
+        'name': 'MIN_FUNDAMENTAL_SILO_FREQUENCY',
+        'type': 'ViReal64'
+    },
+    1150335: {
+        'access': 'read only',
+        'name': 'MAX_FUNDAMENTAL_SILO_FREQUENCY',
+        'type': 'ViReal64'
+    },
+    1150337: {
+        'access': 'read-write',
+        'name': 'LOAD_CONFIGURATIONS_FROM_FILE_RESET_OPTIONS',
+        'type': 'ViInt32'
+    },
+    1150356: {
+        'access': 'read only',
+        'name': 'ASSOC_AUX_SWITCH_GAIN_UID',
+        'type': 'ViInt32'
     }
 }

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -2056,6 +2056,26 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'LoadConfigurationsFromFile': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'name': 'filePath',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'LockSession': {
         'codegen_method': 'private',
         'parameters': [
@@ -2295,6 +2315,26 @@ functions = {
                     'value': 256
                 },
                 'type': 'ViChar[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'SaveConfigurationsToFile': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'name': 'filePath',
+                'type': 'ViConstString'
             }
         ],
         'returns': 'ViStatus'


### PR DESCRIPTION
### What does this Pull Request accomplish?

There was a need to add gRPC Python support for the RFSA driver. Since we had the metadata for the RFSA of 21.0 release and was not in sync with the current RFSA API. The meta-data was needed to update with the current API header. Earlier the RFSA meta-data was generated with the srapigen tool, But since the fpx and sub files were not consistent with the current RFSA API, we had modified the meta-data manually using scripting/ manually matching with current header for newer APIs. We had assumed that the earlier meta-data was correct.

### Why should this Pull Request be merged?

The meta-data is updated, and the generated proto file is copied to the nimi-python repo for the client side stub generation. This will allow gRPC Python support for RFSA driver.

### What testing has been done?

Built the code locally and running the ni_grpc_device_server.exe and testing the python API with the gRPC Session.
<img width="1883" height="118" alt="image" src="https://github.com/user-attachments/assets/7c4f8eeb-4f86-48a0-8bd6-2cd39f353c60" />
