### PR TITLE
Copy server TLS config into output directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,6 +676,15 @@ add_custom_command(
             $<TARGET_FILE_DIR:ni_grpc_device_server>/server_config.json)
 
 #----------------------------------------------------------------------
+# Copy server_nitlsconfig.json to binary output directory
+#----------------------------------------------------------------------
+add_custom_command(
+   TARGET ni_grpc_device_server POST_BUILD
+   COMMAND  ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_SOURCE_DIR}/source/config/server_nitlsconfig.json
+            $<TARGET_FILE_DIR:ni_grpc_device_server>/server_nitlsconfig.json)
+
+#----------------------------------------------------------------------
 # Copy ni-grpc-device.conf.yml to binary output directory
 #----------------------------------------------------------------------
 add_custom_command(


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds a post-build CMake copy step for `server_nitlsconfig.json` so the TLS configuration file is copied into the `ni_grpc_device_server` binary output directory.

### Why should this Pull Request be merged?

The server expects its runtime configuration files to be available in the output directory. This change ensures the TLS config is staged alongside the server binary the same way other server config artifacts already are, which makes local runs and deployments more reliable.

### What testing has been done?

No additional tests were run for this change.

The change is limited to build-time staging logic in `CMakeLists.txt`.
