### PR TITLE
Add DisableCalibrationPlane, EnableCalibrationPlane deembedding functions to NI-RFSA and NI-RFSG

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Indicates the most recent driver version used to test builds of the current sour
 | NI-RFmx WCDMA             | 2025 Q1       | Not Supported | Not Supported |
 | NI-RFmx WLAN              | 2026 Q3       | Not Supported | Not Supported |
 | NI-RFmx WLANGen           | 2026 Q2       | Not Supported | Not Supported |
-| NI-RFSA                   | 2026 Q2       | 2026 Q2       | 2026 Q2       |
-| NI-RFSG                   | 2025 Q3       | 2025 Q3       | 2025 Q3       |
+| NI-RFSA                   | 2026 Q4       | 2026 Q4       | 2026 Q4       |
+| NI-RFSG                   | 2026 Q4       | 2026 Q4       | 2026 Q4       |
 | NI-SCOPE                  | 2023 Q2       | 2023 Q2       | 2023 Q2       |
 | NI-SWITCH                 | 2023 Q1       | 2023 Q1       | 2023 Q1       |
 | NI-TClk                   | 2023 Q1       | 2023 Q1       | 2023 Q1       |

--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFSA API metadata version 21.0.0
+// This file is generated from NI-RFSA API metadata version 26.8.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFSA Metadata
 //---------------------------------------------------------------------

--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -53,8 +53,10 @@ service NiRFSA {
   rpc DeleteDeembeddingTable(DeleteDeembeddingTableRequest) returns (DeleteDeembeddingTableResponse);
   rpc Disable(DisableRequest) returns (DisableResponse);
   rpc DisableAdvanceTrigger(DisableAdvanceTriggerRequest) returns (DisableAdvanceTriggerResponse);
+  rpc DisableCalibrationPlane(DisableCalibrationPlaneRequest) returns (DisableCalibrationPlaneResponse);
   rpc DisableRefTrigger(DisableRefTriggerRequest) returns (DisableRefTriggerResponse);
   rpc DisableStartTrigger(DisableStartTriggerRequest) returns (DisableStartTriggerResponse);
+  rpc EnableCalibrationPlane(EnableCalibrationPlaneRequest) returns (EnableCalibrationPlaneResponse);
   rpc EnableSessionAccess(EnableSessionAccessRequest) returns (EnableSessionAccessResponse);
   rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
   rpc ErrorQuery(ErrorQueryRequest) returns (ErrorQueryResponse);
@@ -1154,6 +1156,15 @@ message DisableAdvanceTriggerResponse {
   int32 status = 1;
 }
 
+message DisableCalibrationPlaneRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message DisableCalibrationPlaneResponse {
+  int32 status = 1;
+}
+
 message DisableRefTriggerRequest {
   nidevice_grpc.Session vi = 1;
 }
@@ -1167,6 +1178,15 @@ message DisableStartTriggerRequest {
 }
 
 message DisableStartTriggerResponse {
+  int32 status = 1;
+}
+
+message EnableCalibrationPlaneRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message EnableCalibrationPlaneResponse {
   int32 status = 1;
 }
 

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -779,6 +779,24 @@ disable_advance_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
+DisableCalibrationPlaneResponse
+disable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name)
+{
+  ::grpc::ClientContext context;
+
+  auto request = DisableCalibrationPlaneRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+
+  auto response = DisableCalibrationPlaneResponse{};
+
+  raise_if_error(
+      stub->DisableCalibrationPlane(&context, request, &response),
+      context);
+
+  return response;
+}
+
 DisableRefTriggerResponse
 disable_ref_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
@@ -808,6 +826,24 @@ disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
 
   raise_if_error(
       stub->DisableStartTrigger(&context, request, &response),
+      context);
+
+  return response;
+}
+
+EnableCalibrationPlaneResponse
+enable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name)
+{
+  ::grpc::ClientContext context;
+
+  auto request = EnableCalibrationPlaneRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+
+  auto response = EnableCalibrationPlaneResponse{};
+
+  raise_if_error(
+      stub->EnableCalibrationPlane(&context, request, &response),
       context);
 
   return response;

--- a/generated/nirfsa/nirfsa_client.h
+++ b/generated/nirfsa/nirfsa_client.h
@@ -58,8 +58,10 @@ DeleteConfigurationListResponse delete_configuration_list(const StubPtr& stub, c
 DeleteDeembeddingTableResponse delete_deembedding_table(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& port, const std::string& table_name);
 DisableResponse disable(const StubPtr& stub, const nidevice_grpc::Session& vi);
 DisableAdvanceTriggerResponse disable_advance_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi);
+DisableCalibrationPlaneResponse disable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name);
 DisableRefTriggerResponse disable_ref_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi);
 DisableStartTriggerResponse disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi);
+EnableCalibrationPlaneResponse enable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name);
 EnableSessionAccessResponse enable_session_access(const StubPtr& stub, const nidevice_grpc::Session& vi, const bool& enable);
 ErrorMessageResponse error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& status_code);
 ErrorQueryResponse error_query(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/generated/nirfsa/nirfsa_compilation_test.cpp
+++ b/generated/nirfsa/nirfsa_compilation_test.cpp
@@ -187,6 +187,11 @@ ViStatus DisableAdvanceTrigger(ViSession vi)
   return niRFSA_DisableAdvanceTrigger(vi);
 }
 
