### PR TITLE
Update client and server configs to enable mTLS by default.

### DIFF
--- a/source/config/ni-grpc-device.client.caps.yml
+++ b/source/config/ni-grpc-device.client.caps.yml
@@ -6,6 +6,7 @@
 #
 # supports_certificate_chain_file_scheme: Whether file:// URI scheme is supported for certs
 # supports_certificate_key_file_scheme: Whether file:// URI scheme is supported for keys
+# supports_trusted_certificates_core_schemes: Indicates the client supports whatever schemes are supported natively by ni-tls-config.
 # supports_trusted_certificates_file_scheme: Whether file:// URI scheme is supported for trusted certs
 # supports_trusted_certificates_directory_scheme: Whether directory:// URI scheme is supported for trusted certs
 #
@@ -14,5 +15,6 @@ supports_server_mode_trust_always: false
 
 supports_certificate_chain_file_scheme: true
 supports_certificate_key_file_scheme: true
+supports_trusted_certificates_core_schemes: true
 supports_trusted_certificates_file_scheme: true
 supports_trusted_certificates_directory_scheme: false

--- a/source/config/ni-grpc-device.client.defaults.yml
+++ b/source/config/ni-grpc-device.client.defaults.yml
@@ -23,8 +23,8 @@ file_version: 1
 #   SystemDefault: Use system-default CA certificates.
 #   To use specific certificates, override in known_servers.yml per-server.
 #
-certificate_mode: Disabled
+certificate_mode: Managed
 certificate_chain: file://$(UserServicesDir)/$(Service)/cert.pem
 certificate_key: file://$(UserServicesDir)/$(Service)/key.pem
-server_mode: Disabled
+server_mode: TrustedCertificates
 trusted_certificates: SystemDefault

--- a/source/config/ni-grpc-device.server.caps.yml
+++ b/source/config/ni-grpc-device.server.caps.yml
@@ -9,6 +9,7 @@
 #
 # supports_certificate_chain_file_scheme: Whether file:// URI scheme is supported for certs
 # supports_certificate_key_file_scheme: Whether file:// URI scheme is supported for keys
+# supports_trusted_certificates_core_schemes: Indicates the server supports whatever schemes are supported natively by ni-tls-config.
 # supports_trusted_certificates_file_scheme: Whether file:// URI scheme is supported for trusted certs
 # supports_trusted_certificates_directory_scheme: Whether directory:// URI scheme is supported for trusted certs
 #
@@ -19,5 +20,6 @@ update_trusted_certificates_without_restart: false
 
 supports_certificate_chain_file_scheme: true
 supports_certificate_key_file_scheme: true
+supports_trusted_certificates_core_schemes: true
 supports_trusted_certificates_file_scheme: true
 supports_trusted_certificates_directory_scheme: true

--- a/source/config/ni-grpc-device.server.conf.yml
+++ b/source/config/ni-grpc-device.server.conf.yml
@@ -25,8 +25,8 @@ file_version: 1
 #   directory://: Server loads all .pem files in the directory.
 #   Substitution variables: $(SystemServicesDir), $(Service)
 #
-certificate_mode: Disabled
+certificate_mode: ManagedSelfSigned
 certificate_chain: file://$(SystemServicesDir)/$(Service)/cert.pem
 certificate_key: file://$(SystemServicesDir)/$(Service)/key.pem
-client_mode: Disabled
+client_mode: ManagedSelfSigned
 trusted_certificates: directory://$(SystemServicesDir)/$(Service)/trusted.d


### PR DESCRIPTION
### What does this Pull Request accomplish?

When using ni-tls-config, use mTLS by default.

### Why should this Pull Request be merged?

When using ni-tls-config we should have secure default configs that enforce the use of mTLS.

### What testing has been done?

I was able to use NI-DMM with mTLS from a Windows host to a Linux RT target running the grpc-device server.
