### PR TITLE
Replace trigger_azdo_ci.yml deprecated GitHub functionality  

### DIFF
--- a/.github/workflows/trigger_azdo_ci.yml
+++ b/.github/workflows/trigger_azdo_ci.yml
@@ -16,19 +16,25 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Trigger Main CI 
-      uses: Azure/pipelines@v1.2
       if: ${{ github.repository == 'ni/grpc-device' && github.event.workflow_run.head_branch == 'main' }}
-      with:
-        azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
-        azure-pipeline-name: 'ni-central-grpc_device'
-        azure-devops-token: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
-        azure-pipeline-variables: '{"BRANCH": "main", "EXPORT_NAME": "ni-grpc-device", "PHASE": "d"}'
+      shell: pwsh
+      env:
+        AZDO_TOKEN: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
+      run: |
+        $token = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$env:AZDO_TOKEN"))
+        $headers = @{ Authorization = "Basic $token"; 'Content-Type' = 'application/json' }
+        $defs = Invoke-RestMethod -Uri 'https://dev.azure.com/ni/DevCentral/_apis/build/definitions?name=ni-central-grpc_device&api-version=7.1' -Headers $headers
+        $body = @{ definition = @{ id = $defs.value[0].id }; parameters = '{"BRANCH": "main", "EXPORT_NAME": "ni-grpc-device", "PHASE": "d"}' } | ConvertTo-Json
+        Invoke-RestMethod -Method Post -Uri 'https://dev.azure.com/ni/DevCentral/_apis/build/builds?api-version=7.1' -Headers $headers -Body $body
                                   
     - name: Trigger Release CI 
-      uses: Azure/pipelines@v1.2
       if: ${{ github.repository == 'ni/grpc-device' && startsWith(github.event.workflow_run.head_branch, 'releases') }}
-      with:
-        azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
-        azure-pipeline-name: 'ni-central-grpc_device'
-        azure-devops-token: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
-        azure-pipeline-variables: '{"BRANCH": "releases", "EXPORT_NAME": "ni-grpc-device", "PHASE": "f", "RELEASE_BRANCH_OPTION": "--release-branch"}'
+      shell: pwsh
+      env:
+        AZDO_TOKEN: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
+      run: |
+        $token = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$env:AZDO_TOKEN"))
+        $headers = @{ Authorization = "Basic $token"; 'Content-Type' = 'application/json' }
+        $defs = Invoke-RestMethod -Uri 'https://dev.azure.com/ni/DevCentral/_apis/build/definitions?name=ni-central-grpc_device&api-version=7.1' -Headers $headers
+        $body = @{ definition = @{ id = $defs.value[0].id }; parameters = '{"BRANCH": "releases", "EXPORT_NAME": "ni-grpc-device", "PHASE": "f", "RELEASE_BRANCH_OPTION": "--release-branch"}' } | ConvertTo-Json
+        Invoke-RestMethod -Method Post -Uri 'https://dev.azure.com/ni/DevCentral/_apis/build/builds?api-version=7.1' -Headers $headers -Body $body


### PR DESCRIPTION
### What does this Pull Request accomplish?

#1265
Removes the use of Azure/pipelines@v1.2 which uses Node.js 20 (deprecated, will be removed Sept 16 2026) and set-output command that's also deprecated. Uses the AzDO REST API instead

### Why should this Pull Request be merged?

To replace deprecated functionality before it is removed.

### What testing has been done?

I made an edit (not included here) to allow the Trigger Main CI step to run on my branch with the final Post commented out (so not to trigger a real build) and had it instead display $body. Verified the content looks good.

```
Would POST: {
  "definition": {
    "id": 13779
  },
  "parameters": "{\"BRANCH\": \"main\", \"EXPORT_NAME\": \"ni-grpc-device\", \"PHASE\": \"d\"}"
}
```
Warnings are also no longer present.
https://github.com/ni/grpc-device/actions/runs/29596523840/job/87938161133