+ViStatus DisableCalibrationPlane(ViSession vi, ViConstString channelName)
+{
+  return niRFSA_DisableCalibrationPlane(vi, channelName);
+}
+
 ViStatus DisableRefTrigger(ViSession vi)
 {
   return niRFSA_DisableRefTrigger(vi);
@@ -195,6 +200,11 @@ ViStatus DisableRefTrigger(ViSession vi)
 ViStatus DisableStartTrigger(ViSession vi)
 {
   return niRFSA_DisableStartTrigger(vi);
+}
+
+ViStatus EnableCalibrationPlane(ViSession vi, ViConstString channelName)
+{
+  return niRFSA_EnableCalibrationPlane(vi, channelName);
 }
 
 ViStatus EnableSessionAccess(ViSession vi, ViBoolean enable)

--- a/generated/nirfsa/nirfsa_library.cpp
+++ b/generated/nirfsa/nirfsa_library.cpp
@@ -63,8 +63,10 @@ NiRFSALibrary::NiRFSALibrary(std::shared_ptr<nidevice_grpc::SharedLibraryInterfa
   function_pointers_.DeleteDeembeddingTable = reinterpret_cast<DeleteDeembeddingTablePtr>(shared_library_->get_function_pointer("niRFSA_DeleteDeembeddingTable"));
   function_pointers_.Disable = reinterpret_cast<DisablePtr>(shared_library_->get_function_pointer("niRFSA_Disable"));
   function_pointers_.DisableAdvanceTrigger = reinterpret_cast<DisableAdvanceTriggerPtr>(shared_library_->get_function_pointer("niRFSA_DisableAdvanceTrigger"));
+  function_pointers_.DisableCalibrationPlane = reinterpret_cast<DisableCalibrationPlanePtr>(shared_library_->get_function_pointer("niRFSA_DisableCalibrationPlane"));
   function_pointers_.DisableRefTrigger = reinterpret_cast<DisableRefTriggerPtr>(shared_library_->get_function_pointer("niRFSA_DisableRefTrigger"));
   function_pointers_.DisableStartTrigger = reinterpret_cast<DisableStartTriggerPtr>(shared_library_->get_function_pointer("niRFSA_DisableStartTrigger"));
+  function_pointers_.EnableCalibrationPlane = reinterpret_cast<EnableCalibrationPlanePtr>(shared_library_->get_function_pointer("niRFSA_EnableCalibrationPlane"));
   function_pointers_.EnableSessionAccess = reinterpret_cast<EnableSessionAccessPtr>(shared_library_->get_function_pointer("niRFSA_EnableSessionAccess"));
   function_pointers_.ErrorMessage = reinterpret_cast<ErrorMessagePtr>(shared_library_->get_function_pointer("niRFSA_error_message"));
   function_pointers_.ErrorQuery = reinterpret_cast<ErrorQueryPtr>(shared_library_->get_function_pointer("niRFSA_error_query"));
@@ -435,6 +437,14 @@ ViStatus NiRFSALibrary::DisableAdvanceTrigger(ViSession vi)
   return function_pointers_.DisableAdvanceTrigger(vi);
 }
 
+ViStatus NiRFSALibrary::DisableCalibrationPlane(ViSession vi, ViConstString channelName)
+{
+  if (!function_pointers_.DisableCalibrationPlane) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_DisableCalibrationPlane.");
+  }
+  return function_pointers_.DisableCalibrationPlane(vi, channelName);
+}
+
 ViStatus NiRFSALibrary::DisableRefTrigger(ViSession vi)
 {
   if (!function_pointers_.DisableRefTrigger) {
@@ -449,6 +459,14 @@ ViStatus NiRFSALibrary::DisableStartTrigger(ViSession vi)
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_DisableStartTrigger.");
   }
   return function_pointers_.DisableStartTrigger(vi);
+}
+
+ViStatus NiRFSALibrary::EnableCalibrationPlane(ViSession vi, ViConstString channelName)
+{
+  if (!function_pointers_.EnableCalibrationPlane) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_EnableCalibrationPlane.");
+  }
+  return function_pointers_.EnableCalibrationPlane(vi, channelName);
 }
 
 ViStatus NiRFSALibrary::EnableSessionAccess(ViSession vi, ViBoolean enable)

--- a/generated/nirfsa/nirfsa_library.h
+++ b/generated/nirfsa/nirfsa_library.h
@@ -57,8 +57,10 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   ViStatus DeleteDeembeddingTable(ViSession vi, ViConstString port, ViConstString tableName) override;
   ViStatus Disable(ViSession vi) override;
   ViStatus DisableAdvanceTrigger(ViSession vi) override;
+  ViStatus DisableCalibrationPlane(ViSession vi, ViConstString channelName) override;
   ViStatus DisableRefTrigger(ViSession vi) override;
   ViStatus DisableStartTrigger(ViSession vi) override;
+  ViStatus EnableCalibrationPlane(ViSession vi, ViConstString channelName) override;
   ViStatus EnableSessionAccess(ViSession vi, ViBoolean enable) override;
   ViStatus ErrorMessage(ViSession vi, ViStatus statusCode, ViChar errorMessage[1024]) override;
   ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]) override;
@@ -166,8 +168,10 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   using DeleteDeembeddingTablePtr = decltype(&niRFSA_DeleteDeembeddingTable);
   using DisablePtr = decltype(&niRFSA_Disable);
   using DisableAdvanceTriggerPtr = decltype(&niRFSA_DisableAdvanceTrigger);
+  using DisableCalibrationPlanePtr = decltype(&niRFSA_DisableCalibrationPlane);
   using DisableRefTriggerPtr = decltype(&niRFSA_DisableRefTrigger);
   using DisableStartTriggerPtr = decltype(&niRFSA_DisableStartTrigger);
+  using EnableCalibrationPlanePtr = decltype(&niRFSA_EnableCalibrationPlane);
   using EnableSessionAccessPtr = decltype(&niRFSA_EnableSessionAccess);
   using ErrorMessagePtr = decltype(&niRFSA_error_message);
   using ErrorQueryPtr = decltype(&niRFSA_error_query);
@@ -275,8 +279,10 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
     DeleteDeembeddingTablePtr DeleteDeembeddingTable;
     DisablePtr Disable;
     DisableAdvanceTriggerPtr DisableAdvanceTrigger;
