### PR TITLE
Document Debian kernel headers prerequisite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,11 @@ For Debian/Ubuntu, install git, cmake (3.18.0 or newer), and mako:
 > sudo apt-get install ninja-build   # optional
 ```
 
+For Debian, install the headers for the running kernel before installing NI drivers:
+```
+> sudo apt-get install linux-headers-$(uname -r)
+```
+
 For NI Linux RT, install packagegroup-core-buildessential, git, git-perltools, cmake (3.18.0 or newer), python3-utils, and mako:
 ```
 > opkg update


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add a Debian-specific prerequisite to install the headers for the running kernel before installing NI drivers.

Without the matching kernel headers, NI driver installation can fail and subsequent communication with the grpc-device server may result in a segmentation fault.

Fixes Issue #1278.

### Why should this Pull Request be merged?

This change documents a required setup step that may otherwise fail silently on Debian. It helps users avoid an NI driver installation failure and makes the resulting grpc-device server failure easier to prevent and diagnose.

### What testing has been done?

Not tested. Documentation-only change.