+    DisableCalibrationPlanePtr DisableCalibrationPlane;
     DisableRefTriggerPtr DisableRefTrigger;
     DisableStartTriggerPtr DisableStartTrigger;
+    EnableCalibrationPlanePtr EnableCalibrationPlane;
     EnableSessionAccessPtr EnableSessionAccess;
     ErrorMessagePtr ErrorMessage;
     ErrorQueryPtr ErrorQuery;

--- a/generated/nirfsa/nirfsa_library_interface.h
+++ b/generated/nirfsa/nirfsa_library_interface.h
@@ -52,8 +52,10 @@ class NiRFSALibraryInterface {
   virtual ViStatus DeleteDeembeddingTable(ViSession vi, ViConstString port, ViConstString tableName) = 0;
   virtual ViStatus Disable(ViSession vi) = 0;
   virtual ViStatus DisableAdvanceTrigger(ViSession vi) = 0;
+  virtual ViStatus DisableCalibrationPlane(ViSession vi, ViConstString channelName) = 0;
   virtual ViStatus DisableRefTrigger(ViSession vi) = 0;
   virtual ViStatus DisableStartTrigger(ViSession vi) = 0;
+  virtual ViStatus EnableCalibrationPlane(ViSession vi, ViConstString channelName) = 0;
   virtual ViStatus EnableSessionAccess(ViSession vi, ViBoolean enable) = 0;
   virtual ViStatus ErrorMessage(ViSession vi, ViStatus statusCode, ViChar errorMessage[1024]) = 0;
   virtual ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]) = 0;

--- a/generated/nirfsa/nirfsa_mock_library.h
+++ b/generated/nirfsa/nirfsa_mock_library.h
@@ -53,8 +53,10 @@ class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   MOCK_METHOD(ViStatus, DeleteDeembeddingTable, (ViSession vi, ViConstString port, ViConstString tableName), (override));
   MOCK_METHOD(ViStatus, Disable, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, DisableAdvanceTrigger, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, DisableCalibrationPlane, (ViSession vi, ViConstString channelName), (override));
   MOCK_METHOD(ViStatus, DisableRefTrigger, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, DisableStartTrigger, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, EnableCalibrationPlane, (ViSession vi, ViConstString channelName), (override));
   MOCK_METHOD(ViStatus, EnableSessionAccess, (ViSession vi, ViBoolean enable), (override));
   MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus statusCode, ViChar errorMessage[1024]), (override));
   MOCK_METHOD(ViStatus, ErrorQuery, (ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]), (override));

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -1157,6 +1157,30 @@ namespace nirfsa_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFSAService::DisableCalibrationPlane(::grpc::ServerContext* context, const DisableCalibrationPlaneRequest* request, DisableCalibrationPlaneResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      auto channel_name_mbcs = convert_from_grpc<std::string>(request->channel_name());
+      auto channel_name = channel_name_mbcs.c_str();
+      auto status = library_->DisableCalibrationPlane(vi, channel_name);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFSAService::DisableRefTrigger(::grpc::ServerContext* context, const DisableRefTriggerRequest* request, DisableRefTriggerResponse* response)
   {
     if (context->IsCancelled()) {
@@ -1188,6 +1212,30 @@ namespace nirfsa_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFSAService::EnableCalibrationPlane(::grpc::ServerContext* context, const EnableCalibrationPlaneRequest* request, EnableCalibrationPlaneResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      auto channel_name_mbcs = convert_from_grpc<std::string>(request->channel_name());
+      auto channel_name = channel_name_mbcs.c_str();
+      auto status = library_->EnableCalibrationPlane(vi, channel_name);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }

--- a/generated/nirfsa/nirfsa_service.h
+++ b/generated/nirfsa/nirfsa_service.h
@@ -78,8 +78,10 @@ public:
   ::grpc::Status DeleteDeembeddingTable(::grpc::ServerContext* context, const DeleteDeembeddingTableRequest* request, DeleteDeembeddingTableResponse* response) override;
   ::grpc::Status Disable(::grpc::ServerContext* context, const DisableRequest* request, DisableResponse* response) override;
   ::grpc::Status DisableAdvanceTrigger(::grpc::ServerContext* context, const DisableAdvanceTriggerRequest* request, DisableAdvanceTriggerResponse* response) override;
+  ::grpc::Status DisableCalibrationPlane(::grpc::ServerContext* context, const DisableCalibrationPlaneRequest* request, DisableCalibrationPlaneResponse* response) override;
   ::grpc::Status DisableRefTrigger(::grpc::ServerContext* context, const DisableRefTriggerRequest* request, DisableRefTriggerResponse* response) override;
   ::grpc::Status DisableStartTrigger(::grpc::ServerContext* context, const DisableStartTriggerRequest* request, DisableStartTriggerResponse* response) override;
+  ::grpc::Status EnableCalibrationPlane(::grpc::ServerContext* context, const EnableCalibrationPlaneRequest* request, EnableCalibrationPlaneResponse* response) override;
   ::grpc::Status EnableSessionAccess(::grpc::ServerContext* context, const EnableSessionAccessRequest* request, EnableSessionAccessResponse* response) override;
   ::grpc::Status ErrorMessage(::grpc::ServerContext* context, const ErrorMessageRequest* request, ErrorMessageResponse* response) override;
   ::grpc::Status ErrorQuery(::grpc::ServerContext* context, const ErrorQueryRequest* request, ErrorQueryResponse* response) override;

--- a/generated/nirfsg/nirfsg.proto
+++ b/generated/nirfsg/nirfsg.proto
@@ -59,6 +59,7 @@ service NiRFSG {
   rpc CreateDeembeddingSparameterTableArray(CreateDeembeddingSparameterTableArrayRequest) returns (CreateDeembeddingSparameterTableArrayResponse);
   rpc CreateDeembeddingSparameterTableS2PFile(CreateDeembeddingSparameterTableS2PFileRequest) returns (CreateDeembeddingSparameterTableS2PFileResponse);
   rpc DeleteAllDeembeddingTables(DeleteAllDeembeddingTablesRequest) returns (DeleteAllDeembeddingTablesResponse);
+  rpc DisableCalibrationPlane(DisableCalibrationPlaneRequest) returns (DisableCalibrationPlaneResponse);
   rpc DeleteConfigurationList(DeleteConfigurationListRequest) returns (DeleteConfigurationListResponse);
   rpc DeleteDeembeddingTable(DeleteDeembeddingTableRequest) returns (DeleteDeembeddingTableResponse);
   rpc DeleteScript(DeleteScriptRequest) returns (DeleteScriptResponse);
@@ -67,6 +68,7 @@ service NiRFSG {
   rpc DisableConfigurationListStepTrigger(DisableConfigurationListStepTriggerRequest) returns (DisableConfigurationListStepTriggerResponse);
   rpc DisableScriptTrigger(DisableScriptTriggerRequest) returns (DisableScriptTriggerResponse);
   rpc DisableStartTrigger(DisableStartTriggerRequest) returns (DisableStartTriggerResponse);
+  rpc EnableCalibrationPlane(EnableCalibrationPlaneRequest) returns (EnableCalibrationPlaneResponse);
   rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
   rpc ErrorQuery(ErrorQueryRequest) returns (ErrorQueryResponse);
   rpc ExportSignal(ExportSignalRequest) returns (ExportSignalResponse);
@@ -1286,6 +1288,15 @@ message DeleteAllDeembeddingTablesResponse {
   int32 status = 1;
 }
 
+message DisableCalibrationPlaneRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message DisableCalibrationPlaneResponse {
+  int32 status = 1;
+}
+
 message DeleteConfigurationListRequest {
   nidevice_grpc.Session vi = 1;
   string list_name = 2;
@@ -1355,6 +1366,15 @@ message DisableStartTriggerRequest {
 }
 
 message DisableStartTriggerResponse {
+  int32 status = 1;
+}
+
+message EnableCalibrationPlaneRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+}
+
+message EnableCalibrationPlaneResponse {
   int32 status = 1;
 }
 

--- a/generated/nirfsg/nirfsg.proto
+++ b/generated/nirfsg/nirfsg.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFSG API metadata version 25.5.0
+// This file is generated from NI-RFSG API metadata version 26.8.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFSG Metadata
 //---------------------------------------------------------------------

--- a/generated/nirfsg/nirfsg_client.cpp
+++ b/generated/nirfsg/nirfsg_client.cpp
@@ -947,6 +947,24 @@ delete_all_deembedding_tables(const StubPtr& stub, const nidevice_grpc::Session&
   return response;
 }
 
+DisableCalibrationPlaneResponse
+disable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name)
+{
+  ::grpc::ClientContext context;
+
+  auto request = DisableCalibrationPlaneRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+
+  auto response = DisableCalibrationPlaneResponse{};
+
+  raise_if_error(
+      stub->DisableCalibrationPlane(&context, request, &response),
+      context);
+
+  return response;
+}
+
 DeleteConfigurationListResponse
 delete_configuration_list(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& list_name)
 {
@@ -1090,6 +1108,24 @@ disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
 
   raise_if_error(
       stub->DisableStartTrigger(&context, request, &response),
+      context);
+
+  return response;
+}
+
+EnableCalibrationPlaneResponse
+enable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name)
+{
+  ::grpc::ClientContext context;
+
+  auto request = EnableCalibrationPlaneRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+
+  auto response = EnableCalibrationPlaneResponse{};
+
+  raise_if_error(
+      stub->EnableCalibrationPlane(&context, request, &response),
       context);
 
   return response;

--- a/generated/nirfsg/nirfsg_client.h
+++ b/generated/nirfsg/nirfsg_client.h
@@ -64,6 +64,7 @@ CreateConfigurationListStepResponse create_configuration_list_step(const StubPtr
 CreateDeembeddingSparameterTableArrayResponse create_deembedding_sparameter_table_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& port, const std::string& table_name, const std::vector<double>& frequencies, const std::vector<nidevice_grpc::NIComplexNumber>& sparameter_table, const pb::int32& number_of_ports, const simple_variant<SParameterOrientation, pb::int32>& sparameter_orientation);
 CreateDeembeddingSparameterTableS2PFileResponse create_deembedding_sparameter_table_s2p_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& port, const std::string& table_name, const std::string& s2p_file_path, const simple_variant<SParameterOrientation, pb::int32>& sparameter_orientation);
 DeleteAllDeembeddingTablesResponse delete_all_deembedding_tables(const StubPtr& stub, const nidevice_grpc::Session& vi);
+DisableCalibrationPlaneResponse disable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name);
 DeleteConfigurationListResponse delete_configuration_list(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& list_name);
 DeleteDeembeddingTableResponse delete_deembedding_table(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& port, const std::string& table_name);
 DeleteScriptResponse delete_script(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& script_name);
@@ -72,6 +73,7 @@ DisableAllModulationResponse disable_all_modulation(const StubPtr& stub, const n
 DisableConfigurationListStepTriggerResponse disable_configuration_list_step_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi);
 DisableScriptTriggerResponse disable_script_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<DigitalEdgeScriptTriggerIdentifier, std::string>& trigger_id);
 DisableStartTriggerResponse disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi);
+EnableCalibrationPlaneResponse enable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_name);
 ErrorMessageResponse error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& error_code);
 ErrorQueryResponse error_query(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ExportSignalResponse export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<RoutedSignal, pb::int32>& signal, const simple_variant<SignalIdentifier, std::string>& signal_identifier, const simple_variant<OutputSignal, std::string>& output_terminal);

--- a/generated/nirfsg/nirfsg_compilation_test.cpp
+++ b/generated/nirfsg/nirfsg_compilation_test.cpp
@@ -217,6 +217,11 @@ ViStatus DeleteAllDeembeddingTables(ViSession vi)
   return niRFSG_DeleteAllDeembeddingTables(vi);
 }
 
+ViStatus DisableCalibrationPlane(ViSession vi, ViConstString channelName)
+{
+  return niRFSG_DisableCalibrationPlane(vi, channelName);
+}
+
 ViStatus DeleteConfigurationList(ViSession vi, ViConstString listName)
 {
   return niRFSG_DeleteConfigurationList(vi, listName);
@@ -255,6 +260,11 @@ ViStatus DisableScriptTrigger(ViSession vi, ViConstString triggerID)
 ViStatus DisableStartTrigger(ViSession vi)
 {
   return niRFSG_DisableStartTrigger(vi);
+}
+
+ViStatus EnableCalibrationPlane(ViSession vi, ViConstString channelName)
+{
+  return niRFSG_EnableCalibrationPlane(vi, channelName);
 }
 
 ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[1024])

--- a/generated/nirfsg/nirfsg_library.cpp
+++ b/generated/nirfsg/nirfsg_library.cpp
@@ -69,6 +69,7 @@ NiRFSGLibrary::NiRFSGLibrary(std::shared_ptr<nidevice_grpc::SharedLibraryInterfa
   function_pointers_.CreateDeembeddingSparameterTableArray = reinterpret_cast<CreateDeembeddingSparameterTableArrayPtr>(shared_library_->get_function_pointer("niRFSG_CreateDeembeddingSparameterTableArray"));
   function_pointers_.CreateDeembeddingSparameterTableS2PFile = reinterpret_cast<CreateDeembeddingSparameterTableS2PFilePtr>(shared_library_->get_function_pointer("niRFSG_CreateDeembeddingSparameterTableS2PFile"));
   function_pointers_.DeleteAllDeembeddingTables = reinterpret_cast<DeleteAllDeembeddingTablesPtr>(shared_library_->get_function_pointer("niRFSG_DeleteAllDeembeddingTables"));
+  function_pointers_.DisableCalibrationPlane = reinterpret_cast<DisableCalibrationPlanePtr>(shared_library_->get_function_pointer("niRFSG_DisableCalibrationPlane"));
   function_pointers_.DeleteConfigurationList = reinterpret_cast<DeleteConfigurationListPtr>(shared_library_->get_function_pointer("niRFSG_DeleteConfigurationList"));
   function_pointers_.DeleteDeembeddingTable = reinterpret_cast<DeleteDeembeddingTablePtr>(shared_library_->get_function_pointer("niRFSG_DeleteDeembeddingTable"));
   function_pointers_.DeleteScript = reinterpret_cast<DeleteScriptPtr>(shared_library_->get_function_pointer("niRFSG_DeleteScript"));
@@ -77,6 +78,7 @@ NiRFSGLibrary::NiRFSGLibrary(std::shared_ptr<nidevice_grpc::SharedLibraryInterfa
   function_pointers_.DisableConfigurationListStepTrigger = reinterpret_cast<DisableConfigurationListStepTriggerPtr>(shared_library_->get_function_pointer("niRFSG_DisableConfigurationListStepTrigger"));
   function_pointers_.DisableScriptTrigger = reinterpret_cast<DisableScriptTriggerPtr>(shared_library_->get_function_pointer("niRFSG_DisableScriptTrigger"));
   function_pointers_.DisableStartTrigger = reinterpret_cast<DisableStartTriggerPtr>(shared_library_->get_function_pointer("niRFSG_DisableStartTrigger"));
+  function_pointers_.EnableCalibrationPlane = reinterpret_cast<EnableCalibrationPlanePtr>(shared_library_->get_function_pointer("niRFSG_EnableCalibrationPlane"));
   function_pointers_.ErrorMessage = reinterpret_cast<ErrorMessagePtr>(shared_library_->get_function_pointer("niRFSG_error_message"));
   function_pointers_.ErrorQuery = reinterpret_cast<ErrorQueryPtr>(shared_library_->get_function_pointer("niRFSG_error_query"));
   function_pointers_.ExportSignal = reinterpret_cast<ExportSignalPtr>(shared_library_->get_function_pointer("niRFSG_ExportSignal"));
@@ -491,6 +493,14 @@ ViStatus NiRFSGLibrary::DeleteAllDeembeddingTables(ViSession vi)
   return function_pointers_.DeleteAllDeembeddingTables(vi);
 }
 
+ViStatus NiRFSGLibrary::DisableCalibrationPlane(ViSession vi, ViConstString channelName)
+{
+  if (!function_pointers_.DisableCalibrationPlane) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niRFSG_DisableCalibrationPlane.");
+  }
+  return function_pointers_.DisableCalibrationPlane(vi, channelName);
+}
+
 ViStatus NiRFSGLibrary::DeleteConfigurationList(ViSession vi, ViConstString listName)
 {
   if (!function_pointers_.DeleteConfigurationList) {
@@ -553,6 +563,14 @@ ViStatus NiRFSGLibrary::DisableStartTrigger(ViSession vi)
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSG_DisableStartTrigger.");
   }
   return function_pointers_.DisableStartTrigger(vi);
+}
+
+ViStatus NiRFSGLibrary::EnableCalibrationPlane(ViSession vi, ViConstString channelName)
+{
+  if (!function_pointers_.EnableCalibrationPlane) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niRFSG_EnableCalibrationPlane.");
+  }
+  return function_pointers_.EnableCalibrationPlane(vi, channelName);
 }
 
 ViStatus NiRFSGLibrary::ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[1024])

--- a/generated/nirfsg/nirfsg_library.h
+++ b/generated/nirfsg/nirfsg_library.h
@@ -63,6 +63,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   ViStatus CreateDeembeddingSparameterTableArray(ViSession vi, ViConstString port, ViConstString tableName, ViReal64 frequencies[], ViInt32 frequenciesSize, NIComplexNumber_struct sparameterTable[], ViInt32 sparameterTableSize, ViInt32 numberOfPorts, ViInt32 sparameterOrientation) override;
   ViStatus CreateDeembeddingSparameterTableS2PFile(ViSession vi, ViConstString port, ViConstString tableName, ViConstString s2pFilePath, ViInt32 sparameterOrientation) override;
   ViStatus DeleteAllDeembeddingTables(ViSession vi) override;
+  ViStatus DisableCalibrationPlane(ViSession vi, ViConstString channelName) override;
   ViStatus DeleteConfigurationList(ViSession vi, ViConstString listName) override;
   ViStatus DeleteDeembeddingTable(ViSession vi, ViConstString port, ViConstString tableName) override;
   ViStatus DeleteScript(ViSession vi, ViConstString scriptName) override;
@@ -71,6 +72,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   ViStatus DisableConfigurationListStepTrigger(ViSession vi) override;
   ViStatus DisableScriptTrigger(ViSession vi, ViConstString triggerID) override;
   ViStatus DisableStartTrigger(ViSession vi) override;
+  ViStatus EnableCalibrationPlane(ViSession vi, ViConstString channelName) override;
   ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[1024]) override;
   ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]) override;
   ViStatus ExportSignal(ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal) override;
@@ -180,6 +182,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   using CreateDeembeddingSparameterTableArrayPtr = decltype(&niRFSG_CreateDeembeddingSparameterTableArray);
   using CreateDeembeddingSparameterTableS2PFilePtr = decltype(&niRFSG_CreateDeembeddingSparameterTableS2PFile);
   using DeleteAllDeembeddingTablesPtr = decltype(&niRFSG_DeleteAllDeembeddingTables);
+  using DisableCalibrationPlanePtr = decltype(&niRFSG_DisableCalibrationPlane);
   using DeleteConfigurationListPtr = decltype(&niRFSG_DeleteConfigurationList);
   using DeleteDeembeddingTablePtr = decltype(&niRFSG_DeleteDeembeddingTable);
   using DeleteScriptPtr = decltype(&niRFSG_DeleteScript);
@@ -188,6 +191,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   using DisableConfigurationListStepTriggerPtr = decltype(&niRFSG_DisableConfigurationListStepTrigger);
   using DisableScriptTriggerPtr = decltype(&niRFSG_DisableScriptTrigger);
   using DisableStartTriggerPtr = decltype(&niRFSG_DisableStartTrigger);
+  using EnableCalibrationPlanePtr = decltype(&niRFSG_EnableCalibrationPlane);
   using ErrorMessagePtr = decltype(&niRFSG_error_message);
   using ErrorQueryPtr = decltype(&niRFSG_error_query);
   using ExportSignalPtr = decltype(&niRFSG_ExportSignal);
@@ -297,6 +301,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
     CreateDeembeddingSparameterTableArrayPtr CreateDeembeddingSparameterTableArray;
     CreateDeembeddingSparameterTableS2PFilePtr CreateDeembeddingSparameterTableS2PFile;
     DeleteAllDeembeddingTablesPtr DeleteAllDeembeddingTables;
+    DisableCalibrationPlanePtr DisableCalibrationPlane;
     DeleteConfigurationListPtr DeleteConfigurationList;
     DeleteDeembeddingTablePtr DeleteDeembeddingTable;
     DeleteScriptPtr DeleteScript;
@@ -305,6 +310,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
     DisableConfigurationListStepTriggerPtr DisableConfigurationListStepTrigger;
     DisableScriptTriggerPtr DisableScriptTrigger;
     DisableStartTriggerPtr DisableStartTrigger;
+    EnableCalibrationPlanePtr EnableCalibrationPlane;
     ErrorMessagePtr ErrorMessage;
     ErrorQueryPtr ErrorQuery;
     ExportSignalPtr ExportSignal;

--- a/generated/nirfsg/nirfsg_library_interface.h
+++ b/generated/nirfsg/nirfsg_library_interface.h
@@ -57,6 +57,7 @@ class NiRFSGLibraryInterface {
   virtual ViStatus CreateDeembeddingSparameterTableArray(ViSession vi, ViConstString port, ViConstString tableName, ViReal64 frequencies[], ViInt32 frequenciesSize, NIComplexNumber_struct sparameterTable[], ViInt32 sparameterTableSize, ViInt32 numberOfPorts, ViInt32 sparameterOrientation) = 0;
   virtual ViStatus CreateDeembeddingSparameterTableS2PFile(ViSession vi, ViConstString port, ViConstString tableName, ViConstString s2pFilePath, ViInt32 sparameterOrientation) = 0;
   virtual ViStatus DeleteAllDeembeddingTables(ViSession vi) = 0;
+  virtual ViStatus DisableCalibrationPlane(ViSession vi, ViConstString channelName) = 0;
   virtual ViStatus DeleteConfigurationList(ViSession vi, ViConstString listName) = 0;
   virtual ViStatus DeleteDeembeddingTable(ViSession vi, ViConstString port, ViConstString tableName) = 0;
   virtual ViStatus DeleteScript(ViSession vi, ViConstString scriptName) = 0;
@@ -65,6 +66,7 @@ class NiRFSGLibraryInterface {
   virtual ViStatus DisableConfigurationListStepTrigger(ViSession vi) = 0;
   virtual ViStatus DisableScriptTrigger(ViSession vi, ViConstString triggerID) = 0;
   virtual ViStatus DisableStartTrigger(ViSession vi) = 0;
+  virtual ViStatus EnableCalibrationPlane(ViSession vi, ViConstString channelName) = 0;
   virtual ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[1024]) = 0;
   virtual ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]) = 0;
   virtual ViStatus ExportSignal(ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal) = 0;

--- a/generated/nirfsg/nirfsg_mock_library.h
+++ b/generated/nirfsg/nirfsg_mock_library.h
@@ -59,6 +59,7 @@ class NiRFSGMockLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   MOCK_METHOD(ViStatus, CreateDeembeddingSparameterTableArray, (ViSession vi, ViConstString port, ViConstString tableName, ViReal64 frequencies[], ViInt32 frequenciesSize, NIComplexNumber_struct sparameterTable[], ViInt32 sparameterTableSize, ViInt32 numberOfPorts, ViInt32 sparameterOrientation), (override));
   MOCK_METHOD(ViStatus, CreateDeembeddingSparameterTableS2PFile, (ViSession vi, ViConstString port, ViConstString tableName, ViConstString s2pFilePath, ViInt32 sparameterOrientation), (override));
   MOCK_METHOD(ViStatus, DeleteAllDeembeddingTables, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, DisableCalibrationPlane, (ViSession vi, ViConstString channelName), (override));
   MOCK_METHOD(ViStatus, DeleteConfigurationList, (ViSession vi, ViConstString listName), (override));
   MOCK_METHOD(ViStatus, DeleteDeembeddingTable, (ViSession vi, ViConstString port, ViConstString tableName), (override));
   MOCK_METHOD(ViStatus, DeleteScript, (ViSession vi, ViConstString scriptName), (override));
@@ -67,6 +68,7 @@ class NiRFSGMockLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   MOCK_METHOD(ViStatus, DisableConfigurationListStepTrigger, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, DisableScriptTrigger, (ViSession vi, ViConstString triggerID), (override));
   MOCK_METHOD(ViStatus, DisableStartTrigger, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, EnableCalibrationPlane, (ViSession vi, ViConstString channelName), (override));
   MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus errorCode, ViChar errorMessage[1024]), (override));
   MOCK_METHOD(ViStatus, ErrorQuery, (ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]), (override));
   MOCK_METHOD(ViStatus, ExportSignal, (ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal), (override));

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -1457,6 +1457,30 @@ namespace nirfsg_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFSGService::DisableCalibrationPlane(::grpc::ServerContext* context, const DisableCalibrationPlaneRequest* request, DisableCalibrationPlaneResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      auto channel_name_mbcs = convert_from_grpc<std::string>(request->channel_name());
+      auto channel_name = channel_name_mbcs.c_str();
+      auto status = library_->DisableCalibrationPlane(vi, channel_name);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFSGService::DeleteConfigurationList(::grpc::ServerContext* context, const DeleteConfigurationListRequest* request, DeleteConfigurationListResponse* response)
   {
     if (context->IsCancelled()) {
@@ -1650,6 +1674,30 @@ namespace nirfsg_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFSGService::EnableCalibrationPlane(::grpc::ServerContext* context, const EnableCalibrationPlaneRequest* request, EnableCalibrationPlaneResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      auto channel_name_mbcs = convert_from_grpc<std::string>(request->channel_name());
+      auto channel_name = channel_name_mbcs.c_str();
+      auto status = library_->EnableCalibrationPlane(vi, channel_name);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }

--- a/generated/nirfsg/nirfsg_service.h
+++ b/generated/nirfsg/nirfsg_service.h
@@ -84,6 +84,7 @@ public:
   ::grpc::Status CreateDeembeddingSparameterTableArray(::grpc::ServerContext* context, const CreateDeembeddingSparameterTableArrayRequest* request, CreateDeembeddingSparameterTableArrayResponse* response) override;
   ::grpc::Status CreateDeembeddingSparameterTableS2PFile(::grpc::ServerContext* context, const CreateDeembeddingSparameterTableS2PFileRequest* request, CreateDeembeddingSparameterTableS2PFileResponse* response) override;
   ::grpc::Status DeleteAllDeembeddingTables(::grpc::ServerContext* context, const DeleteAllDeembeddingTablesRequest* request, DeleteAllDeembeddingTablesResponse* response) override;
+  ::grpc::Status DisableCalibrationPlane(::grpc::ServerContext* context, const DisableCalibrationPlaneRequest* request, DisableCalibrationPlaneResponse* response) override;
   ::grpc::Status DeleteConfigurationList(::grpc::ServerContext* context, const DeleteConfigurationListRequest* request, DeleteConfigurationListResponse* response) override;
   ::grpc::Status DeleteDeembeddingTable(::grpc::ServerContext* context, const DeleteDeembeddingTableRequest* request, DeleteDeembeddingTableResponse* response) override;
   ::grpc::Status DeleteScript(::grpc::ServerContext* context, const DeleteScriptRequest* request, DeleteScriptResponse* response) override;
@@ -92,6 +93,7 @@ public:
   ::grpc::Status DisableConfigurationListStepTrigger(::grpc::ServerContext* context, const DisableConfigurationListStepTriggerRequest* request, DisableConfigurationListStepTriggerResponse* response) override;
   ::grpc::Status DisableScriptTrigger(::grpc::ServerContext* context, const DisableScriptTriggerRequest* request, DisableScriptTriggerResponse* response) override;
   ::grpc::Status DisableStartTrigger(::grpc::ServerContext* context, const DisableStartTriggerRequest* request, DisableStartTriggerResponse* response) override;
+  ::grpc::Status EnableCalibrationPlane(::grpc::ServerContext* context, const EnableCalibrationPlaneRequest* request, EnableCalibrationPlaneResponse* response) override;
   ::grpc::Status ErrorMessage(::grpc::ServerContext* context, const ErrorMessageRequest* request, ErrorMessageResponse* response) override;
   ::grpc::Status ErrorQuery(::grpc::ServerContext* context, const ErrorQueryRequest* request, ErrorQueryResponse* response) override;
   ::grpc::Status ExportSignal(::grpc::ServerContext* context, const ExportSignalRequest* request, ExportSignalResponse* response) override;

--- a/imports/include/niRFSA.h
+++ b/imports/include/niRFSA.h
@@ -1612,6 +1612,14 @@ ViStatus _VI_FUNC niRFSA_DeleteDeembeddingTable(
 ViStatus _VI_FUNC niRFSA_DeleteAllDeembeddingTables(
    ViSession vi);
 
+ViStatus _VI_FUNC niRFSA_EnableCalibrationPlane(
+   ViSession vi,
+   ViConstString channelName);
+
+ViStatus _VI_FUNC niRFSA_DisableCalibrationPlane(
+   ViSession vi,
+   ViConstString channelName);
+
 ViStatus _VI_FUNC niRFSA_ConfigureDeembeddingTableInterpolationNearest
 (
    ViSession vi,

--- a/imports/include/niRFSG.h
+++ b/imports/include/niRFSG.h
@@ -1537,6 +1537,14 @@ ViStatus _VI_FUNC niRFSG_DeleteDeembeddingTable(
 ViStatus _VI_FUNC niRFSG_DeleteAllDeembeddingTables(
    ViSession vi);
 
+ViStatus _VI_FUNC niRFSG_EnableCalibrationPlane(
+   ViSession vi,
+   ViConstString channelName);
+
+ViStatus _VI_FUNC niRFSG_DisableCalibrationPlane(
+   ViSession vi,
+   ViConstString channelName);
+
 ViStatus _VI_FUNC niRFSG_ConfigureDeembeddingTableInterpolationNearest
 (
    ViSession vi,

--- a/imports/include/niRFSG.h
+++ b/imports/include/niRFSG.h
@@ -1539,7 +1539,7 @@ ViStatus _VI_FUNC niRFSG_DeleteAllDeembeddingTables(
 
 ViStatus _VI_FUNC niRFSG_EnableCalibrationPlane(
    ViSession vi,
-   ViConstString channelName); 
+   ViConstString channelName);
 
 ViStatus _VI_FUNC niRFSG_DisableCalibrationPlane(
    ViSession vi,

--- a/imports/include/niRFSG.h
+++ b/imports/include/niRFSG.h
@@ -1539,7 +1539,7 @@ ViStatus _VI_FUNC niRFSG_DeleteAllDeembeddingTables(
 
 ViStatus _VI_FUNC niRFSG_EnableCalibrationPlane(
    ViSession vi,
-   ViConstString channelName);
+   ViConstString channelName); 
 
 ViStatus _VI_FUNC niRFSG_DisableCalibrationPlane(
    ViSession vi,

--- a/source/codegen/metadata/nirfsa/config.py
+++ b/source/codegen/metadata/nirfsa/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '21.0.0',
+    'api_version': '26.8.0',
     'c_header': 'niRFSA.h',
     'c_function_prefix': 'niRFSA_',
     'service_class_prefix': 'NiRFSA',

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -708,6 +708,21 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'DisableCalibrationPlane': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'DisableRefTrigger': {
         'parameters': [
             {
@@ -724,6 +739,21 @@ functions = {
                 'direction': 'in',
                 'name': 'vi',
                 'type': 'ViSession'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'EnableCalibrationPlane': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'ViConstString'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/nirfsg/config.py
+++ b/source/codegen/metadata/nirfsg/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '25.5.0',
+    'api_version': '26.8.0',
     'c_header': 'niRFSG.h',
     'c_function_prefix': 'niRFSG_',
     'service_class_prefix': 'NiRFSG',

--- a/source/codegen/metadata/nirfsg/functions.py
+++ b/source/codegen/metadata/nirfsg/functions.py
@@ -847,6 +847,21 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'DisableCalibrationPlane': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'DeleteConfigurationList': {
         'parameters': [
             {
@@ -949,6 +964,21 @@ functions = {
                 'direction': 'in',
                 'name': 'vi',
                 'type': 'ViSession'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'EnableCalibrationPlane': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'ViConstString'
             }
         ],
         'returns': 'ViStatus'


### PR DESCRIPTION
### What does this Pull Request accomplish?
Adds two new gRPC APIs to both the NI-RFSA and NI-RFSG services for controlling calibration-plane de-embedding:

- **NI-RFSA**
  - `EnableCalibrationPlane`
  - `DisableCalibrationPlane`
- **NI-RFSG**
  - `EnableCalibrationPlane`
  - `DisableCalibrationPlane`
  
Earlier the RFSA/G meta-data was generated with the scrapigen tool, But since the fpx and sub files were not consistent with the current API, I have modified the meta-data manually using scripting/ manually matching with current header for newer APIs.

### Why should this Pull Request be merged?
The RFSA and RFSG drivers added enabling/disabling a calibration plane as part of de-embedding, this capability need to be exposed through the gRPC interface.

### What testing has been done?

- **Codegen validation:** Ran the metadata validator for both `nirfsa` and `nirfsg` metadata — passed with no errors. Regenerated both services from metadata; the resulting diffs were exactly the expected additions (`EnableCalibrationPlane`/`DisableCalibrationPlane` RPCs, request/response messages, and the corresponding client/library/service/mock glue code) symmetric across both services.
- **Full build:** Completed a full Debug build (`cmake --build`) of the entire project — all targets compiled and linked with **0 errors**, including `ni_grpc_device_server.exe` and the test runners.
- **Unit tests:** `UnitTestsRunner.exe` — **518 tests across 27 test suites; All passing.** 